### PR TITLE
Update spawn to use Boost.Coroutines2

### DIFF
--- a/asio/include/asio/impl/spawn.hpp
+++ b/asio/include/asio/impl/spawn.hpp
@@ -371,9 +371,7 @@ namespace detail {
     void operator()(typename basic_yield_context<Handler>::caller_type& ca)
     {
       shared_ptr<spawn_data<Handler, Function> > data(data_);
-#if !defined(BOOST_COROUTINES_UNIDIRECT) && !defined(BOOST_COROUTINES_V2)
       ca(); // Yield until coroutine pointer has been initialised.
-#endif // !defined(BOOST_COROUTINES_UNIDIRECT) && !defined(BOOST_COROUTINES_V2)
       const basic_yield_context<Handler> yield(
           data->coro_, ca, data->handler_);
 
@@ -392,13 +390,12 @@ namespace detail {
     {
       typedef typename basic_yield_context<Handler>::callee_type callee_type;
       coro_entry_point<Handler, Function> entry_point = { data_ };
-      shared_ptr<callee_type> coro(new callee_type(entry_point, attributes_));
+      shared_ptr<callee_type> coro(new callee_type(entry_point));
       data_->coro_ = coro;
       (*coro)();
     }
 
     shared_ptr<spawn_data<Handler, Function> > data_;
-    boost::coroutines::attributes attributes_;
   };
 
   template <typename Function, typename Handler, typename Function1>
@@ -422,21 +419,19 @@ namespace detail {
 } // namespace detail
 
 template <typename Function>
-inline void spawn(ASIO_MOVE_ARG(Function) function,
-    const boost::coroutines::attributes& attributes)
+inline void spawn(ASIO_MOVE_ARG(Function) function)
 {
   typedef typename decay<Function>::type function_type;
 
   typename associated_executor<function_type>::type ex(
       (get_associated_executor)(function));
 
-  asio::spawn(ex, ASIO_MOVE_CAST(Function)(function), attributes);
+  asio::spawn(ex, ASIO_MOVE_CAST(Function)(function));
 }
 
 template <typename Handler, typename Function>
 void spawn(ASIO_MOVE_ARG(Handler) handler,
     ASIO_MOVE_ARG(Function) function,
-    const boost::coroutines::attributes& attributes,
     typename enable_if<!is_executor<typename decay<Handler>::type>::value &&
       !is_convertible<Handler&, execution_context&>::value>::type*)
 {
@@ -453,15 +448,13 @@ void spawn(ASIO_MOVE_ARG(Handler) handler,
       new detail::spawn_data<handler_type, Function>(
         ASIO_MOVE_CAST(Handler)(handler), true,
         ASIO_MOVE_CAST(Function)(function)));
-  helper.attributes_ = attributes;
 
   ex.dispatch(helper, a);
 }
 
 template <typename Handler, typename Function>
 void spawn(basic_yield_context<Handler> ctx,
-    ASIO_MOVE_ARG(Function) function,
-    const boost::coroutines::attributes& attributes)
+    ASIO_MOVE_ARG(Function) function)
 {
   Handler handler(ctx.handler_); // Explicit copy that might be moved from.
 
@@ -476,7 +469,6 @@ void spawn(basic_yield_context<Handler> ctx,
       new detail::spawn_data<Handler, Function>(
         ASIO_MOVE_CAST(Handler)(handler), false,
         ASIO_MOVE_CAST(Function)(function)));
-  helper.attributes_ = attributes;
 
   ex.dispatch(helper, a);
 }
@@ -484,42 +476,38 @@ void spawn(basic_yield_context<Handler> ctx,
 template <typename Function, typename Executor>
 inline void spawn(const Executor& ex,
     ASIO_MOVE_ARG(Function) function,
-    const boost::coroutines::attributes& attributes,
     typename enable_if<is_executor<Executor>::value>::type*)
 {
   asio::spawn(asio::strand<Executor>(ex),
-      ASIO_MOVE_CAST(Function)(function), attributes);
+      ASIO_MOVE_CAST(Function)(function));
 }
 
 template <typename Function, typename Executor>
 inline void spawn(const strand<Executor>& ex,
-    ASIO_MOVE_ARG(Function) function,
-    const boost::coroutines::attributes& attributes)
+    ASIO_MOVE_ARG(Function) function)
 {
   asio::spawn(asio::bind_executor(
         ex, &detail::default_spawn_handler),
-      ASIO_MOVE_CAST(Function)(function), attributes);
+      ASIO_MOVE_CAST(Function)(function));
 }
 
 template <typename Function>
 inline void spawn(const asio::io_context::strand& s,
-    ASIO_MOVE_ARG(Function) function,
-    const boost::coroutines::attributes& attributes)
+    ASIO_MOVE_ARG(Function) function)
 {
   asio::spawn(asio::bind_executor(
         s, &detail::default_spawn_handler),
-      ASIO_MOVE_CAST(Function)(function), attributes);
+      ASIO_MOVE_CAST(Function)(function));
 }
 
 template <typename Function, typename ExecutionContext>
 inline void spawn(ExecutionContext& ctx,
     ASIO_MOVE_ARG(Function) function,
-    const boost::coroutines::attributes& attributes,
     typename enable_if<is_convertible<
       ExecutionContext&, execution_context&>::value>::type*)
 {
   asio::spawn(ctx.get_executor(),
-      ASIO_MOVE_CAST(Function)(function), attributes);
+      ASIO_MOVE_CAST(Function)(function));
 }
 
 #endif // !defined(GENERATING_DOCUMENTATION)

