### PR TITLE
IPv4 addresses in CIDR (Classless Inter Domain Routing) notation 

### DIFF
--- a/asio/include/asio/ip/cidr_address_v4.hpp
+++ b/asio/include/asio/ip/cidr_address_v4.hpp
@@ -1,0 +1,190 @@
+//
+// ip/cidr_address_v4.hpp
+// ~~~~~~~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2014 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+//                    Oliver Kowalke (oliver dot kowalke at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef ASIO_IP_CIDR_ADDRESS_V4_HPP
+#define ASIO_IP_CIDR_ADDRESS_V4_HPP
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#include <cstddef>
+#include <iterator>
+#include <string>
+
+#include "asio/ip/address_v4.hpp"
+#include "asio/detail/config.hpp"
+#include "asio/error_code.hpp"
+
+#include "asio/detail/push_options.hpp"
+
+namespace asio {
+namespace ip {
+
+class address_iterator_v4
+{
+public:
+  typedef std::ptrdiff_t difference_type;
+  typedef address_v4 value_type;
+  typedef const address_v4* pointer;
+  typedef const address_v4& reference;
+  typedef std::bidirectional_iterator_tag iterator_category;
+
+  explicit address_iterator_v4(const address_v4& addr);
+
+  const address_v4& operator*() const;
+  const address_v4* operator->() const;
+
+  address_iterator_v4& operator++();
+  address_iterator_v4 operator++(int);
+
+  address_iterator_v4& operator--();
+  address_iterator_v4 operator--(int);
+
+  friend bool operator==(const address_iterator_v4& a, const address_iterator_v4& b);
+  friend bool operator!=(const address_iterator_v4& a, const address_iterator_v4& b);
+
+private:
+  address_v4 address_;
+};
+
+
+/// Implements IP version 4 style addresses in CIDR notation.
+/**
+ * The asio::ip::cidr_address_v4 class provides the ability to use and
+ * manipulate IP version 4 addresses in CIDR notation.
+ *
+ * @par Thread Safety
+ * @e Distinct @e objects: Safe.@n
+ * @e Shared @e objects: Unsafe.
+ */
+class cidr_address_v4 {
+public:
+    /// Default constructor.
+    cidr_address_v4();
+    
+    /// Construct an CIDR address based on the passed address and prefix length
+    ASIO_DECL cidr_address_v4(const address_v4& addr, std::size_t prefix_length);
+    
+    /// Construct an CIDR address based on the passed address and netmask
+    ASIO_DECL cidr_address_v4(const address_v4& addr, const address_v4& mask);
+    
+    /// Copy constructor.
+    cidr_address_v4(const cidr_address_v4& other);
+
+#if defined(ASIO_HAS_MOVE)
+    /// Move constructor.
+    cidr_address_v4(cidr_address_v4&& other) {}
+#endif // defined(ASIO_HAS_MOVE)
+
+    /// Assign from another CIDR address.
+    cidr_address_v4& operator=(const cidr_address_v4& other)
+    {
+      return *this;
+    }
+
+#if defined(ASIO_HAS_MOVE)
+    /// Move-assign from another CIDR address.
+    cidr_address_v4& operator=(cidr_address_v4&& other)
+    {
+      return *this;
+    }
+#endif // defined(ASIO_HAS_MOVE)
+
+    /// Optain an address range object that represents the network range
+    /// that corresponds to the specific network.
+    ASIO_DECL address_v4 network() const;
+
+    /// Optain an address object that represents the host address
+    /// that corresponds to the specific host part.
+    ASIO_DECL address_v4 host() const;
+   
+    /// Obtain the netmask that corresponds to the address, based on its
+    /// CIDR address class.
+    ASIO_DECL address_v4 netmask() const;
+
+    /// Obtain an address object that represents the broadcast address that
+    /// corresponds to the specified address and netmask.
+    ASIO_DECL address_v4 broadcast() const;
+
+    typedef address_iterator_v4 iterator;
+
+    /// Optain an iterator poiting to the first address that belongs to
+    /// the specific network segment.
+    ASIO_DECL iterator begin() const;
+
+    /// Optain an iterator pointing to the end of the address range beonging
+    /// to the specifix network segment.
+    ASIO_DECL iterator end() const;
+
+    /// Optain an iterator as an result of searching the requested address
+    /// in the specific network segment.
+    ASIO_DECL iterator find(const address_v4& addr) const;
+   
+    /// Calculate CIDR prefix length from netmask.
+    static std::size_t calculate_prefix_length(const address_v4& netmask);
+    
+    /// Calculate netmask from CIDR prefix length.
+    static address_v4 calculate_netmask(std::size_t prefix_length);
+
+    /// GET prefix length.
+    ASIO_DECL std::size_t prefix_length() const;
+    
+    /// Construct an CIDR address from string in CIDR notation.
+    static cidr_address_v4 from_string(const char* str);
+    
+    /// Get the CIDR address as address in dotted decimal format.
+    ASIO_DECL std::string to_string() const;
+
+    /// Test if CIDR address contains a valid host address.
+    ASIO_DECL bool is_host() const;
+
+    /// Test if CIDR address is a real subnet of other CIDR address.
+    ASIO_DECL bool is_subnet_of(const cidr_address_v4&) const;
+   
+    /// Get network part as CIDR address. 
+    ASIO_DECL cidr_address_v4 network_cidr() const;
+
+    /// Get host part as CIDR address. 
+    ASIO_DECL cidr_address_v4 host_cidr() const;
+
+    /// Compare two CIDR addresses for equality.
+    friend bool operator==(const cidr_address_v4& a1, const cidr_address_v4& a2)
+    {
+      return a1.base_address_ == a2.base_address_ &&
+             a1.netmask_ == a2.netmask_ &&
+             a1.network_ == a2.network_ &&
+             a1.broadcast_ == a2.broadcast_;
+    }
+    
+    /// Compare two CIDR addresses for inequality.
+    friend bool operator!=(const cidr_address_v4& a1, const cidr_address_v4& a2)
+    {
+      return ! ( a1 == a2);
+    }
+
+private:
+    address_v4 base_address_;
+    address_v4 netmask_;
+    address_v4 network_;
+    address_v4 broadcast_;
+};
+
+} // namespace ip
+} // namespace asio
+
+#include "asio/detail/pop_options.hpp"
+
+#if defined(ASIO_HEADER_ONLY)
+# include "asio/ip/impl/cidr_address_v4.ipp"
+#endif // defined(ASIO_HEADER_ONLY)
+
+#endif // ASIO_IP_CIDR_ADDRESS_V4_HPP

