### PR TITLE
Adding missing include for libc++ support.

### DIFF
--- a/asio/include/asio/impl/error_code.ipp
+++ b/asio/include/asio/impl/error_code.ipp
@@ -21,6 +21,7 @@
 #else
 # include <cerrno>
 # include <cstring>
+# include <string>
 #endif
 #include "asio/detail/local_free_on_block_exit.hpp"
 #include "asio/detail/socket_types.hpp"


### PR DESCRIPTION
Trivial patch for working with Clang and libc++.
