### PR TITLE
Fix the rights for event objects on UWP.

### DIFF
--- a/asio/include/asio/detail/impl/win_event.ipp
+++ b/asio/include/asio/detail/impl/win_event.ipp
@@ -32,7 +32,7 @@ win_event::win_event()
   : state_(0)
 {
 #if defined(ASIO_WINDOWS_APP)
-  events_[0] = ::CreateEventExW(0, 0, CREATE_EVENT_MANUAL_RESET, 0);
+  events_[0] = ::CreateEventExW(0, 0, CREATE_EVENT_MANUAL_RESET, EVENT_ALL_ACCESS);
 #else // defined(ASIO_WINDOWS_APP)
   events_[0] = ::CreateEventW(0, true, false, 0);
 #endif // defined(ASIO_WINDOWS_APP)
@@ -45,7 +45,7 @@ win_event::win_event()
   }
 
 #if defined(ASIO_WINDOWS_APP)
-  events_[1] = ::CreateEventExW(0, 0, 0, 0);
+  events_[1] = ::CreateEventExW(0, 0, 0, EVENT_ALL_ACCESS);
 #else // defined(ASIO_WINDOWS_APP)
   events_[1] = ::CreateEventW(0, false, false, 0);
 #endif // defined(ASIO_WINDOWS_APP)


### PR DESCRIPTION
On Windows 10 UWP, I'm getting access denied when tryin to `WaitForMultipleObjects` on these events. Requesting the explicit rights fixes the problem.