### PR TITLE
Clang's unsigned integer overflow santizer reports a runtime error when ...

### DIFF
--- a/asio/include/asio/detail/timer_queue.hpp
+++ b/asio/include/asio/detail/timer_queue.hpp
@@ -219,7 +219,7 @@ private:
   // Move the item at the given index up the heap to its correct position.
   void up_heap(std::size_t index)
   {
-    std::size_t parent = (index - 1) / 2;
+    std::size_t parent = index ? (index - 1) / 2 : 0;
     while (index > 0
         && Time_Traits::less_than(heap_[index].time_, heap_[parent].time_))
     {


### PR DESCRIPTION
...up_heap()

is called with index == 0. This error is currently harmless, since the next line
short-circuits when index == 0, but it seems prudent to remove the warning, both
to make Clang's sanitizer happy (remove false positive), and to make sure that
the function remains safe if subsequent logic changes.

Sample Clang output: /usr/include/asio/detail/timer_queue.hpp:195:33: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'unsigned long'