### PR TITLE
Fix includes in some cpp11 and cpp14 examples

### DIFF
--- a/asio/src/examples/cpp11/buffers/reference_counted.cpp
+++ b/asio/src/examples/cpp11/buffers/reference_counted.cpp
@@ -13,6 +13,7 @@
 #include <memory>
 #include <utility>
 #include <vector>
+#include <ctime>
 
 using asio::ip::tcp;
 

--- a/asio/src/examples/cpp11/executors/fork_join.cpp
+++ b/asio/src/examples/cpp11/executors/fork_join.cpp
@@ -6,6 +6,7 @@
 #include <mutex>
 #include <queue>
 #include <thread>
+#include <numeric>
 
 using asio::dispatch;
 using asio::execution_context;

--- a/asio/src/examples/cpp11/executors/pipeline.cpp
+++ b/asio/src/examples/cpp11/executors/pipeline.cpp
@@ -11,6 +11,7 @@
 #include <queue>
 #include <thread>
 #include <vector>
+#include <cctype>
 
 using asio::execution_context;
 using asio::executor_binder;

--- a/asio/src/examples/cpp14/executors/fork_join.cpp
+++ b/asio/src/examples/cpp14/executors/fork_join.cpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <queue>
 #include <thread>
+#include <numeric>
 
 using asio::dispatch;
 using asio::execution_context;

--- a/asio/src/examples/cpp14/executors/pipeline.cpp
+++ b/asio/src/examples/cpp14/executors/pipeline.cpp
@@ -6,6 +6,7 @@
 #include <queue>
 #include <thread>
 #include <vector>
+#include <cctype>
 
 using asio::execution_context;
 using asio::executor_binder;


### PR DESCRIPTION
This small changes fix building of the some standalone examples with MSVC.

Includes:
* ctime - for std::time_t and std::ctime();
* numeric - for std::iota();
* cctype - for std::toupper().

I tested this with MSVC2017.