### PR TITLE
Add support for disabling TLS v1.1 and TLS v1.2

### DIFF
--- a/asio/include/asio/ssl/context_base.hpp
+++ b/asio/include/asio/ssl/context_base.hpp
@@ -105,6 +105,12 @@ public:
   /// Disable TLS v1.
   static const long no_tlsv1 = implementation_defined;
 
+  /// Disable TLS v1.1
+  static const long no_tlsv1_1 = implementation_defined;
+
+  /// Disable TLS v1.2
+  static const long no_tlsv1_2 = implementation_defined;
+
   /// Disable compression. Compression is disabled by default.
   static const long no_compression = implementation_defined;
 #else
@@ -113,6 +119,8 @@ public:
   ASIO_STATIC_CONSTANT(long, no_sslv2 = SSL_OP_NO_SSLv2);
   ASIO_STATIC_CONSTANT(long, no_sslv3 = SSL_OP_NO_SSLv3);
   ASIO_STATIC_CONSTANT(long, no_tlsv1 = SSL_OP_NO_TLSv1);
+  ASIO_STATIC_CONSTANT(long, no_tlsv1_1 = SSL_OP_NO_TLSv1_1);
+  ASIO_STATIC_CONSTANT(long, no_tlsv1_2 = SSL_OP_NO_TLSv1_2);
 # if defined(SSL_OP_NO_COMPRESSION)
   ASIO_STATIC_CONSTANT(long, no_compression = SSL_OP_NO_COMPRESSION);
 # else // defined(SSL_OP_NO_COMPRESSION)


### PR DESCRIPTION
Previously it has been possible to call asio::ssl::context::set_options to disable SSL v2.0, SSL v3.0 and TLS v1.0. Since TLS v1.1 and TLS v1.2 will be considered insecure sooner or later, it makes sense for applications to give end-users the possibility to disable these protocols.

Personally I wanted to add this to my own software which relies on Asio. To do this today, I had to access the context::native_handle() and call SSL_CTX_set_options myself. 

This very small patch makes it possible to disable TLSv1.1 and TLSv1.2 without having to call OpenSSL as mentioned above. 

I've tested the patch and confirmed that it works as intended.
