### PR TITLE
Fix: wrong condition for end check

### DIFF
--- a/asio/include/asio/impl/connect.hpp
+++ b/asio/include/asio/impl/connect.hpp
@@ -307,7 +307,7 @@ namespace detail
 
           default:
 
-          if (iter == end)
+          if (std::next(iter) == end)
             break;
 
           if (!socket_.is_open())


### PR DESCRIPTION
At the point of the proposed change the iter points to the current value (host). We need to check whether the next value is the end. If we don't do that the iterator is incremented and may reach the end. And later the end iterator is dereferenced:
 handler_(static_cast<const asio::error_code&>(ec),
            static_cast<const typename Protocol::endpoint&>(*iter));
This results in an access violation.