### PR TITLE
Don't rely on deprecated implicit OpenSSL includes

### DIFF
--- a/asio/include/asio/ssl/detail/openssl_types.hpp
+++ b/asio/include/asio/ssl/detail/openssl_types.hpp
@@ -23,6 +23,8 @@
 #endif // !defined(OPENSSL_NO_ENGINE)
 #include <openssl/err.h>
 #include <openssl/x509v3.h>
+#include <openssl/rsa.h>
+#include <openssl/dh.h>
 #include "asio/detail/socket_types.hpp"
 
 #endif // ASIO_SSL_DETAIL_OPENSSL_TYPES_HPP


### PR DESCRIPTION
rsa.h and dh.h are needed in context.ipp for RSA_free and DH_free.
They are only included implicitly if OPENSSL_NO_DEPRECATED is not defined.