### PR TITLE
Bug fix: wrong iterator increment

### DIFF
--- a/asio/include/asio/ip/basic_resolver_iterator.hpp
+++ b/asio/include/asio/ip/basic_resolver_iterator.hpp
@@ -156,12 +156,7 @@ public:
 protected:
   void increment()
   {
-    if (++index_ == values_->size())
-    {
-      // Reset state to match a default constructed end iterator.
-      values_.reset();
-      index_ = 0;
-    }
+    ++index_;
   }
 
   bool equal(const basic_resolver_iterator& other) const


### PR DESCRIPTION
Description
========
Access violation when iterator is dereferenced because iterator is incremented over the end because end iterators are not equal.

How to reproduce
=============
asio::error_code ec;
auto results = resolver.resolve("www.test.com", "25", ec);

auto b = results.begin();
auto end = results.end();
for (auto it = results.begin(); it != end; ++it) ;

Solution
======
increment() should not reset the values when the end is reached. See how the end iterator is created in basic_resolver_results:

File: basic_resolver_results.hpp
  /// Obtain an end iterator for the results range.
  const_iterator end() const
  {
    basic_resolver_results tmp(*this);
    tmp.index_ = size();
    return tmp;
  }