--- a/asio/include/asio/ip/impl/cidr_address_v4.ipp
+++ b/asio/include/asio/ip/impl/cidr_address_v4.ipp
@@ -1,0 +1,282 @@
+#ifndef ASIO_IP_IMPL_CIDR_ADDRESS_V4_IPP
+#define ASIO_IP_IMPL_CIDR_ADDRESS_V4_IPP
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#include "asio/ip/cidr_address_v4.hpp"
+
+#include <algorithm>
+#include <sstream>
+#include <iostream>
+
+#include "asio/detail/throw_error.hpp"
+#include "asio/detail/throw_exception.hpp"
+
+#include "asio/detail/push_options.hpp"
+
+namespace asio {
+namespace ip {
+
+address_iterator_v4::address_iterator_v4(const address_v4& addr)
+  : address_(addr)
+{
+}
+
+const address_v4& address_iterator_v4::operator*() const
+{
+  return address_;
+}
+
+const address_v4* address_iterator_v4::operator->() const
+{
+  return &address_;
+}
+
+address_iterator_v4& address_iterator_v4::operator++()
+{
+  address_ = address_v4((address_.to_ulong() + 1) & 0xFFFFFFFF);
+  return *this;
+}
+
+address_iterator_v4 address_iterator_v4::operator++(int)
+{
+  address_iterator_v4 tmp(*this);
+  ++*this;
+  return tmp;
+}
+
+address_iterator_v4& address_iterator_v4::operator--()
+{
+  address_ = address_v4((address_.to_ulong() - 1) & 0xFFFFFFFF);
+  return *this;
+}
+
+address_iterator_v4 address_iterator_v4::operator--(int)
+{
+  address_iterator_v4 tmp(*this);
+  --*this;
+  return tmp;
+}
+
+bool operator==(const address_iterator_v4& a, const address_iterator_v4& b)
+{
+  return a.address_ == b.address_;
+}
+
+bool operator!=(const address_iterator_v4& a, const address_iterator_v4& b)
+{
+  return a.address_ != b.address_;
+}
+
+cidr_address_v4::cidr_address_v4()
+  : base_address_(0),
+    netmask_(0),
+    network_(0),
+    broadcast_(0xFFFFFFFF)
+{
+}
+
+cidr_address_v4::cidr_address_v4(const address_v4& addr, std::size_t prefix_length)
+  : base_address_( addr),
+    netmask_(calculate_netmask(prefix_length)),
+    network_(addr.to_ulong() & netmask_.to_ulong()),
+    broadcast_(address_v4::broadcast(network_, netmask_))
+{}
+
+cidr_address_v4::cidr_address_v4(const address_v4& addr, const address_v4& mask)
+  : base_address_(addr),
+    netmask_(mask),
+    network_(addr.to_ulong() & netmask_.to_ulong()),
+    broadcast_(address_v4::broadcast(network_, netmask_))
+{
+}
+
+cidr_address_v4::cidr_address_v4(const cidr_address_v4& addr)
+  : base_address_(addr.base_address_),
+    netmask_(addr.netmask_),
+    network_(addr.network_),
+    broadcast_(addr.broadcast_)
+{
+}
+
+address_v4 cidr_address_v4::network() const
+{
+  return network_;
+}
+
+address_v4 cidr_address_v4::host() const
+{
+    return base_address_;
+}
+
+address_v4 cidr_address_v4::netmask() const
+{
+  return netmask_;
+}
+
+address_v4 cidr_address_v4::broadcast() const
+{
+  return broadcast_;
+}
+
+cidr_address_v4::iterator cidr_address_v4::begin() const
+{
+  return iterator(address_v4(network_.to_ulong() + 1));
+}
+
+cidr_address_v4::iterator cidr_address_v4::end() const
+{
+  return iterator(broadcast_);
+}
+
+cidr_address_v4::iterator cidr_address_v4::find(const address_v4& addr) const
+{
+  return addr > network_ && addr < broadcast_ ? iterator(addr) : end();
+}
+
+std::size_t cidr_address_v4::calculate_prefix_length(const address_v4& netmask)
+{
+    address_v4::bytes_type mask = netmask.to_bytes();
+    bool finished = false;
+    std::size_t nbits = 0;
+
+    for ( std::size_t i = 0; i < mask.size(); ++i)
+    {
+        if ( finished)
+        {
+            if ( 0 != mask[i]) {
+                std::out_of_range ex("prefix from netmask");
+                asio::detail::throw_exception(ex);
+            }
+            continue;
+        }
+        else
+        {
+            switch ( mask[i])
+            {
+                case 255:
+                    nbits += 8;
+                    break;
+                case 254: // nbits += 7
+                    nbits += 1;
+                case 252: // nbits += 6
+                    nbits += 1;
+                case 248: // nbits += 5
+                    nbits += 1;
+                case 240: // nbits += 4
+                    nbits += 1;
+                case 224: // nbits += 3
+                    nbits += 1;
+                case 192: // nbits += 2
+                    nbits += 1;
+                case 128: // nbits += 1
+                    nbits += 1;
+                case 0:   // nbits += 0
+                    finished = true;
+                    break;
+                default:
+                    std::out_of_range ex("prefix from netmask");
+                    asio::detail::throw_exception(ex);
+            }
+        }
+    }
+
+    return nbits; 
+}
+
+address_v4 cidr_address_v4::calculate_netmask(std::size_t prefix_length)
+{
+    if ( 32 < prefix_length)
+    {
+        std::out_of_range ex("netmask from prefix");
+        asio::detail::throw_exception(ex);
+    }
+    uint32_t nmbits = 0xffffffff;
+    if ( 0 == prefix_length)
+    {
+        nmbits = 0;
+    }
+    else
+    {
+        nmbits = nmbits << (32 - prefix_length);
+    }
+    return address_v4(nmbits);
+}
+
+std::size_t cidr_address_v4::prefix_length() const
+{
+    return calculate_prefix_length(netmask_);
+}
+
+cidr_address_v4 cidr_address_v4::from_string(const char* str)
+{
+    std::string addr_str( str);
+    std::string::size_type pos = addr_str.find_first_of("/");
+
+    if (std::string::npos == pos)
+    {
+        std::invalid_argument ex("no prefix found");
+        asio::detail::throw_exception(ex);
+    }
+
+    if (pos == ( addr_str.size() - 1))
+    {
+        std::invalid_argument ex("prefix is empty");
+        asio::detail::throw_exception(ex);
+    }
+
+    std::string::size_type end = addr_str.find_first_not_of("0123456789",pos+1);
+    if (std::string::npos != end)
+    {
+        std::invalid_argument ex("invalid prefix");
+        asio::detail::throw_exception(ex);
+    }
+
+    return cidr_address_v4(
+        address_v4::from_string( addr_str.substr( 0, pos) ),
+        atoi( addr_str.substr( pos + 1).c_str() ) );
+}
+
+std::string cidr_address_v4::to_string() const
+{
+    std::stringstream oss;
+    oss << base_address_.to_string();
+    oss << "/";
+    oss << prefix_length();
+    return oss.str();
+}
+
+bool cidr_address_v4::is_host() const
+{
+    return 32 == prefix_length();
+}
+
+bool cidr_address_v4::is_subnet_of( cidr_address_v4 const& net) const
+{
+    if ( this == & net) {
+        return false;
+    }
+    if ( net.prefix_length() >= prefix_length() ) {
+        return false; // only real subsets are allowed.
+    }
+    const cidr_address_v4 me(host(), net.netmask());
+    // TODO: ugly, but cidr_address_v4 has no comparation operators yet
+    return net.network_cidr().to_string() == me.network_cidr().to_string();
+}
+
+cidr_address_v4 cidr_address_v4::network_cidr() const
+{
+    return cidr_address_v4(network_,netmask_);
+}
+
+cidr_address_v4 cidr_address_v4::host_cidr() const
+{
+    return cidr_address_v4(base_address_,32);
+}
+
+} // namespace ip
+} // namespace asio
+
+#endif // ASIO_IP_IMPL_CIDR_ADDRESS_V4_IPP

