### PR TITLE
Don't do free() if Object has already been freed

### DIFF
--- a/asio/include/asio/detail/object_pool.hpp
+++ b/asio/include/asio/detail/object_pool.hpp
@@ -124,6 +124,8 @@ public:
   // Free an object. Moves it to the free list. No destructors are run.
   void free(Object* o)
   {
+    if (o == free_list_)
+      return;
     if (live_list_ == o)
       live_list_ = object_pool_access::next(o);
 


### PR DESCRIPTION
Somewhere within ASIO, a double-free is occurring. Since I unfortunately can't pin it down further, this check ensures we don't free the object twice.

See Issue #268 for further details.