### PR TITLE
Data race fix on resolver canceling

### DIFF
--- a/asio/include/asio/detail/impl/socket_ops.ipp
+++ b/asio/include/asio/detail/impl/socket_ops.ipp
@@ -3286,7 +3286,8 @@ asio::error_code background_getaddrinfo(
     const char* service, const addrinfo_type& hints,
     addrinfo_type** result, asio::error_code& ec)
 {
-  if (cancel_token.expired())
+  shared_cancel_token_type shared_token = cancel_token.lock();
+  if (!shared_token)
     ec = asio::error::operation_aborted;
   else
     socket_ops::getaddrinfo(host, service, hints, result, ec);
@@ -3391,7 +3392,8 @@ asio::error_code background_getnameinfo(
     char* host, std::size_t hostlen, char* serv,
     std::size_t servlen, int sock_type, asio::error_code& ec)
 {
-  if (cancel_token.expired())
+  shared_cancel_token_type shared_token = cancel_token.lock();
+  if (!shared_token)
   {
     ec = asio::error::operation_aborted;
   }


### PR DESCRIPTION
There's a data race in the resolver code caused by weak_ptr::expired() usage which is not atomic. A safer approach is to acquire shared_ptr by calling weak_ptr::lock().

This issue was discovered by clang Thread Sanitizer. Happens when resolver::cancel() called and the resolver result is ready to be returned back to the user. Original report:

```

WARNING: ThreadSanitizer: data race (pid=31734)
  Atomic write of size 8 at 0x7d080002c528 by thread T7:
    #0 __tsan_atomic64_fetch_add <null> (test_client+0x000000567457)
    #1 long std::__1::(anonymous namespace)::decrement<long>(long&) /home/dmitry.sobinov/builds/libcxx-3.7.0.src/src/support/atomic_support.h:73 (libc++.so+0x000000092c5f)
    #2 decrement<long> /home/dmitry.sobinov/builds/libcxx-3.7.0.src/src/memory.cpp:37 (libc++.so+0x000000092c5f)
    #3 std::__1::__shared_count::__release_shared() /home/dmitry.sobinov/builds/libcxx-3.7.0.src/src/memory.cpp:65 (libc++.so+0x000000092b06)
    #4 std::__1::__shared_weak_count::__release_shared() /home/dmitry.sobinov/builds/libcxx-3.7.0.src/src/memory.cpp:92 (libc++.so+0x000000092df2)
    #5 ~shared_ptr /home/dmitry.sobinov/webrtc/src/chromium/src/buildtools/third_party/libc++/trunk/include/memory:4448 (test_client+0x000000730f48)
    #6 _ZNSt3__110shared_ptrIvE5resetIvN5boost4asio6detail10socket_ops12noop_deleterEEENS_9enable_ifIXsr14is_convertibleIPT_PvEE5valueEvE4typeESA_T0_ /home/dmitry.sobinov/webrtc/src/chromium/src/buildtools/third_party/libc++/trunk/include/memory:4603 (test_client+0x000000736c84)
    #7 boost::asio::detail::resolver_service_base::cancel(std::__1::shared_ptr<void>&) /home/dmitry.sobinov/libs_tsan_cxx/include/boost/asio/detail/impl/resolver_service_base.ipp:106 (test_client+0x000000736c84)
    #8 boost::asio::ip::resolver_service<boost::asio::ip::tcp>::cancel(std::__1::shared_ptr<void>&) /home/dmitry.sobinov/libs_tsan_cxx/include/boost/asio/ip/resolver_service.hpp:106 (test_client+0x000000740174)
    #9 boost::asio::ip::basic_resolver<boost::asio::ip::tcp, boost::asio::ip::resolver_service<boost::asio::ip::tcp> >::cancel() /home/dmitry.sobinov/libs_tsan_cxx/include/boost/asio/ip/basic_resolver.hpp:80 (test_client+0x00000073c975)
    ... <calling stop function here>
    #18 boost::asio::detail::task_io_service_operation::complete(boost::asio::detail::task_io_service&, boost::system::error_code const&, unsigned long) /home/dmitry.sobinov/libs_tsan_cxx/include/boost/asio/detail/task_io_service_operation.hpp:38 (test_client+0x0000005a2957)
    #19 boost::asio::detail::task_io_service::do_run_one(boost::asio::detail::scoped_lock<boost::asio::detail::posix_mutex>&, boost::asio::detail::task_io_service_thread_info&, boost::system::error_code const&) /home/dmitry.sobinov/libs_tsan_cxx/include/boost/asio/detail/impl/task_io_service.ipp:372 (test_client+0x0000005a2186)
    #20 boost::asio::detail::task_io_service::run(boost::system::error_code&) /home/dmitry.sobinov/libs_tsan_cxx/include/boost/asio/detail/impl/task_io_service.ipp:149 (test_client+0x0000005a1db4)
    #21 boost::asio::io_service::run() /home/dmitry.sobinov/libs_tsan_cxx/include/boost/asio/impl/io_service.ipp:59 (test_client+0x0000005886b7)
    ...
    #27 void std::__1::__thread_execute<std::__1::__bind<void (SomeClass::*)(), SomeClass*>>(std::__1::tuple<std::__1::__bind<void (SomeClass::*)(), SomeClass*>>&, std::__1::__tuple_indices<>) /home/dmitry.sobinov/webrtc/src/chromium/src/buildtools/third_party/libc++/trunk/include/thread:332 (test_client+0x0000007036f3)
    #28 void* std::__1::__thread_proxy<std::__1::tuple<std::__1::__bind<void (SomeClass::*)(), SomeClass*> > >(void*) /home/dmitry.sobinov/webrtc/src/chromium/src/buildtools/third_party/libc++/trunk/include/thread:342 (test_client+0x0000007036f3)

  Previous read of size 8 at 0x7d080002c528 by thread T8:
    #0 std::__1::__shared_count::use_count() const /home/dmitry.sobinov/webrtc/src/chromium/src/buildtools/third_party/libc++/trunk/include/memory:3602 (test_client+0x000000733d48)
    #1 std::__1::__shared_weak_count::use_count() const /home/dmitry.sobinov/webrtc/src/chromium/src/buildtools/third_party/libc++/trunk/include/memory:3624 (test_client+0x000000733d48)
    #2 std::__1::weak_ptr<void>::expired() const /home/dmitry.sobinov/webrtc/src/chromium/src/buildtools/third_party/libc++/trunk/include/memory:4980 (test_client+0x000000733d48)
    #3 boost::asio::detail::socket_ops::background_getaddrinfo(std::__1::weak_ptr<void> const&, char const*, char const*, addrinfo const&, addrinfo**, boost::system::error_code&) /home/dmitry.sobinov/libs_tsan_cxx/include/boost/asio/detail/impl/socket_ops.ipp:3246 (test_client+0x000000733d48)
    #4 <our_app_code>
    #5 boost::asio::detail::task_io_service_operation::complete(boost::asio::detail::task_io_service&, boost::system::error_code const&, unsigned long) /home/dmitry.sobinov/libs_tsan_cxx/include/boost/asio/detail/task_io_service_operation.hpp:38 (test_client+0x0000005a2957)
    #6 boost::asio::detail::task_io_service::do_run_one(boost::asio::detail::scoped_lock<boost::asio::detail::posix_mutex>&, boost::asio::detail::task_io_service_thread_info&, boost::system::error_code const&) /home/dmitry.sobinov/libs_tsan_cxx/include/boost/asio/detail/impl/task_io_service.ipp:372 (test_client+0x0000005a2186)
    #7 boost::asio::detail::task_io_service::run(boost::system::error_code&) /home/dmitry.sobinov/libs_tsan_cxx/include/boost/asio/detail/impl/task_io_service.ipp:149 (test_client+0x0000005a1db4)
    #8 boost::asio::io_service::run() /home/dmitry.sobinov/libs_tsan_cxx/include/boost/asio/impl/io_service.ipp:59 (test_client+0x0000005886b7)
    #9 boost::asio::detail::resolver_service_base::work_io_service_runner::operator()() /home/dmitry.sobinov/libs_tsan_cxx/include/boost/asio/detail/impl/resolver_service_base.ipp:32 (test_client+0x000000732d71)
    #10 boost::asio::detail::posix_thread::func<boost::asio::detail::resolver_service_base::work_io_service_runner>::run() /home/dmitry.sobinov/libs_tsan_cxx/include/boost/asio/detail/posix_thread.hpp:82 (test_client+0x000000732ced)
    #11 boost_asio_detail_posix_thread_function /home/dmitry.sobinov/libs_tsan_cxx/include/boost/asio/detail/impl/posix_thread.ipp:64 (test_client+0x000000732be9)



```