### PR TITLE
Fix error clearing for use_tmp_dh functions

### DIFF
--- a/asio/include/asio/ssl/impl/context.ipp
+++ b/asio/include/asio/ssl/impl/context.ipp
@@ -779,6 +779,8 @@ void context::use_tmp_dh(const const_buffer& dh)
 asio::error_code context::use_tmp_dh(
     const const_buffer& dh, asio::error_code& ec)
 {
+  ::ERR_clear_error();
+
   bio_cleanup bio = { make_buffer_bio(dh) };
   if (bio.p)
   {
@@ -801,6 +803,8 @@ void context::use_tmp_dh_file(const std::string& filename)
 asio::error_code context::use_tmp_dh_file(
     const std::string& filename, asio::error_code& ec)
 {
+  ::ERR_clear_error();
+
   bio_cleanup bio = { ::BIO_new_file(filename.c_str(), "r") };
   if (bio.p)
   {
@@ -816,8 +820,6 @@ asio::error_code context::use_tmp_dh_file(
 asio::error_code context::do_use_tmp_dh(
     BIO* bio, asio::error_code& ec)
 {
-  ::ERR_clear_error();
-
   dh_cleanup dh = { ::PEM_read_bio_DHparams(bio, 0, 0, 0) };
   if (dh.p)
   {


### PR DESCRIPTION
The SSL error is cleared a bit too late in the functions related to use_tmp_dh.

The change addresses for example the case where in use_tmp_dh_file, the call to BIO_new_file fails.