### PR TITLE
add const to basic_socket_acceptor::get_option()

### DIFF
--- a/asio/include/asio/basic_socket_acceptor.hpp
+++ b/asio/include/asio/basic_socket_acceptor.hpp
@@ -742,7 +742,7 @@ public:
    * @endcode
    */
   template <typename GettableSocketOption>
-  void get_option(GettableSocketOption& option)
+  void get_option(GettableSocketOption& option) const
   {
     asio::error_code ec;
     this->get_service().get_option(this->get_implementation(), option, ec);
@@ -778,7 +778,7 @@ public:
    */
   template <typename GettableSocketOption>
   ASIO_SYNC_OP_VOID get_option(GettableSocketOption& option,
-      asio::error_code& ec)
+      asio::error_code& ec) const
   {
     this->get_service().get_option(this->get_implementation(), option, ec);
     ASIO_SYNC_OP_VOID_RETURN(ec);


### PR DESCRIPTION
...since it appears to be const-safe and would fix an issue I encountered during use