### PR TITLE
Fix build when only asio/spawn.hpp is included

### DIFF
--- a/asio/include/asio/bind_executor.hpp
+++ b/asio/include/asio/bind_executor.hpp
@@ -22,6 +22,8 @@
 #include "asio/async_result.hpp"
 #include "asio/handler_type.hpp"
 #include "asio/uses_executor.hpp"
+#include "asio/is_executor.hpp"
+#include "asio/associated_executor.hpp"
 
 #include "asio/detail/push_options.hpp"
 


### PR DESCRIPTION
When asio/spawn.hpp is the only one header included, build fails because bind_executor.hpp lacks some includes.