### PR TITLE
Close old sockets and open new ones to watch when recv fails

### DIFF
--- a/asio/include/asio/detail/impl/socket_select_interrupter.ipp
+++ b/asio/include/asio/detail/impl/socket_select_interrupter.ipp
@@ -159,6 +159,8 @@ bool socket_select_interrupter::reset()
   bool was_interrupted = (bytes_read > 0);
   while (bytes_read == sizeof(data))
     bytes_read = socket_ops::recv(read_descriptor_, &b, 1, 0, ec);
+  if (ec)
+    recreate();
   return was_interrupted;
 }
 


### PR DESCRIPTION
When the ec is ignored, the same socket fds are passed to select over and over again, which returns them as to be read causing an endless loop. [https://github.com/chriskohlhoff/asio/issues/14](url)