### PR TITLE
On Windows, if using SSL, include socket_types before OpenSSL headers.

### DIFF
--- a/asio/include/asio/ssl/detail/openssl_types.hpp
+++ b/asio/include/asio/ssl/detail/openssl_types.hpp
@@ -17,12 +17,17 @@
 
 #include "asio/detail/config.hpp"
 #include <openssl/conf.h>
+#if defined(ASIO_WINDOWS)
+#include "asio/detail/socket_types.hpp"
+#endif // defined(ASIO_WINDOWS)
 #include <openssl/ssl.h>
 #if !defined(OPENSSL_NO_ENGINE)
 # include <openssl/engine.h>
 #endif // !defined(OPENSSL_NO_ENGINE)
 #include <openssl/err.h>
 #include <openssl/x509v3.h>
+#if !defined(ASIO_WINDOWS)
 #include "asio/detail/socket_types.hpp"
+#endif // !defined(ASIO_WINDOWS)
 
 #endif // ASIO_SSL_DETAIL_OPENSSL_TYPES_HPP


### PR DESCRIPTION
This is the non-pretty solution to #108: it does work to complete a build successfully, and it's not really that gross of a hack, it's just platform-specificity leaking where you'd probably rather not have it, but OpenSSL forced the hand.
