### PR TITLE
Recognize loopback IPv4-mapped IPv6 addresses as such

### DIFF
--- a/asio/include/asio/ip/impl/address_v6.ipp
+++ b/asio/include/asio/ip/impl/address_v6.ipp
@@ -147,7 +147,8 @@ bool address_v6::is_loopback() const
       && (addr_.s6_addr[8] == 0) && (addr_.s6_addr[9] == 0)
       && (addr_.s6_addr[10] == 0) && (addr_.s6_addr[11] == 0)
       && (addr_.s6_addr[12] == 0) && (addr_.s6_addr[13] == 0)
-      && (addr_.s6_addr[14] == 0) && (addr_.s6_addr[15] == 1));
+      && (addr_.s6_addr[14] == 0) && (addr_.s6_addr[15] == 1))
+      || (is_v4_mapped() && (addr_.s6_addr[12] == 0x7f));
 }
 
 bool address_v6::is_unspecified() const


### PR DESCRIPTION
Per https://tools.ietf.org/html/rfc4291#section-2.5.5.2, IPv4 addresses can be mapped to IPv6 addresses (`127.0.0.1` turns into `[::ffff:127.0.0.1]`). Since `127.0.0.0/8` addresses are loopback, I would assume that their IPv6 mappings would be loopback as well.

This issue has been previously reported on the Boost bug tracker (https://svn.boost.org/trac/boost/ticket/9084). I believe I've coded a solution to it.