### PR TITLE
Problem of hangs caused by the infinite wait or constant readiness to read the new data

### DIFF
--- a/asio/include/asio/detail/impl/epoll_reactor.ipp
+++ b/asio/include/asio/detail/impl/epoll_reactor.ipp
@@ -503,6 +503,24 @@ void epoll_reactor::run(long usec, op_queue<operation>& ops)
 #if defined(ASIO_HAS_TIMERFD)
     else if (ptr == &timer_fd_)
     {
+      // We should read an 8-byte timeout expiration counter (using
+      // the "timerfd" descriptor) every time when the EPOLLIN event
+      // occurs. Otherwise, the timer stops to notifying the application
+      // about new events, and all activity associated with this timer
+      // will be frozen on some systems, or vice versa, we get an infinite
+      // loop of notifications because of the constant readiness to read
+      // the new data:
+
+      if (events[i].events & EPOLLIN)
+      {
+        // If timeout was expired, we should read the expiration counter:
+        uint64_t count;
+        if (read(timer_fd_, &count, sizeof(count)))
+        {
+          // Just to ignore return value of the read() function
+          // without compiler warning...
+        }
+      }
       check_timers = true;
     }
 #endif // defined(ASIO_HAS_TIMERFD)


### PR DESCRIPTION
Recently I encountered a problem of hangs caused by the infinite wait in numerous unit tests during build of the Galera project from the Codership.

In particular, this problem manifests itself in the following configurations:

- debian-wheezy-x64 (https://wiki.debian.org/DebianWheezy);
- ubuntu-wily-x64 (http://old-releases.ubuntu.com/releases/15.10/);
- debian-jessie-x64 with AddressSanitizer (https://www.debian.org/releases/jessie/ + https://en.wikipedia.org/wiki/AddressSanitizer);
- centos6-32 (https://wiki.centos.org/Manuals/ReleaseNotes/CentOS6.8);

In particular, the program may hang in the epoll_wait() function, or vice versa, this function can be completed instantly (on other systems).

I think this error occurs in the ASIO C++ library because the Linux kernel requires the application to read an 8-byte timeout expiration counter (using the "timerfd" descriptor) every time when the EPOLLIN event occurs. Otherwise, the timer stops to notifying the application about new events, and all activity associated with this timer will be frozen on some systems, or vice versa, we get an infinite loop of notifications because of the constant readiness to read the new data.

But current version of the ASIO library does not read the data using the "timerfd" descriptor after returning from the epoll_wait().

To fix this problem, we should read the 8-byte expiration counter from the "timerfd" descriptor every time, when the EPOLLIN event occurs.