--- a/asio/include/asio/spawn.hpp
+++ b/asio/include/asio/spawn.hpp
@@ -16,7 +16,8 @@
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
 #include "asio/detail/config.hpp"
-#include <boost/coroutine/all.hpp>
+#include <boost/version.hpp>
+#include <boost/coroutine2/all.hpp>
 #include "asio/bind_executor.hpp"
 #include "asio/detail/memory.hpp"
 #include "asio/detail/type_traits.hpp"
@@ -61,10 +62,8 @@ public:
    */
 #if defined(GENERATING_DOCUMENTATION)
   typedef implementation_defined callee_type;
-#elif defined(BOOST_COROUTINES_UNIDIRECT) || defined(BOOST_COROUTINES_V2)
-  typedef boost::coroutines::push_coroutine<void> callee_type;
 #else
-  typedef boost::coroutines::coroutine<void()> callee_type;
+  typedef boost::coroutines2::asymmetric_coroutine<void>::push_type callee_type;
 #endif
   
   /// The coroutine caller type, used by the implementation.
@@ -76,10 +75,8 @@ public:
    */
 #if defined(GENERATING_DOCUMENTATION)
   typedef implementation_defined caller_type;
-#elif defined(BOOST_COROUTINES_UNIDIRECT) || defined(BOOST_COROUTINES_V2)
-  typedef boost::coroutines::pull_coroutine<void> caller_type;
 #else
-  typedef boost::coroutines::coroutine<void()>::caller_type caller_type;
+  typedef boost::coroutines2::asymmetric_coroutine<void>::pull_type caller_type;
 #endif
 
   /// Construct a yield context to represent the specified coroutine.
@@ -201,9 +198,7 @@ typedef basic_yield_context<
  * @param attributes Boost.Coroutine attributes used to customise the coroutine.
  */
 template <typename Function>
-void spawn(ASIO_MOVE_ARG(Function) function,
-    const boost::coroutines::attributes& attributes
-      = boost::coroutines::attributes());
+void spawn(ASIO_MOVE_ARG(Function) function);
 
 /// Start a new stackful coroutine, calling the specified handler when it
 /// completes.
@@ -223,8 +218,6 @@ void spawn(ASIO_MOVE_ARG(Function) function,
 template <typename Handler, typename Function>
 void spawn(ASIO_MOVE_ARG(Handler) handler,
     ASIO_MOVE_ARG(Function) function,
-    const boost::coroutines::attributes& attributes
-      = boost::coroutines::attributes(),
     typename enable_if<!is_executor<typename decay<Handler>::type>::value &&
       !is_convertible<Handler&, execution_context&>::value>::type* = 0);
 
@@ -245,9 +238,7 @@ void spawn(ASIO_MOVE_ARG(Handler) handler,
  */
 template <typename Handler, typename Function>
 void spawn(basic_yield_context<Handler> ctx,
-    ASIO_MOVE_ARG(Function) function,
-    const boost::coroutines::attributes& attributes
-      = boost::coroutines::attributes());
+    ASIO_MOVE_ARG(Function) function);
 
 /// Start a new stackful coroutine that executes on a given executor.
 /**
@@ -264,8 +255,6 @@ void spawn(basic_yield_context<Handler> ctx,
 template <typename Function, typename Executor>
 void spawn(const Executor& ex,
     ASIO_MOVE_ARG(Function) function,
-    const boost::coroutines::attributes& attributes
-      = boost::coroutines::attributes(),
     typename enable_if<is_executor<Executor>::value>::type* = 0);
 
 /// Start a new stackful coroutine that executes on a given strand.
@@ -281,9 +270,7 @@ void spawn(const Executor& ex,
  */
 template <typename Function, typename Executor>
 void spawn(const strand<Executor>& ex,
-    ASIO_MOVE_ARG(Function) function,
-    const boost::coroutines::attributes& attributes
-      = boost::coroutines::attributes());
+    ASIO_MOVE_ARG(Function) function);
 
 /// Start a new stackful coroutine that executes in the context of a strand.
 /**
@@ -300,9 +287,7 @@ void spawn(const strand<Executor>& ex,
  */
 template <typename Function>
 void spawn(const asio::io_context::strand& s,
-    ASIO_MOVE_ARG(Function) function,
-    const boost::coroutines::attributes& attributes
-      = boost::coroutines::attributes());
+    ASIO_MOVE_ARG(Function) function);
 
 /// Start a new stackful coroutine that executes on a given execution context.
 /**
@@ -320,8 +305,6 @@ void spawn(const asio::io_context::strand& s,
 template <typename Function, typename ExecutionContext>
 void spawn(ExecutionContext& ctx,
     ASIO_MOVE_ARG(Function) function,
-    const boost::coroutines::attributes& attributes
-      = boost::coroutines::attributes(),
     typename enable_if<is_convertible<
       ExecutionContext&, execution_context&>::value>::type* = 0);
 


### PR DESCRIPTION
Fixes #170.

If retaining support for C++98 in spawn is important, I can pull request this other branch instead:
https://github.com/vdav/asio/commit/fe9d99a6ef71ebff99a000219a5aabb4f2fc0321

But I think it is better to just to using a library that has been deprecated for a while.