--- a/asio/src/tests/Makefile.am
+++ b/asio/src/tests/Makefile.am
@@ -47,6 +47,7 @@ check_PROGRAMS = \
 	unit/ip/basic_resolver_entry \
 	unit/ip/basic_resolver_iterator \
 	unit/ip/basic_resolver_query \
+	unit/ip/cidr_address_v4 \
 	unit/ip/host_name \
 	unit/ip/icmp \
 	unit/ip/multicast \
@@ -157,6 +158,7 @@ TESTS = \
 	unit/ip/basic_resolver_entry \
 	unit/ip/basic_resolver_iterator \
 	unit/ip/basic_resolver_query \
+	unit/ip/cidr_address_v4 \
 	unit/ip/host_name \
 	unit/ip/icmp \
 	unit/ip/multicast \
@@ -280,6 +282,7 @@ unit_ip_basic_resolver_SOURCES = unit/ip/basic_resolver.cpp unit/unit_test.cpp
 unit_ip_basic_resolver_entry_SOURCES = unit/ip/basic_resolver_entry.cpp unit/unit_test.cpp
 unit_ip_basic_resolver_iterator_SOURCES = unit/ip/basic_resolver_iterator.cpp unit/unit_test.cpp
 unit_ip_basic_resolver_query_SOURCES = unit/ip/basic_resolver_query.cpp unit/unit_test.cpp
