### PR TITLE
#287: Fixed compilation on Android NDK15

### DIFF
--- a/asio/include/asio/detail/posix_event.hpp
+++ b/asio/include/asio/detail/posix_event.hpp
@@ -117,13 +117,13 @@ public:
       state_ += 2;
       timespec ts;
 #if (defined(__MACH__) && defined(__APPLE__)) \
-      || (defined(__ANDROID__) && (__ANDROID_API__ < 21))
+      || (defined(__ANDROID__) && (__ANDROID_API__ < 21) && defined(HAVE_PTHREAD_COND_TIMEDWAIT_RELATIVE))
       ts.tv_sec = usec / 1000000;
       ts.tv_nsec = (usec % 1000000) * 1000;
       ::pthread_cond_timedwait_relative_np(
           &cond_, &lock.mutex().mutex_, &ts); // Ignore EINVAL.
 #else // (defined(__MACH__) && defined(__APPLE__))
-      // || (defined(__ANDROID__) && (__ANDROID_API__ < 21))
+      // || (defined(__ANDROID__) && (__ANDROID_API__ < 21) && defined(HAVE_PTHREAD_COND_TIMEDWAIT_RELATIVE))
       if (::clock_gettime(CLOCK_MONOTONIC, &ts) == 0)
       {
         ts.tv_sec += usec / 1000000;
@@ -134,7 +134,7 @@ public:
             &lock.mutex().mutex_, &ts); // Ignore EINVAL.
       }
 #endif // (defined(__MACH__) && defined(__APPLE__))
-       // || (defined(__ANDROID__) && (__ANDROID_API__ < 21))
+       // || (defined(__ANDROID__) && (__ANDROID_API__ < 21) && defined(HAVE_PTHREAD_COND_TIMEDWAIT_RELATIVE))
       state_ -= 2;
     }
     return (state_ & 1) != 0;


### PR DESCRIPTION
Fixed `#if` around `pthread_cond_timedwait_relative_np` invocation.