### PR TITLE
Acceptex

### DIFF
--- a/asio/include/asio/detail/impl/win_iocp_socket_service_base.ipp
+++ b/asio/include/asio/detail/impl/win_iocp_socket_service_base.ipp
@@ -488,12 +488,13 @@ void win_iocp_socket_service_base::start_accept_op(
   {
     asio::error_code ec;
     new_socket.reset(socket_ops::socket(family, type, protocol, ec));
-    if (new_socket.get() == invalid_socket)
+    accept_ex_fn accept_ex = get_accept_ex(impl, type);
+    if (new_socket.get() == invalid_socket || !accept_ex)
       iocp_service_.on_completion(op, ec);
     else
     {
       DWORD bytes_read = 0;
-      BOOL result = ::AcceptEx(impl.socket_, new_socket.get(), output_buffer,
+      BOOL result = accept_ex(impl.socket_, new_socket.get(), output_buffer,
           0, address_length, address_length, &bytes_read, op);
       DWORD last_error = ::WSAGetLastError();
       if (!result && last_error != WSA_IO_PENDING)

--- a/asio/include/asio/detail/win_iocp_socket_service_base.hpp
+++ b/asio/include/asio/detail/win_iocp_socket_service_base.hpp
@@ -536,6 +536,21 @@ protected:
   ASIO_DECL connect_ex_fn get_connect_ex(
       base_implementation_type& impl, int type);
 
+  // The type of an AcceptEx function pointer, as old SDKs may not provide it.
+  typedef BOOL (PASCAL *accept_ex_fn)(SOCKET, SOCKET, void*, DWORD, DWORD,
+      DWORD, DWORD*, OVERLAPPED*);
+
+  // Helper function to get the AcceptEx pointer. If no AcceptEx pointer has
+  // been obtained yet, one is obtained using WSAIoctl and the pointer is
+  // cached. Returns a null pointer if AcceptEx is not available.
+  ASIO_DECL accept_ex_fn get_accept_ex(
+      base_implementation_type& impl, int type);
+
+  // Common implementation between get_connect_ex and get_accept_ex
+  ASIO_DECL void* lookup_extension_pointer(
+      base_implementation_type& impl, int type, void*& cache,
+      GUID& guid);
+
   // Helper function to emulate InterlockedCompareExchangePointer functionality
   // for:
   // - very old Platform SDKs; and
@@ -562,7 +577,10 @@ protected:
   // Pointer to ConnectEx implementation.
   void* connect_ex_;
 
-  // Mutex to protect access to the linked list of implementations. 
+  // Pointer to AcceptEx implementation.
+  void* accept_ex_;
+
+  // Mutex to protect access to the linked list of implementations.
   asio::detail::mutex mutex_;
 
   // The head of a linked list of all implementations.


### PR DESCRIPTION
Turns out that directly linking to AcceptEx is as bad of an idea in disparate environments as ConnectEx (failed in at least one of my test build environments). This code handles the AcceptEx case the same way as ConnectEx was already handled, in part by factoring out and re-using some of the connectex machinery.