### PR TITLE
Reset parser state machine between requests

### DIFF
--- a/asio/src/examples/cpp11/http/server/request_parser.hpp
+++ b/asio/src/examples/cpp11/http/server/request_parser.hpp
@@ -39,6 +39,7 @@ public:
   std::tuple<result_type, InputIterator> parse(request& req,
       InputIterator begin, InputIterator end)
   {
+    reset();
     while (begin != end)
     {
       result_type result = consume(req, *begin++);


### PR DESCRIPTION
The state machine in HTTP Server C++11 example was not reset between parsing of requests. Which makes second and later requests fail if the previous request left the parser in an unfortunate state.