### PR TITLE
Fix warning with MSVC14

### DIFF
--- a/asio/include/asio/detail/impl/win_object_handle_service.ipp
+++ b/asio/include/asio/detail/impl/win_object_handle_service.ipp
@@ -420,7 +420,7 @@ void win_object_handle_service::wait_callback(PVOID param, BOOLEAN)
         asio::error_code ec(last_error,
             asio::error::get_system_category());
 
-        while (wait_op* op = impl->op_queue_.front())
+        while (op = impl->op_queue_.front())
         {
           op->ec_ = ec;
           impl->op_queue_.pop();


### PR DESCRIPTION
Microsoft Visual C++ 14 has new variable shadowing warnings. This fixes
"warning C4456: declaration of 'op' hides previous local declaration"
