### PR TITLE
Fix poll.h compile warning under Emscripten

### DIFF
--- a/asio/include/asio/detail/socket_types.hpp
+++ b/asio/include/asio/detail/socket_types.hpp
@@ -59,7 +59,8 @@
 # include <sys/ioctl.h>
 # if (defined(__MACH__) && defined(__APPLE__)) \
    || defined(__FreeBSD__) || defined(__NetBSD__) \
-   || defined(__OpenBSD__) || defined(__linux__)
+   || defined(__OpenBSD__) || defined(__linux__) \
+   || defined(__EMSCRIPTEN__)
 #  include <poll.h>
 # elif !defined(__SYMBIAN32__)
 #  include <sys/poll.h>


### PR DESCRIPTION
The conservative fix in https://github.com/chriskohlhoff/asio/commit/5adce6e26769228f2c9fcc0b9dda8bf00279821f does not fix compilation under the Emscripten environment. See https://github.com/kripken/emscripten/issues/5447 and https://github.com/mamedev/mame/issues/2552.