### PR TITLE
InitializeCriticalSectionEx has undocumented max spincount of 0xFFFFFF

### DIFF
--- a/asio/include/asio/detail/impl/win_mutex.ipp
+++ b/asio/include/asio/detail/impl/win_mutex.ipp
@@ -44,7 +44,8 @@ int win_mutex::do_init()
 # if defined(UNDER_CE)
   ::InitializeCriticalSection(&crit_section_);
 # elif defined(ASIO_WINDOWS_APP)
-  ::InitializeCriticalSectionEx(&crit_section_, 0x80000000, 0);
+  if (!::InitializeCriticalSectionEx(&crit_section_, 0xFFFFFF, 0))
+    return ::GetLastError();
 # else
   if (!::InitializeCriticalSectionAndSpinCount(&crit_section_, 0x80000000))
     return ::GetLastError();
@@ -56,7 +57,8 @@ int win_mutex::do_init()
 # if defined(UNDER_CE)
     ::InitializeCriticalSection(&crit_section_);
 # elif defined(ASIO_WINDOWS_APP)
-    ::InitializeCriticalSectionEx(&crit_section_, 0x80000000, 0);
+    if (!::InitializeCriticalSectionEx(&crit_section_, 0xFFFFFF, 0))
+	  return ::GetLastError();
 # else
     if (!::InitializeCriticalSectionAndSpinCount(&crit_section_, 0x80000000))
       return ::GetLastError();


### PR DESCRIPTION
On Win 10 Universal Windows (Store) apps InitializeCriticalSectionEx was failing with 0x00000057 ERROR_INVALID_PARAMETER.  Found that there is apparently a max value for this function on Win10 of 0xFFFFFF.  Also added error handling that wasn't there.