+unit_ip_cidr_address_v4_SOURCES = unit/ip/cidr_address_v4.cpp unit/unit_test.cpp
 unit_ip_host_name_SOURCES = unit/ip/host_name.cpp unit/unit_test.cpp
 unit_ip_icmp_SOURCES = unit/ip/icmp.cpp unit/unit_test.cpp
 unit_ip_multicast_SOURCES = unit/ip/multicast.cpp unit/unit_test.cpp

--- a/asio/src/tests/unit/ip/cidr_address_v4.cpp
+++ b/asio/src/tests/unit/ip/cidr_address_v4.cpp
@@ -178,8 +178,8 @@ void test()
   ASIO_CHECK(addr3.network() == address_v4::from_string("192.168.1.16"));
   // netmask
   ASIO_CHECK(addr1.netmask() == address_v4::from_string("255.255.255.0"));
-  ASIO_CHECK(addr2.netmask() == address_v4::from_string("255.255.255.0"));
-  ASIO_CHECK(addr3.netmask() == address_v4::from_string("255.255.255.0"));
+  ASIO_CHECK(addr2.netmask() == address_v4::from_string("255.255.255.240"));
+  ASIO_CHECK(addr3.netmask() == address_v4::from_string("255.255.255.240"));
   // broadcast
   ASIO_CHECK(addr1.broadcast() == address_v4::from_string("192.168.0.255"));
   ASIO_CHECK(addr2.broadcast() == address_v4::from_string("192.168.1.15"));
