### PR TITLE
Fix GetModuleHandleA(NTDLL.DLL)

### DIFF
--- a/asio/include/asio/detail/impl/win_iocp_socket_service_base.ipp
+++ b/asio/include/asio/detail/impl/win_iocp_socket_service_base.ipp
@@ -744,7 +744,7 @@ win_iocp_socket_service_base::get_nt_set_info()
   void* ptr = interlocked_compare_exchange_pointer(&nt_set_info_, 0, 0);
   if (!ptr)
   {
-    if (HMODULE h = GetModuleHandle("NTDLL.DLL"))
+    if (HMODULE h = GetModuleHandleA("NTDLL.DLL"))
       ptr = reinterpret_cast<void*>(GetProcAddress(h, "NtSetInformationFile"));
 
     // On failure, set nt_set_info_ to a special value to indicate that the

--- a/asio/include/asio/impl/connect.hpp
+++ b/asio/include/asio/impl/connect.hpp
@@ -309,6 +309,7 @@ namespace detail
             return;
           }
 
+	  /* FALL THROUGH */
           default:
 
           if (iter == end)
@@ -464,6 +465,7 @@ namespace detail
             return;
           }
 
+	  /* FALL THROUGH */
           default:
 
           if (iter_ == end_)


### PR DESCRIPTION
Closes issue #188, VC++ Unicode Compile error, reported by dreamnemo.