### PR TITLE
Remove global mutex protecting SSL_accept() calls

### DIFF
--- a/asio/include/asio/ssl/detail/engine.hpp
+++ b/asio/include/asio/ssl/detail/engine.hpp
@@ -115,10 +115,6 @@ private:
   ASIO_DECL static int verify_callback_function(
       int preverified, X509_STORE_CTX* ctx);
 
-  // The SSL_accept function may not be thread safe. This mutex is used to
-  // protect all calls to the SSL_accept function.
-  ASIO_DECL static asio::detail::static_mutex& accept_mutex();
-
   // Perform one operation. Returns >= 0 on success or error, want_read if the
   // operation needs more input, or want_write if it needs to write some output
   // before the operation can complete.

--- a/asio/include/asio/ssl/detail/impl/engine.ipp
+++ b/asio/include/asio/ssl/detail/impl/engine.ipp
@@ -40,8 +40,6 @@ engine::engine(SSL_CTX* context)
     asio::detail::throw_error(ec, "engine");
   }
 
-  accept_mutex().init();
-
   ::SSL_set_mode(ssl_, SSL_MODE_ENABLE_PARTIAL_WRITE);
   ::SSL_set_mode(ssl_, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
 #if defined(SSL_MODE_RELEASE_BUFFERS)
@@ -213,12 +211,6 @@ const asio::error_code& engine::map_error_code(
   return ec;
 }
 
-asio::detail::static_mutex& engine::accept_mutex()
-{
-  static asio::detail::static_mutex mutex = ASIO_STATIC_MUTEX_INIT;
-  return mutex;
-}
-
 engine::want engine::perform(int (engine::* op)(void*, std::size_t),
     void* data, std::size_t length, asio::error_code& ec,
     std::size_t* bytes_transferred)
@@ -276,7 +268,6 @@ engine::want engine::perform(int (engine::* op)(void*, std::size_t),
 
 int engine::do_accept(void*, std::size_t)
 {
-  asio::detail::static_mutex::scoped_lock lock(accept_mutex());
   return ::SSL_accept(ssl_);
 }
 


### PR DESCRIPTION
There is no indication in OpenSSL / BoringSSL docs that SSL_accept() is
not thread safe if "an application sets up the thread callback
function". ASIO does set up those functions. So SSL_accept() should be
thread safe.

The mutex was suggested by https://sourceforge.net/p/asio/patches/1/.
Probably there was a mistake in user testing (e.g. thread callback
function was not configured). Regardless, the global mutex locking leads
to heavy lock contention and thus very low performance. In our tests we
used to have ~200-250 requests per second, and CPU was far from being
maxed out.

We did some stress tests with the mutex removed from the asio code.
After ~65M requests at ~1350 req/sec there was no indication of any
problems (no crashes / errors / memory leaks). The test box CPU was
maxed out. Looks like the documentation does not lie and the mutex is
not necessary.