@@ -189,14 +189,14 @@ void test()
   ASIO_CHECK(*addr1.begin() == address_v4::from_string("192.168.0.1"));
   ASIO_CHECK(addr1.end() != addr1.find(address_v4::from_string("192.168.0.10")));
   ASIO_CHECK(addr1.end() == addr1.find(address_v4::from_string("192.168.1.10")));
-  ASIO_CHECK(std::distance(addr2.begin(),addr2.end()) == 15);
+  ASIO_CHECK(std::distance(addr2.begin(),addr2.end()) == 14);
   ASIO_CHECK(*addr2.begin() == address_v4::from_string("192.168.1.1"));
-  ASIO_CHECK(addr2.end() != addr2.find(address_v4::from_string("192.168.1.15")));
-  ASIO_CHECK(addr2.end() == addr2.find(address_v4::from_string("192.168.1.14")));
+  ASIO_CHECK(addr2.end() != addr2.find(address_v4::from_string("192.168.1.14")));
+  ASIO_CHECK(addr2.end() == addr2.find(address_v4::from_string("192.168.1.15")));
   ASIO_CHECK(std::distance(addr3.begin(),addr3.end()) == 14);
   ASIO_CHECK(*addr3.begin() == address_v4::from_string("192.168.1.17"));
-  ASIO_CHECK(addr3.end() != addr3.find(address_v4::from_string("192.168.1.31")));
-  ASIO_CHECK(addr3.end() == addr3.find(address_v4::from_string("192.168.1.30")));
+  ASIO_CHECK(addr3.end() != addr3.find(address_v4::from_string("192.168.1.30")));
+  ASIO_CHECK(addr3.end() == addr3.find(address_v4::from_string("192.168.1.31")));
 }
 
 } // namespace ip_cidr_address_v4_runtime

--- a/asio/src/tests/unit/ip/cidr_address_v4.cpp
+++ b/asio/src/tests/unit/ip/cidr_address_v4.cpp
@@ -169,18 +169,34 @@ void test()
   cidr_address_v4 r(cidr_address_v4::from_string("192.168.0.0/24"));
   ASIO_CHECK(!r.is_subnet_of(r));
 
-  cidr_address_v4 addr(cidr_address_v4::from_string("192.168.0.2/24"));
+  cidr_address_v4 addr1(cidr_address_v4::from_string("192.168.0.2/24"));
+  cidr_address_v4 addr2(cidr_address_v4::from_string("192.168.1.1/28"));
+  cidr_address_v4 addr3(cidr_address_v4::from_string("192.168.1.21/28"));
   // network
-  ASIO_CHECK(addr.network() == address_v4::from_string("192.168.0.0"));
-  // netamsk
-  ASIO_CHECK(addr.netmask() == address_v4::from_string("255.255.255.0"));
+  ASIO_CHECK(addr1.network() == address_v4::from_string("192.168.0.0"));
+  ASIO_CHECK(addr2.network() == address_v4::from_string("192.168.1.0"));
+  ASIO_CHECK(addr3.network() == address_v4::from_string("192.168.1.16"));
+  // netmask
+  ASIO_CHECK(addr1.netmask() == address_v4::from_string("255.255.255.0"));
+  ASIO_CHECK(addr2.netmask() == address_v4::from_string("255.255.255.0"));
+  ASIO_CHECK(addr3.netmask() == address_v4::from_string("255.255.255.0"));
   // broadcast
