### PR TITLE
Fix configure.ac to support mingw64

### DIFF
--- a/asio/configure.ac
+++ b/asio/configure.ac
@@ -214,6 +214,12 @@ case $host in
     LIBS="$LIBS -lws2_32 -lmswsock"
     WINDOWS=yes
     ;;
+  *-*-mingw64*)
+    CXXFLAGS="$CXXFLAGS -mthreads"
+    LDFLAGS="$LDFLAGS -mthreads"
+    LIBS="$LIBS -lws2_32 -lmswsock"
+    WINDOWS=yes
+    ;;
   *-pc-cygwin*)
     CXXFLAGS="$CXXFLAGS -D__USE_W32_SOCKETS -D_WIN32_WINNT=0x0501"
     LIBS="$LIBS -lws2_32 -lmswsock"


### PR DESCRIPTION
This enhances the configure script to recognize MinGW64, as present in MSYS2, as a valid Windows platform, and thus to link with the right Windows libraries, and to not try building syslog daemons and such on it.
