### PR TITLE
Use proper SSL_version() function so that asio can build with BoringSSL.

### DIFF
--- a/asio/include/asio/ssl/detail/impl/engine.ipp
+++ b/asio/include/asio/ssl/detail/impl/engine.ipp
@@ -204,7 +204,7 @@ const asio::error_code& engine::map_error_code(
   // SSL v2 doesn't provide a protocol-level shutdown, so an eof on the
   // underlying transport is passed through.
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L)
-  if (ssl_->version == SSL2_VERSION)
+  if (SSL_version(ssl_) == SSL2_VERSION)
     return ec;
 #endif // (OPENSSL_VERSION_NUMBER < 0x10100000L)
 


### PR DESCRIPTION
Very minor change. This is the only thing needed for asio to work with BoringSSL.