### PR TITLE
resolver_query resulting in one 2 many derefs of outstanding_work_

### DIFF
--- a/asio/include/asio/detail/resolve_query_op.hpp
+++ b/asio/include/asio/detail/resolve_query_op.hpp
@@ -67,7 +67,6 @@ public:
     // Take ownership of the operation object.
     resolve_query_op* o(static_cast<resolve_query_op*>(base));
     ptr p = { asio::detail::addressof(o->handler_), o, o };
-    handler_work<Handler> w(o->handler_);
 
     if (owner && owner != &o->io_context_impl_)
     {
@@ -85,7 +84,8 @@ public:
     }
     else
     {
-      // The operation has been returned to the main io_context. The completion
+	  handler_work<Handler> w(o->handler_);
+	  // The operation has been returned to the main io_context. The completion
       // handler is ready to be delivered.
 
       ASIO_HANDLER_COMPLETION((*o));
@@ -106,13 +106,15 @@ public:
       }
       p.reset();
 
-      if (owner)
-      {
-        fenced_block b(fenced_block::half);
-        ASIO_HANDLER_INVOCATION_BEGIN((handler.arg1_, "..."));
-        w.complete(handler, handler.handler_);
-        ASIO_HANDLER_INVOCATION_END;
-      }
+	  if (owner)
+	  {
+		  fenced_block b(fenced_block::half);
+		  ASIO_HANDLER_INVOCATION_BEGIN((handler.arg1_, "..."));
+		  w.complete(handler, handler.handler_);
+		  ASIO_HANDLER_INVOCATION_END;
+	  }
+	  else
+		  OutputDebugString(L"resolver is not the owner");
     }
   }
 


### PR DESCRIPTION
This fixed my problem in issue #215 
It derrefs just the right amount with this patch. tried a loop of 50 resolves and io_context.run() finishes when I reset my work guard at the end. Sorry about the spacing getting messed up. That wasn't visible in visual studio. This actually only moving one line. 