### PR TITLE
Fix use of strerror_r()

### DIFF
--- a/asio/include/asio/impl/error_code.ipp
+++ b/asio/include/asio/impl/error_code.ipp
@@ -98,17 +98,14 @@ public:
 #if defined(__sun) || defined(__QNX__) || defined(__SYMBIAN32__)
     using namespace std;
     return strerror(value);
-#elif defined(__MACH__) && defined(__APPLE__) \
-  || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__OpenBSD__) \
-  || defined(_AIX) || defined(__hpux) || defined(__osf__) \
-  || defined(__ANDROID__)
+#elif defined(__GLIBC__) && defined(_GNU_SOURCE)
+    char buf[256] = "";
+    return strerror_r(value, buf, sizeof(buf));
+#else
     char buf[256] = "";
     using namespace std;
     strerror_r(value, buf, sizeof(buf));
     return buf;
-#else
-    char buf[256] = "";
-    return strerror_r(value, buf, sizeof(buf));
 #endif
 #endif // defined(ASIO_WINDOWS_DESKTOP) || defined(__CYGWIN__)
   }


### PR DESCRIPTION
Don't try keep track of all platforms which follows posix standard.
Instead, make the platform which don't follow standard to an exception
and fall back to standard implementation for everything else.

This fixes building with musl libc.

Fixes #94