### PR TITLE
Correct prepare_memfn_helper test

### DIFF
--- a/asio/include/asio/detail/is_buffer_sequence.hpp
+++ b/asio/include/asio/detail/is_buffer_sequence.hpp
@@ -112,7 +112,7 @@ template <typename T>
 char prepare_memfn_helper(
     buffer_sequence_memfns_check<
       void (buffer_sequence_memfns_base::*)(),
-      &buffer_sequence_memfns_derived<T>::data>*);
+      &buffer_sequence_memfns_derived<T>::prepare>*);
 
 template <typename>
 char (&commit_memfn_helper(...))[2];


### PR DESCRIPTION
Fix prepare_memfn_helper test to use intended member function
'prepare' rather than 'data' copied by mistake from previous check.