### PR TITLE
This pull request allows people to select boost::future over std::future

### DIFF
--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -22,6 +22,7 @@
 # define ASIO_DISABLE_BOOST_STATIC_CONSTANT 1
 # define ASIO_DISABLE_BOOST_THROW_EXCEPTION 1
 # define ASIO_DISABLE_BOOST_WORKAROUND 1
+# define ASIO_DISABLE_BOOST_FUTURE 1
 #else // defined(ASIO_STANDALONE)
 # include <boost/config.hpp>
 # include <boost/version.hpp>
@@ -731,6 +732,10 @@
 #  endif // defined(ASIO_MSVC)
 # endif // !defined(ASIO_DISABLE_STD_FUTURE)
 #endif // !defined(ASIO_HAS_STD_FUTURE)
+
+#if !defined(ASIO_HAS_STD_FUTURE) && defined(ASIO_DISABLE_BOOST_FUTURE)
+#   define ASIO_DISABLE_FUTURE
+#endif
 
 // Standard library support for experimental::string_view.
 #if !defined(ASIO_HAS_STD_STRING_VIEW)

--- a/asio/include/asio/detail/future.hpp
+++ b/asio/include/asio/detail/future.hpp
@@ -1,0 +1,46 @@
+//
+// detail/array.hpp
+// ~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2003-2016 Christopher M. Kohlhoff (chris at kohlhoff dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef ASIO_DETAIL_FUTURE_HPP
+#define ASIO_DETAIL_FUTURE_HPP
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#include "asio/detail/config.hpp"
+
+#if defined(ASIO_HAS_STD_FUTURE)
+# include <future>
+#else // defined(ASIO_HAS_STD_FUTURE)
+# define ASIO_USING_BOOST_FUTURE
+# include <boost/thread/future.hpp>
+#endif // defined(ASIO_HAS_STD_FUTURE)
+
+namespace asio {
+namespace detail {
+
+#if defined(ASIO_HAS_STD_FUTURE)
+using std::future;
+using std::packaged_task;
+using std::promise;
+#else // defined(ASIO_HAS_STD_FUTURE)
+#if BOOST_THREAD_VERSION < 3
+#	error BOOST_THREAD_VERSION must be defined to at least 3
+#endif
+using boost::future;
+using boost::packaged_task;
+using boost::promise;
+#endif // defined(ASIO_HAS_STD_FUTURE)
+
+} // namespace detail
+} // namespace asio
+
+#endif // ASIO_DETAIL_FUTURE_HPP

--- a/asio/include/asio/detail/winrt_async_manager.hpp
+++ b/asio/include/asio/detail/winrt_async_manager.hpp
@@ -19,7 +19,7 @@
 
 #if defined(ASIO_WINDOWS_RUNTIME)
 
-#include <future>
+#include "asio/detail/future.hpp"
 #include "asio/detail/atomic_count.hpp"
 #include "asio/detail/winrt_async_op.hpp"
 #include "asio/error.hpp"
@@ -53,7 +53,7 @@ public:
     if (--outstanding_ops_ > 0)
     {
       // Block until last operation is complete.
-      std::future<void> f = promise_.get_future();
+      future<void> f = promise_.get_future();
       f.wait();
     }
   }
@@ -64,7 +64,7 @@ public:
     using namespace Windows::Foundation;
     using Windows::Foundation::AsyncStatus;
 
-    auto promise = std::make_shared<std::promise<asio::error_code>>();
+    auto promise = std::make_shared<promise<asio::error_code>>();
     auto future = promise->get_future();
 
     action->Completed = ref new AsyncActionCompletedHandler(
@@ -96,7 +96,7 @@ public:
     using namespace Windows::Foundation;
     using Windows::Foundation::AsyncStatus;
 
-    auto promise = std::make_shared<std::promise<asio::error_code>>();
+    auto promise = std::make_shared<promise<asio::error_code>>();
     auto future = promise->get_future();
 
     operation->Completed = ref new AsyncOperationCompletedHandler<TResult>(
@@ -131,7 +131,7 @@ public:
     using namespace Windows::Foundation;
     using Windows::Foundation::AsyncStatus;
 
-    auto promise = std::make_shared<std::promise<asio::error_code>>();
+    auto promise = std::make_shared<promise<asio::error_code>>();
     auto future = promise->get_future();
 
     operation->Completed
@@ -281,7 +281,7 @@ private:
   atomic_count outstanding_ops_;
 
   // Used to keep wait for outstanding operations to complete.
-  std::promise<void> promise_;
+  promise<void> promise_;
 };
 
 } // namespace detail

