### PR TITLE
Use WSASocketW

### DIFF
--- a/asio/include/asio/detail/impl/socket_ops.ipp
+++ b/asio/include/asio/detail/impl/socket_ops.ipp
@@ -1358,7 +1358,7 @@ socket_type socket(int af, int type, int protocol,
 {
   clear_last_error();
 #if defined(ASIO_WINDOWS) || defined(__CYGWIN__)
-  socket_type s = error_wrapper(::WSASocket(af, type, protocol, 0, 0,
+  socket_type s = error_wrapper(::WSASocketW(af, type, protocol, 0, 0,
         WSA_FLAG_OVERLAPPED), ec);
   if (s == invalid_socket)
     return s;


### PR DESCRIPTION
This is basically the same issue as fixed in pull request #22. WSASocket resolves to WSASocketA unless UNICODE is defined. This is the case when building the boost source. I think using the W version should be OK (the LPWSAPROTOCOL_INFO argument is null).