-  ASIO_CHECK(addr.broadcast() == address_v4::from_string("192.168.0.255"));
+  ASIO_CHECK(addr1.broadcast() == address_v4::from_string("192.168.0.255"));
+  ASIO_CHECK(addr2.broadcast() == address_v4::from_string("192.168.1.15"));
+  ASIO_CHECK(addr3.broadcast() == address_v4::from_string("192.168.1.31"));
   // iterator
-  ASIO_CHECK(std::distance(addr.begin(),addr.end()) == 254);
-  ASIO_CHECK(*addr.begin() == address_v4::from_string("192.168.0.1"));
-  ASIO_CHECK(addr.end() != addr.find(address_v4::from_string("192.168.0.10")));
-  ASIO_CHECK(addr.end() == addr.find(address_v4::from_string("192.168.1.10")));
+  ASIO_CHECK(std::distance(addr1.begin(),addr1.end()) == 254);
+  ASIO_CHECK(*addr1.begin() == address_v4::from_string("192.168.0.1"));
+  ASIO_CHECK(addr1.end() != addr1.find(address_v4::from_string("192.168.0.10")));
+  ASIO_CHECK(addr1.end() == addr1.find(address_v4::from_string("192.168.1.10")));
+  ASIO_CHECK(std::distance(addr2.begin(),addr2.end()) == 15);
+  ASIO_CHECK(*addr2.begin() == address_v4::from_string("192.168.1.1"));
+  ASIO_CHECK(addr2.end() != addr2.find(address_v4::from_string("192.168.1.15")));
+  ASIO_CHECK(addr2.end() == addr2.find(address_v4::from_string("192.168.1.14")));
+  ASIO_CHECK(std::distance(addr3.begin(),addr3.end()) == 14);
+  ASIO_CHECK(*addr3.begin() == address_v4::from_string("192.168.1.17"));
+  ASIO_CHECK(addr3.end() != addr3.find(address_v4::from_string("192.168.1.31")));
+  ASIO_CHECK(addr3.end() == addr3.find(address_v4::from_string("192.168.1.30")));
 }
 
 } // namespace ip_cidr_address_v4_runtime

