### PR TITLE
Add compatibility with OpenSSL 1.1

### DIFF
--- a/asio/include/asio/ssl/detail/impl/engine.ipp
+++ b/asio/include/asio/ssl/detail/impl/engine.ipp
@@ -201,8 +201,10 @@ const asio::error_code& engine::map_error_code(
 
   // SSL v2 doesn't provide a protocol-level shutdown, so an eof on the
   // underlying transport is passed through.
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
   if (ssl_->version == SSL2_VERSION)
     return ec;
+#endif // (OPENSSL_VERSION_NUMBER < 0x10100000L)
 
   // Otherwise, the peer should have negotiated a proper shutdown.
   if ((::SSL_get_shutdown(ssl_) & SSL_RECEIVED_SHUTDOWN) == 0)

--- a/asio/include/asio/ssl/detail/impl/openssl_init.ipp
+++ b/asio/include/asio/ssl/detail/impl/openssl_init.ipp
@@ -39,11 +39,13 @@ public:
     ::SSL_load_error_strings();        
     ::OpenSSL_add_all_algorithms();
 
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
     mutexes_.resize(::CRYPTO_num_locks());
     for (size_t i = 0; i < mutexes_.size(); ++i)
       mutexes_[i].reset(new asio::detail::mutex);
     ::CRYPTO_set_locking_callback(&do_init::openssl_locking_func);
     ::CRYPTO_set_id_callback(&do_init::openssl_id_func);
+#endif // (OPENSSL_VERSION_NUMBER < 0x10100000L)
 
 #if !defined(SSL_OP_NO_COMPRESSION) \
   && (OPENSSL_VERSION_NUMBER >= 0x00908000L)
@@ -60,22 +62,26 @@ public:
 #endif // !defined(SSL_OP_NO_COMPRESSION)
        // && (OPENSSL_VERSION_NUMBER >= 0x00908000L)
 
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
     ::CRYPTO_set_id_callback(0);
     ::CRYPTO_set_locking_callback(0);
     ::ERR_free_strings();
-#if (OPENSSL_VERSION_NUMBER >= 0x10000000L)
-    ::ERR_remove_thread_state(NULL);
-#else // (OPENSSL_VERSION_NUMBER >= 0x10000000L)
-    ::ERR_remove_state(0);
-#endif // (OPENSSL_VERSION_NUMBER >= 0x10000000L)
     ::EVP_cleanup();
     ::CRYPTO_cleanup_all_ex_data();
+#endif // (OPENSSL_VERSION_NUMBER < 0x10100000L)
+#if (OPENSSL_VERSION_NUMBER < 0x10000000L)
+    ::ERR_remove_state(0);
+#elif (OPENSSL_VERSION_NUMBER < 0x10100000L)
+    ::ERR_remove_thread_state(NULL);
+#endif // (OPENSSL_VERSION_NUMBER < 0x10000000L)
 #if !defined(OPENSSL_IS_BORINGSSL)
     ::CONF_modules_unload(1);
 #endif // !defined(OPENSSL_IS_BORINGSSL)
-#if !defined(OPENSSL_NO_ENGINE)
+#if !defined(OPENSSL_NO_ENGINE) \
+  && (OPENSSL_VERSION_NUMBER < 0x10100000L)
     ::ENGINE_cleanup();
 #endif // !defined(OPENSSL_NO_ENGINE)
+       // && (OPENSSL_VERSION_NUMBER < 0x10100000L)
   }
 
 #if !defined(SSL_OP_NO_COMPRESSION) \
@@ -104,10 +110,12 @@ private:
   static void openssl_locking_func(int mode, int n, 
     const char* /*file*/, int /*line*/)
   {
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
     if (mode & CRYPTO_LOCK)
       instance()->mutexes_[n]->lock();
     else
       instance()->mutexes_[n]->unlock();
+#endif // (OPENSSL_VERSION_NUMBER < 0x10100000L)
   }
 
   // Mutexes to be used in locking callbacks.


### PR DESCRIPTION
- SSLv2 has been completely removed from OpenSSL, even without OPENSSL_NO_SSL2
- there is a new threading API without locking callbacks
- the argument has been removed from ERR_remove_thread_state
- struct SSL_CTX has been made opaque and must be used via accessor functions

Tested as Boost.Asio with OpenSSL 1.1.0 Beta and 1.0.2g.