### PR TITLE
Use std::atomic_thread_fence if <atomic> exists

### DIFF
--- a/asio/include/asio/detail/atomic_fenced_block.hpp
+++ b/asio/include/asio/detail/atomic_fenced_block.hpp
@@ -1,0 +1,62 @@
+//
+// detail/atomic_fenced_block.hpp
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2003-2016 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef ASIO_DETAIL_ATOMIC_FENCED_BLOCK_HPP
+#define ASIO_DETAIL_ATOMIC_FENCED_BLOCK_HPP
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#include "asio/detail/config.hpp"
+
+#if defined(ASIO_HAS_STD_ATOMIC)
+
+#include <atomic>
+#include "asio/detail/noncopyable.hpp"
+
+#include "asio/detail/push_options.hpp"
+
+namespace asio {
+namespace detail {
+
+class atomic_fenced_block
+  : private noncopyable
+{
+public:
+  enum half_t { half };
+  enum full_t { full };
+
+  // Constructor for a half fenced block.
+  explicit atomic_fenced_block(half_t)
+  {
+  }
+
+  // Constructor for a full fenced block.
+  explicit atomic_fenced_block(full_t)
+  {
+    std::atomic_thread_fence(std::memory_order_acquire);
+  }
+
+  // Destructor.
+  ~atomic_fenced_block()
+  {
+    std::atomic_thread_fence(std::memory_order_release);
+  }
+};
+
+} // namespace detail
+} // namespace asio
+
+#include "asio/detail/pop_options.hpp"
+
+#endif // defined(ASIO_HAS_STD_ATOMIC)
+
+#endif // ASIO_DETAIL_ATOMIC_FENCED_BLOCK_HPP

--- a/asio/include/asio/detail/fenced_block.hpp
+++ b/asio/include/asio/detail/fenced_block.hpp
@@ -20,6 +20,8 @@
 #if !defined(ASIO_HAS_THREADS) \
   || defined(ASIO_DISABLE_FENCED_BLOCK)
 # include "asio/detail/null_fenced_block.hpp"
+#elif defined(ASIO_HAS_STD_ATOMIC)
+# include "asio/detail/atomic_fenced_block.hpp"
 #elif defined(__MACH__) && defined(__APPLE__)
 # include "asio/detail/macos_fenced_block.hpp"
 #elif defined(__sun)
@@ -48,6 +50,8 @@ namespace detail {
 #if !defined(ASIO_HAS_THREADS) \
   || defined(ASIO_DISABLE_FENCED_BLOCK)
 typedef null_fenced_block fenced_block;
+#elif defined(ASIO_HAS_STD_ATOMIC)
+typedef atomic_fenced_block fenced_block;
 #elif defined(__MACH__) && defined(__APPLE__)
 typedef macos_fenced_block fenced_block;
 #elif defined(__sun)


### PR DESCRIPTION
This pull request is an alternate approach to #149 , instead of specializing `macos_fenced_block` for C++11, I added a new fenced block implementation for toolchains that have `<atomic>`

This is a bit less conservative than #149 since it just assumes that any toolchain with `<atomic>` will provide `std::atomic_thread_fence`, though I don't know if there's one where the latter does not exist but still implements the rest of the C++11 atomic API.

Addresses #144 