### PR TITLE
Fix Helgrind warning on using pthread_cond_signal while unlocked

### DIFF
--- a/asio/include/asio/detail/posix_event.hpp
+++ b/asio/include/asio/detail/posix_event.hpp
@@ -65,9 +65,9 @@ public:
     ASIO_ASSERT(lock.locked());
     state_ |= 1;
     bool have_waiters = (state_ > 1);
-    lock.unlock();
     if (have_waiters)
       ::pthread_cond_signal(&cond_); // Ignore EINVAL.
+    lock.unlock();
   }
 
   // If there's a waiter, unlock the mutex and signal it.
@@ -78,8 +78,8 @@ public:
     state_ |= 1;
     if (state_ > 1)
     {
-      lock.unlock();
       ::pthread_cond_signal(&cond_); // Ignore EINVAL.
+      lock.unlock();
       return true;
     }
     return false;


### PR DESCRIPTION
Helgrind would report a dubious use of pthread_cond_signal before this
patch. The original code was already correct, though, but this one seems
to be preferred.