### PR TITLE
Avoid `make_network_v{4,6}(..., error_code)` exception throwing

### DIFF
--- a/asio/include/asio/ip/impl/network_v4.ipp
+++ b/asio/include/asio/ip/impl/network_v4.ipp
@@ -182,7 +182,12 @@ network_v4 make_network_v4(const std::string& str,
   if (ec)
     return network_v4();
 
-  return network_v4(addr, std::atoi(str.substr(pos + 1).c_str()));
+  try {
+    return network_v4(addr, std::atoi(str.substr(pos + 1).c_str()));
+  } catch (const std::out_of_range&) {
+    ec = asio::error::invalid_argument;
+    return network_v4();
+  }
 }
 
 #if defined(ASIO_HAS_STD_STRING_VIEW)

--- a/asio/include/asio/ip/impl/network_v6.ipp
+++ b/asio/include/asio/ip/impl/network_v6.ipp
@@ -151,7 +151,12 @@ network_v6 make_network_v6(const std::string& str,
   if (ec)
     return network_v6();
 
-  return network_v6(addr, std::atoi(str.substr(pos + 1).c_str()));
+  try {
+    return network_v6(addr, std::atoi(str.substr(pos + 1).c_str()));
+  } catch (const std::out_of_range&) {
+    ec = asio::error::invalid_argument;
+    return network_v6();
+  }
 }
 
 #if defined(ASIO_HAS_STD_STRING_VIEW)

--- a/asio/src/tests/unit/ip/network_v4.cpp
+++ b/asio/src/tests/unit/ip/network_v4.cpp
@@ -17,6 +17,7 @@
 // Test that header file is self-contained.
 #include "asio/ip/network_v4.hpp"
 
+#include "asio/error.hpp"
 #include "../unit_test.hpp"
 #include <sstream>
 

--- a/asio/src/tests/unit/ip/network_v4.cpp
+++ b/asio/src/tests/unit/ip/network_v4.cpp
@@ -221,6 +221,8 @@ void test()
   ASIO_CHECK(ec == asio::error::invalid_argument);
   make_network_v4("10.0.0.0", ec);
   ASIO_CHECK(ec == asio::error::invalid_argument);
+  make_network_v4("10.0.0.0/24", ec);
+  ASIO_CHECK(!ec);
 
   // construct address range from address and prefix length
   ASIO_CHECK(network_v4(make_address_v4("192.168.77.100"), 32).network() == make_address_v4("192.168.77.100"));

--- a/asio/src/tests/unit/ip/network_v4.cpp
+++ b/asio/src/tests/unit/ip/network_v4.cpp
@@ -210,6 +210,18 @@ void test()
   }
   ASIO_CHECK(msg == std::string("prefix length too large"));
 
+  asio::error_code ec;
+  make_network_v4("10.0.0.256/24", ec);
+  ASIO_CHECK(ec == asio::error::invalid_argument);
+  make_network_v4("10.0.0.0/33", ec);
+  ASIO_CHECK(ec == asio::error::invalid_argument);
+  make_network_v4("10.0.0.0/-1", ec);
+  ASIO_CHECK(ec == asio::error::invalid_argument);
+  make_network_v4("10.0.0.0/", ec);
+  ASIO_CHECK(ec == asio::error::invalid_argument);
+  make_network_v4("10.0.0.0", ec);
+  ASIO_CHECK(ec == asio::error::invalid_argument);
+
   // construct address range from address and prefix length
   ASIO_CHECK(network_v4(make_address_v4("192.168.77.100"), 32).network() == make_address_v4("192.168.77.100"));
   ASIO_CHECK(network_v4(make_address_v4("192.168.77.100"), 24).network() == make_address_v4("192.168.77.0"));

--- a/asio/src/tests/unit/ip/network_v6.cpp
+++ b/asio/src/tests/unit/ip/network_v6.cpp
@@ -143,6 +143,18 @@ void test()
   }
   ASIO_CHECK(msg == std::string("prefix length too large"));
 
+  asio::error_code ec;
+  make_network_v6("a:b/24", ec);
+  ASIO_CHECK(ec == asio::error::invalid_argument);
+  make_network_v6("a::b/129", ec);
+  ASIO_CHECK(ec == asio::error::invalid_argument);
+  make_network_v6("a::b/-1", ec);
+  ASIO_CHECK(ec == asio::error::invalid_argument);
+  make_network_v6("a::b/", ec);
+  ASIO_CHECK(ec == asio::error::invalid_argument);
+  make_network_v6("a::b", ec);
+  ASIO_CHECK(ec == asio::error::invalid_argument);
+
   // construct address range from address and prefix length
   ASIO_CHECK(network_v6(make_address_v6("2001:370::10:7344"), 128).network() == make_address_v6("2001:370::10:7344"));
   ASIO_CHECK(network_v6(make_address_v6("2001:370::10:7344"), 64).network() == make_address_v6("2001:370::"));

--- a/asio/src/tests/unit/ip/network_v6.cpp
+++ b/asio/src/tests/unit/ip/network_v6.cpp
@@ -17,6 +17,7 @@
 // Test that header file is self-contained.
 #include "asio/ip/network_v6.hpp"
 
+#include "asio/error.hpp"
 #include "../unit_test.hpp"
 #include <sstream>
 

--- a/asio/src/tests/unit/ip/network_v6.cpp
+++ b/asio/src/tests/unit/ip/network_v6.cpp
@@ -154,6 +154,8 @@ void test()
   ASIO_CHECK(ec == asio::error::invalid_argument);
   make_network_v6("a::b", ec);
   ASIO_CHECK(ec == asio::error::invalid_argument);
+  make_network_v6("a::b/24", ec);
+  ASIO_CHECK(!ec);
 
   // construct address range from address and prefix length
   ASIO_CHECK(network_v6(make_address_v6("2001:370::10:7344"), 128).network() == make_address_v6("2001:370::10:7344"));


### PR DESCRIPTION
This fix is continuation of ddef4994f42f2eb3aa1e4b8f376d3e42facfaa4b.