### PR TITLE
Compile fix for Windows SDK 8.1

### DIFF
--- a/asio/include/asio/detail/impl/win_iocp_io_service.ipp
+++ b/asio/include/asio/detail/impl/win_iocp_io_service.ipp
@@ -456,10 +456,13 @@ size_t win_iocp_io_service::do_one(bool block, asio::error_code& ec)
 
 DWORD win_iocp_io_service::get_gqcs_timeout()
 {
-  OSVERSIONINFO version_info;
-  version_info.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-  if (::GetVersionEx(&version_info))
-    if (version_info.dwMajorVersion >= 6)
+  OSVERSIONINFOEX version_info;
+  memset(&version_info, 0, sizeof(version_info));
+  version_info.dwOSVersionInfoSize = sizeof(version_info);
+  version_info.dwMajorVersion = 6ul;
+  DWORDLONG condition_mask = ::VerSetConditionMask(0ull,
+      VER_MAJORVERSION, VER_GREATER_EQUAL);
+  if (::VerifyVersionInfo(&version_info, VER_MAJORVERSION, condition_mask))
       return INFINITE;
   return default_gqcs_timeout;
 }


### PR DESCRIPTION
GetVersionEx is deprecated in Windows SDK 8.1 (the SDK used by Visual Studio 2013 by default) and results in a compile error by default (using the /sdl compiler switch). This is a regression in asio 1.10.2. Using VerifyVersionInfo instead of GetVersionEx works around this issue.
