### PR TITLE
Enable ECDHE temporary parameters in ASIO SSL

### DIFF
--- a/asio/include/asio/ssl/context.hpp
+++ b/asio/include/asio/ssl/context.hpp
@@ -667,6 +667,37 @@ public:
   ASIO_DECL asio::error_code use_tmp_dh_file(
       const std::string& filename, asio::error_code& ec);
 
+  /// Use the specified certificate to obtain temporary Diffie-Hellman parameters
+  /// for Elliptic Curve Diffie-Hellman.
+  /**
+   * This function is used to load Elliptic Curve Diffie-Hellman parameters into
+   * the context from a certificate based on Elliptic Curve Cryptography (ECC).
+   *
+   * @param certificate The name of the file containing the ECC-based certificate.
+   * The file must use the PEM format.
+   *
+   * @param ec Set to indicate what error occurred, if any.
+   *
+   * @note Calls @c SSL_CTX_set_tmp_ecdh.
+   */
+  ASIO_DECL void use_tmp_ecdh(const std::string& certificate);
+
+  /// Use the specified certificate to obtain temporary Diffie-Hellman parameters
+  /// for Elliptic Curve Diffie-Hellman.
+  /**
+   * This function is used to load Elliptic Curve Diffie-Hellman parameters into
+   * the context from a certificate based on Elliptic Curve Cryptography (ECC).
+   *
+   * @param certificate The name of the file containing the ECC-based certificate.
+   * The file must use the PEM format.
+   *
+   * @param ec Set to indicate what error occurred, if any.
+   *
+   * @note Calls @c SSL_CTX_set_tmp_ecdh.
+   */
+  ASIO_DECL asio::error_code use_tmp_ecdh(
+		  const std::string& certificate, asio::error_code& ec);
+
   /// Set the password callback.
   /**
    * This function is used to specify a callback function to obtain password
@@ -714,6 +745,7 @@ private:
   struct evp_pkey_cleanup;
   struct rsa_cleanup;
   struct dh_cleanup;
+  struct ec_key_cleanup;
 
   // Helper function used to set a peer certificate verification callback.
   ASIO_DECL asio::error_code do_set_verify_callback(
@@ -734,6 +766,10 @@ private:
   // Helper function to set the temporary Diffie-Hellman parameters from a BIO.
   ASIO_DECL asio::error_code do_use_tmp_dh(
       BIO* bio, asio::error_code& ec);
+
+  // Helper function to set the temprorary ECC Diffie-Hellman parameters from a BIO.
+  ASIO_DECL asio::error_code do_use_tmp_ecdh(
+  		  BIO* bio, asio::error_code& ec);
 
   // Helper function to make a BIO from a memory buffer.
   ASIO_DECL BIO* make_buffer_bio(const const_buffer& b);

--- a/asio/include/asio/ssl/impl/context.ipp
+++ b/asio/include/asio/ssl/impl/context.ipp
@@ -59,6 +59,12 @@ struct context::dh_cleanup
   ~dh_cleanup() { if (p) ::DH_free(p); }
 };
 
+struct context::ec_key_cleanup
+{
+  EC_KEY *p;
+  ~ec_key_cleanup() { if (p) ::EC_KEY_free(p); }
+};
+
 context::context(context::method m)
   : handle_(0)
 {
@@ -855,6 +861,68 @@ asio::error_code context::do_use_tmp_dh(
   ec = asio::error_code(
       static_cast<int>(::ERR_get_error()),
       asio::error::get_ssl_category());
+  return ec;
+}
+
+void context::use_tmp_ecdh(const std::string& certificate)
+{
+  asio::error_code ec;
+  use_tmp_ecdh(certificate, ec);
+  asio::detail::throw_error(ec, "use_tmp_ecdh");
+}
+
+asio::error_code context::use_tmp_ecdh(const std::string& certificate,
+		asio::error_code& ec)
+{
+  ::ERR_clear_error();
+
+  bio_cleanup bio = { ::BIO_new_file(certificate.c_str(), "r") };
+  if (bio.p)
+  {
+	return do_use_tmp_ecdh(bio.p,ec);
+  }
+
+  ec = asio::error_code(
+	  static_cast<int>(::ERR_get_error()),
+	  asio::error::get_ssl_category());
+  return ec;
+}
+
+asio::error_code context::do_use_tmp_ecdh(
+		BIO* bio, asio::error_code& ec)
+{
+  ::ERR_clear_error();
+
+  int nid = NID_undef;
+
+  x509_cleanup x509 = { ::PEM_read_bio_X509(bio, NULL, 0, NULL) };
+  if (x509.p)
+  {
+    evp_pkey_cleanup pkey = { ::X509_get_pubkey(x509.p) };
+    if(pkey.p)
+    {
+      int type = EVP_PKEY_type(pkey.p->type);
+      if(type == EVP_PKEY_EC)
+      {
+        const EC_GROUP *group = EC_KEY_get0_group(pkey.p->pkey.ec);
+        nid = EC_GROUP_get_curve_name(group);
+      }
+    }
+  }
+
+  ec_key_cleanup ec_key = { ::EC_KEY_new_by_curve_name(nid) };
+  if(ec_key.p)
+  {
+    if (::SSL_CTX_set_tmp_ecdh(handle_, ec_key.p) == 1 )
+    {
+      ec = asio::error_code();
+      return ec;
+    }
+  }
+
+  ec = asio::error_code(
+	  static_cast<int>(::ERR_get_error()),
+	  asio::error::get_ssl_category());
   return ec;
 }
 


### PR DESCRIPTION
Implemented API context::use_tmp_ecdh(std::string& certificate) to
enable SSL_CTX_set_tmp_ecdh() from OpenSSL.

This functionality was missing and certificates using ECC were not able
to use ECDHE due to missing temporary ECDH parameters.

Using this new API, the user can just pass in their certificate and the
API will identify the ECC curve and use it's generator point to create
new temporary key pairs to provide Perfect Forward Secrecy (PFS).