### PR TITLE
Fix compilation with OpenSSL 1.1 API

### DIFF
--- a/asio/include/asio/ssl/detail/impl/openssl_init.ipp
+++ b/asio/include/asio/ssl/detail/impl/openssl_init.ipp
@@ -35,11 +35,11 @@ class openssl_init_base::do_init
 public:
   do_init()
   {
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
     ::SSL_library_init();
     ::SSL_load_error_strings();        
     ::OpenSSL_add_all_algorithms();
 
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L)
     mutexes_.resize(::CRYPTO_num_locks());
     for (size_t i = 0; i < mutexes_.size(); ++i)
       mutexes_[i].reset(new asio::detail::mutex);


### PR DESCRIPTION
With OPENSSL_API_COMPAT=0x10100000L, SSL_library_init, SSL_load_error_strings, and OpenSSL_add_all_algorithms are removed.
With OPENSSL_API_COMPAT=0x10000000L, these are function-style macros mapping to OPENSSL_init_ssl, which is called automatically anyway.

References:
https://www.openssl.org/docs/man1.1.0/ssl/OPENSSL_init_ssl.html
https://www.openssl.org/docs/man1.1.0/crypto/OPENSSL_init_crypto.html