### PR TITLE
Fix consuming buffer.

### DIFF
--- a/asio/include/asio/detail/consuming_buffers.hpp
+++ b/asio/include/asio/detail/consuming_buffers.hpp
@@ -101,7 +101,7 @@ public:
     Buffer_Iterator next = asio::buffer_sequence_begin(buffers_);
     Buffer_Iterator end = asio::buffer_sequence_end(buffers_);
 
-    std::advance(end, next_elem_);
+    std::advance(next, next_elem_);
     while (next != end && size > 0)
     {
       Buffer next_buf = Buffer(*next) + next_elem_offset_;


### PR DESCRIPTION
Fix consuming buffer. Fixes Visual Studio crash and transfer of larger buffers works fine now.

Example for C++11 version of http server was transfering just up to 64k files and with this change all working fine.