### PR TITLE
Adds iostream to UDP as well for easier use with UDP type connections.

### DIFF
--- a/asio/include/asio/ip/udp.hpp
+++ b/asio/include/asio/ip/udp.hpp
@@ -81,6 +81,11 @@ public:
   /// The UDP resolver type.
   typedef basic_resolver<udp> resolver;
 
+#if !defined(ASIO_NO_IOSTREAM)
+  /// The UDP iostream type.
+  typedef basic_socket_iostream<udp> iostream;
+#endif // !defined(ASIO_NO_IOSTREAM)
+  
   /// Compare two protocols for equality.
   friend bool operator==(const udp& p1, const udp& p2)
   {


### PR DESCRIPTION
Many softwares or even games cannot handle TCP connections as they might lag or crash too much as speed is critical for them. For that it is recommended to use UDP for them. Softwares that need such type of connections in clude games and other things up to and including antihack libraries for online games to be fast. (Fixes https://github.com/chriskohlhoff/asio/issues/223)

This might need adopting into the Technical Specification as well. Many Game developers might use this for their games.