--- a/asio/src/tests/unit/ip/cidr_address_v4.cpp
+++ b/asio/src/tests/unit/ip/cidr_address_v4.cpp
@@ -1,0 +1,195 @@
+//
+// cidr_address_v4.cpp
+// ~~~~~~~~~~~~~~
+//
+// Copyright (c) 2003-2012 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+// Test that header file is self-contained.
+#include "asio/ip/cidr_address_v4.hpp"
+
+#include "../unit_test.hpp"
+#include <sstream>
+
+//------------------------------------------------------------------------------
+
+// ip_cidr_address_v4_compile test
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~
+// The following test checks that all public member functions on the class
+// ip::cidr_address_v4 compile and link correctly. Runtime failures are ignored.
+
+namespace ip_cidr_address_v4_compile {
+
+void test()
+{
+  using namespace asio;
+  namespace ip = asio::ip;
+
+  try
+  {
+    asio::error_code ec;
+
+    // cidr_address_v4 constructors.
+
+    ip::cidr_address_v4 range1( ip::address_v4::from_string("192.168.1.0"),
+                                ip::address_v4::from_string("255.255.255.0") );
+
+    ip::cidr_address_v4 range2( ip::address_v4::from_string("192.168.1.0"), 32);
+
+    ip::address_v4 addr;
+    ip::address_iterator_v4 i( addr);
+
+    addr = range2.network();
+    (void) addr;
+
+    addr = range2.netmask();
+    (void) addr;
+
+    addr = range2.broadcast();
+    (void) addr;
+
+    i = range2.begin();
+    (void) i;
+
+    i = range2.end();
+    (void) i;
+
+    i = range2.find( ip::address_v4::from_string("192.168.1.250") );
+    (void) i;
+
+  }
+  catch (std::exception&)
+  {
+  }
+}
+
+} // namespace ip_cidr_address_v4_compile
+
+//------------------------------------------------------------------------------
+
+// ip_cidr_address_v4_runtime test
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~
+// The following test checks that the various public member functions meet the
+// necessary postconditions.
+
+namespace ip_cidr_address_v4_runtime {
+
+void test()
+{
+  using asio::ip::address_v4;
+  using asio::ip::address_iterator_v4;
+  using asio::ip::cidr_address_v4;
+
+  // calculate prefix length
+  ASIO_CHECK( cidr_address_v4::calculate_prefix_length( address_v4::from_string("255.255.255.0") ) == 24);
+  ASIO_CHECK( cidr_address_v4::calculate_prefix_length( address_v4::from_string("255.255.255.192") ) == 26);
+  ASIO_CHECK( cidr_address_v4::calculate_prefix_length( address_v4::from_string("128.0.0.0") ) == 1);
+
+  std::string msg;
+  try
+  { cidr_address_v4::calculate_prefix_length( address_v4::from_string("255.255.255.1") ); }
+  catch( std::out_of_range const& ex)
+  { msg = ex.what(); }
+  ASIO_CHECK( msg == std::string("prefix from netmask") );
+
+  msg.clear();
+  try
+  { cidr_address_v4::calculate_prefix_length( address_v4::from_string("0.255.255.0") ); }
+  catch( std::out_of_range const& ex)
+  { msg = ex.what(); }
+  ASIO_CHECK( msg == std::string("prefix from netmask") );
+
+
+  // calculate netmask
+  ASIO_CHECK(cidr_address_v4::calculate_netmask(23) == address_v4::from_string("255.255.254.0"));
+  ASIO_CHECK(cidr_address_v4::calculate_netmask(12) == address_v4::from_string("255.240.0.0"));
+  ASIO_CHECK(cidr_address_v4::calculate_netmask(24) == address_v4::from_string("255.255.255.0"));
+  ASIO_CHECK(cidr_address_v4::calculate_netmask(16) == address_v4::from_string("255.255.0.0"));
+  ASIO_CHECK(cidr_address_v4::calculate_netmask(8) == address_v4::from_string("255.0.0.0"));
+  ASIO_CHECK(cidr_address_v4::calculate_netmask(32) == address_v4::from_string("255.255.255.255"));
+  ASIO_CHECK(cidr_address_v4::calculate_netmask(1) == address_v4::from_string("128.0.0.0"));
+  ASIO_CHECK(cidr_address_v4::calculate_netmask(0) == address_v4::from_string("0.0.0.0"));
+
+  msg.clear();
+  try
+  { cidr_address_v4::calculate_netmask(33); }
+  catch( std::out_of_range const& ex)
+  { msg = ex.what(); }
+  ASIO_CHECK( msg == std::string("netmask from prefix") );
+
+  // construct address range from address and prefix length
+  ASIO_CHECK(cidr_address_v4(address_v4::from_string("192.168.77.100"), 32).network() == address_v4::from_string("192.168.77.100"));
+  ASIO_CHECK(cidr_address_v4(address_v4::from_string("192.168.77.100"), 24).network() == address_v4::from_string("192.168.77.0"));
+  ASIO_CHECK(cidr_address_v4(address_v4::from_string("192.168.77.128"), 25).network() == address_v4::from_string("192.168.77.128"));
+
+  // construct address range from string in CIDR notation
+  ASIO_CHECK(cidr_address_v4::from_string("192.168.77.100/32").network() == address_v4::from_string("192.168.77.100"));
+  ASIO_CHECK(cidr_address_v4::from_string("192.168.77.100/24").network() == address_v4::from_string("192.168.77.0"));
+  ASIO_CHECK(cidr_address_v4::from_string("192.168.77.128/25").network() == address_v4::from_string("192.168.77.128"));
+
+  // prefix length
+  ASIO_CHECK(cidr_address_v4::from_string("193.99.144.80/24").prefix_length() == 24);
+  ASIO_CHECK(cidr_address_v4(address_v4::from_string("193.99.144.80"), 24).prefix_length() == 24);
+  ASIO_CHECK(cidr_address_v4(address_v4::from_string("192.168.77.0"), address_v4::from_string("255.255.255.0")).prefix_length() == 24);
+
+  // to string
+  std::string a("192.168.77.0/32");
+  ASIO_CHECK(cidr_address_v4::from_string(a.c_str()).to_string() == a);
+  ASIO_CHECK(cidr_address_v4(address_v4::from_string("192.168.77.10"), 24).to_string() == std::string("192.168.77.10/24"));
+
+  // return host part
+  ASIO_CHECK(cidr_address_v4::from_string("192.168.77.11/24").host() == address_v4::from_string("192.168.77.11"));
+
+  // return host in CIDR notation
+  ASIO_CHECK(cidr_address_v4::from_string("192.168.78.30/20").host_cidr().to_string() == "192.168.78.30/32");
+
+  // return network in CIDR notation
+  ASIO_CHECK(cidr_address_v4::from_string("192.168.78.30/20").network_cidr().to_string() == "192.168.64.0/20");
+
+  // is host
+  ASIO_CHECK(cidr_address_v4::from_string("192.168.77.0/32").is_host());
+  ASIO_CHECK(!cidr_address_v4::from_string("192.168.77.0/31").is_host());
+
+  // is real subnet of
+  ASIO_CHECK(cidr_address_v4::from_string("192.168.0.192/24").is_subnet_of(cidr_address_v4::from_string("192.168.0.0/16")));
+  ASIO_CHECK(cidr_address_v4::from_string("192.168.0.0/24").is_subnet_of(cidr_address_v4::from_string("192.168.192.168/16")));
+  ASIO_CHECK(cidr_address_v4::from_string("192.168.0.192/24").is_subnet_of(cidr_address_v4::from_string("192.168.192.168/16")));
+  ASIO_CHECK(cidr_address_v4::from_string("192.168.0.0/24").is_subnet_of(cidr_address_v4::from_string("192.168.0.0/16")));
+  ASIO_CHECK(cidr_address_v4::from_string("192.168.0.0/24").is_subnet_of(cidr_address_v4::from_string("192.168.0.0/23")));
+  ASIO_CHECK(cidr_address_v4::from_string("192.168.0.0/24").is_subnet_of(cidr_address_v4::from_string("192.168.0.0/0")));
+  ASIO_CHECK(cidr_address_v4::from_string("192.168.0.0/32").is_subnet_of(cidr_address_v4::from_string("192.168.0.0/24")));
+
+  ASIO_CHECK(!cidr_address_v4::from_string("192.168.0.0/32").is_subnet_of(cidr_address_v4::from_string("192.168.0.0/32")));
+  ASIO_CHECK(!cidr_address_v4::from_string("192.168.0.0/24").is_subnet_of(cidr_address_v4::from_string("192.168.1.0/24")));
+  ASIO_CHECK(!cidr_address_v4::from_string("192.168.0.0/16").is_subnet_of(cidr_address_v4::from_string("192.168.1.0/24")));
+
+  cidr_address_v4 r(cidr_address_v4::from_string("192.168.0.0/24"));
+  ASIO_CHECK(!r.is_subnet_of(r));
+
+  cidr_address_v4 addr(cidr_address_v4::from_string("192.168.0.2/24"));
+  // network
+  ASIO_CHECK(addr.network() == address_v4::from_string("192.168.0.0"));
+  // netamsk
+  ASIO_CHECK(addr.netmask() == address_v4::from_string("255.255.255.0"));
+  // broadcast
+  ASIO_CHECK(addr.broadcast() == address_v4::from_string("192.168.0.255"));
+  // iterator
+  ASIO_CHECK(std::distance(addr.begin(),addr.end()) == 254);
+  ASIO_CHECK(*addr.begin() == address_v4::from_string("192.168.0.1"));
+  ASIO_CHECK(addr.end() != addr.find(address_v4::from_string("192.168.0.10")));
+  ASIO_CHECK(addr.end() == addr.find(address_v4::from_string("192.168.1.10")));
+}
+
+} // namespace ip_cidr_address_v4_runtime
+
+//------------------------------------------------------------------------------
+
+ASIO_TEST_SUITE
+(
+  "ip/cidr_address_v4",
+  ASIO_TEST_CASE(ip_cidr_address_v4_compile::test)
+  ASIO_TEST_CASE(ip_cidr_address_v4_runtime::test)
+)


### PR DESCRIPTION
class cidr_address_v4 abstracts IPv4 address in CIDR notation providing infos like:
cidr :                          192.168.1.21/28
network (subnet-id) : 192.168.1.16
netmask :                   255.255.255.240
broadcast:                 192.168.1.31
address range:          192.168.1.17 - 192.168.1.30