--- a/asio/include/asio/detail/winrt_utils.hpp
+++ b/asio/include/asio/detail/winrt_utils.hpp
@@ -21,7 +21,7 @@
 
 #include <codecvt>
 #include <cstdlib>
-#include <future>
+#include "asio/detail/future.hpp"
 #include <locale>
 #include <robuffer.h>
 #include <windows.storage.streams.h>

--- a/asio/include/asio/impl/use_future.hpp
+++ b/asio/include/asio/impl/use_future.hpp
@@ -16,7 +16,7 @@
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
 #include "asio/detail/config.hpp"
-#include <future>
+#include "asio/detail/future.hpp"
 #include <tuple>
 #include "asio/async_result.hpp"
 #include "asio/detail/memory.hpp"
@@ -33,7 +33,7 @@ namespace detail {
 #if defined(ASIO_HAS_VARIADIC_TEMPLATES)
 
 template <typename T, typename F, typename... Args>
-inline void promise_invoke_and_set(std::promise<T>& p,
+inline void promise_invoke_and_set(promise<T>& p,
     F& f, ASIO_MOVE_ARG(Args)... args)
 {
 #if !defined(ASIO_NO_EXCEPTIONS)
@@ -51,7 +51,7 @@ inline void promise_invoke_and_set(std::promise<T>& p,
 }
 
 template <typename F, typename... Args>
-inline void promise_invoke_and_set(std::promise<void>& p,
+inline void promise_invoke_and_set(promise<void>& p,
     F& f, ASIO_MOVE_ARG(Args)... args)
 {
 #if !defined(ASIO_NO_EXCEPTIONS)
@@ -72,7 +72,7 @@ inline void promise_invoke_and_set(std::promise<void>& p,
 #else // defined(ASIO_HAS_VARIADIC_TEMPLATES)
 
 template <typename T, typename F>
-inline void promise_invoke_and_set(std::promise<T>& p, F& f)
+inline void promise_invoke_and_set(promise<T>& p, F& f)
 {
 #if !defined(ASIO_NO_EXCEPTIONS)
   try
@@ -89,7 +89,7 @@ inline void promise_invoke_and_set(std::promise<T>& p, F& f)
 }
 
 template <typename F, typename Args>
-inline void promise_invoke_and_set(std::promise<void>& p, F& f)
+inline void promise_invoke_and_set(promise<void>& p, F& f)
 {
 #if !defined(ASIO_NO_EXCEPTIONS)
   try
@@ -110,14 +110,14 @@ inline void promise_invoke_and_set(std::promise<void>& p, F& f)
 
 #define ASIO_PRIVATE_PROMISE_INVOKE_DEF(n) \
   template <typename T, typename F, ASIO_VARIADIC_TPARAMS(n)> \
-  inline void promise_invoke_and_set(std::promise<T>& p, \
+  inline void promise_invoke_and_set(promise<T>& p, \
       F& f, ASIO_VARIADIC_MOVE_PARAMS(n)) \
   { \
     p.set_value(f(ASIO_VARIADIC_MOVE_ARGS(n))); \
   } \
   \
   template <typename F, ASIO_VARIADIC_TPARAMS(n)> \
-  inline void promise_invoke_and_set(std::promise<void>& p, \
+  inline void promise_invoke_and_set(promise<void>& p, \
       F& f, ASIO_VARIADIC_MOVE_PARAMS(n)) \
   { \
     f(ASIO_VARIADIC_MOVE_ARGS(n)); \
@@ -131,7 +131,7 @@ inline void promise_invoke_and_set(std::promise<void>& p, F& f)
 
 #define ASIO_PRIVATE_PROMISE_INVOKE_DEF(n) \
   template <typename T, typename F, ASIO_VARIADIC_TPARAMS(n)> \
-  inline void promise_invoke_and_set(std::promise<T>& p, \
+  inline void promise_invoke_and_set(promise<T>& p, \
       F& f, ASIO_VARIADIC_MOVE_PARAMS(n)) \
   { \
     try \
@@ -145,7 +145,7 @@ inline void promise_invoke_and_set(std::promise<void>& p, F& f)
   } \
   \
   template <typename F, ASIO_VARIADIC_TPARAMS(n)> \
-  inline void promise_invoke_and_set(std::promise<void>& p, \
+  inline void promise_invoke_and_set(promise<void>& p, \
       F& f, ASIO_VARIADIC_MOVE_PARAMS(n)) \
   { \
     try \
@@ -172,7 +172,7 @@ template <typename T, typename F>
 class promise_invoker
 {
 public:
-  promise_invoker(const shared_ptr<std::promise<T> >& p,
+  promise_invoker(const shared_ptr<promise<T> >& p,
       ASIO_MOVE_ARG(F) f)
     : p_(p), f_(f)
   {
@@ -195,7 +195,7 @@ public:
   }
 
 private:
-  shared_ptr<std::promise<T> > p_;
+  shared_ptr<promise<T> > p_;
   typename decay<F>::type f_;
 };
 
@@ -205,7 +205,7 @@ template <typename T>
 class promise_executor
 {
 public:
-  explicit promise_executor(const shared_ptr<std::promise<T> >& p)
+  explicit promise_executor(const shared_ptr<promise<T> >& p)
     : p_(p)
   {
   }
@@ -251,7 +251,7 @@ public:
   }
 
 private:
-  shared_ptr<std::promise<T> > p_;
+  shared_ptr<promise<T> > p_;
 };
 
 // The base class for all completion handlers that create promises.
@@ -266,7 +266,7 @@ public:
     return executor_type(p_);
   }
 
-  typedef std::future<T> future_type;
+  typedef future<T> future_type;
 
   future_type get_future()
   {
@@ -278,10 +278,10 @@ protected:
   void create_promise(const Allocator& a)
   {
     ASIO_REBIND_ALLOC(Allocator, char) b(a);
-    p_ = std::allocate_shared<std::promise<T>>(b, std::allocator_arg, b);
+    p_ = std::allocate_shared<promise<T>>(b, std::allocator_arg, b);
   }
 
-  shared_ptr<std::promise<T> > p_;
+  shared_ptr<promise<T> > p_;
 };
 
 // For completion signature void().

--- a/asio/include/asio/packaged_task.hpp
+++ b/asio/include/asio/packaged_task.hpp
@@ -17,10 +17,10 @@
 
 #include "asio/detail/config.hpp"
 
-#if defined(ASIO_HAS_STD_FUTURE) \
-  || defined(GENERATING_DOCUMENTATION)
+#if !defined(ASIO_DISABLE_FUTURE) || defined(GENERATING_DOCUMENTATION)
 
-#include <future>
+#include "asio/detail/future.hpp"
+
 #include "asio/async_result.hpp"
 #include "asio/detail/type_traits.hpp"
 #include "asio/detail/variadic_templates.hpp"
@@ -32,17 +32,17 @@ namespace asio {
 #if defined(ASIO_HAS_VARIADIC_TEMPLATES) \
   || defined(GENERATING_DOCUMENTATION)
 
-/// Partial specialisation of @c async_result for @c std::packaged_task.
+/// Partial specialisation of @c async_result for @c packaged_task.
 template <typename Result, typename... Args, typename Signature>
-class async_result<std::packaged_task<Result(Args...)>, Signature>
+class async_result<detail::packaged_task<Result(Args...)>, Signature>
 {
 public:
   /// The packaged task is the concrete completion handler type.
-  typedef std::packaged_task<Result(Args...)> completion_handler_type;
+  typedef detail::packaged_task<Result(Args...)> completion_handler_type;
 
   /// The return type of the initiating function is the future obtained from
   /// the packaged task.
-  typedef std::future<Result> return_type;
+  typedef detail::future<Result> return_type;
 
   /// The constructor extracts the future from the packaged task.
   explicit async_result(completion_handler_type& h)
@@ -64,10 +64,10 @@ private:
       //   || defined(GENERATING_DOCUMENTATION)
 
 template <typename Result, typename Signature>
-struct async_result<std::packaged_task<Result()>, Signature>
+struct async_result<detail::packaged_task<Result()>, Signature>
 {
-  typedef std::packaged_task<Result()> completion_handler_type;
-  typedef std::future<Result> return_type;
+  typedef detail::packaged_task<Result()> completion_handler_type;
+  typedef detail::future<Result> return_type;
 
   explicit async_result(completion_handler_type& h)
     : future_(h.get_future())
@@ -87,14 +87,14 @@ private:
   template <typename Result, \
     ASIO_VARIADIC_TPARAMS(n), typename Signature> \
   class async_result< \
-    std::packaged_task<Result(ASIO_VARIADIC_TARGS(n))>, Signature> \
+    detail::packaged_task<Result(ASIO_VARIADIC_TARGS(n))>, Signature> \
   { \
   public: \
-    typedef std::packaged_task< \
+    typedef packaged_task< \
       Result(ASIO_VARIADIC_TARGS(n))> \
         completion_handler_type; \
   \
-    typedef std::future<Result> return_type; \
+    typedef detail::future<Result> return_type; \
   \
     explicit async_result(completion_handler_type& h) \
       : future_(h.get_future()) \
@@ -120,7 +120,6 @@ private:
 
 #include "asio/detail/pop_options.hpp"
 
-#endif // defined(ASIO_HAS_STD_FUTURE)
-       //   || defined(GENERATING_DOCUMENTATION)
+#endif // !defined(ASIO_DISABLE_FUTURE) || defined(GENERATING_DOCUMENTATION)
 
 #endif // ASIO_PACKAGED_TASK_HPP

--- a/asio/include/asio/packaged_task.hpp
+++ b/asio/include/asio/packaged_task.hpp
@@ -90,7 +90,7 @@ private:
     detail::packaged_task<Result(ASIO_VARIADIC_TARGS(n))>, Signature> \
   { \
   public: \
-    typedef packaged_task< \
+    typedef detail::packaged_task< \
       Result(ASIO_VARIADIC_TARGS(n))> \
         completion_handler_type; \
   \

--- a/asio/include/asio/use_future.hpp
+++ b/asio/include/asio/use_future.hpp
@@ -17,8 +17,7 @@
 
 #include "asio/detail/config.hpp"
 
-#if defined(ASIO_HAS_STD_FUTURE) \
-  || defined(GENERATING_DOCUMENTATION)
+#if !defined(ASIO_DISABLE_FUTURE) || defined(GENERATING_DOCUMENTATION)
 
 #include <memory>
 #include "asio/detail/type_traits.hpp"
@@ -39,11 +38,11 @@ class packaged_handler;
 /// Class used to specify that an asynchronous operation should return a future.
 /**
  * The use_future_t class is used to indicate that an asynchronous operation
- * should return a std::future object. A use_future_t object may be passed as a
+ * should return a future object. A use_future_t object may be passed as a
  * handler to an asynchronous operation, typically using the special value @c
  * asio::use_future. For example:
  *
- * @code std::future<std::size_t> my_future
+ * @code future<std::size_t> my_future
  *   = my_socket.async_read_some(my_buffer, asio::use_future); @endcode
  *
  * The initiating function (async_read_some in the above example) returns a
@@ -56,7 +55,7 @@ class use_future_t
 {
 public:
   /// The allocator type. The allocator is used when constructing the
-  /// @c std::promise object for a given asynchronous operation.
+  /// @c promise object for a given asynchronous operation.
   typedef Allocator allocator_type;
 
   /// Construct using default-constructed allocator.
@@ -96,11 +95,11 @@ public:
   /**
    * The @c package function is used to adapt a function object as a packaged
    * task. When this adapter is passed as a completion token to an asynchronous
-   * operation, the result of the function object is retuned via a std::future.
+   * operation, the result of the function object is retuned via a future.
    *
    * @par Example
    *
-   * @code std::future<std::size_t> fut =
+   * @code future<std::size_t> fut =
    *   my_socket.async_read_some(buffer,
    *     use_future([](asio::error_code ec, std::size_t n)
    *       {
@@ -137,7 +136,6 @@ __declspec(selectany) use_future_t<> use_future;
 
 #include "asio/impl/use_future.hpp"
 
-#endif // defined(ASIO_HAS_STD_FUTURE)
-       //   || defined(GENERATING_DOCUMENTATION)
+#endif //!(ASIO_DISABLE_FUTURE) || defined(GENERATING_DOCUMENTATION)
 
 #endif // ASIO_USE_FUTURE_HPP


### PR DESCRIPTION
I needed continuation with std::future doesn't have.
simple
#define ASIO_DISABLE_STD_FUTURE 
and it ill fail over to boost::future unless ASIO_DISABLE_BOOST_FUTURE is also defined.