### PR TITLE
config: Fix condition for NOEXCEPT to accept ASIO_STANDALONE

### DIFF
--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -229,7 +229,7 @@
 // Support noexcept on compilers known to allow it.
 #if !defined(ASIO_NOEXCEPT)
 # if !defined(ASIO_DISABLE_NOEXCEPT)
-#  if (BOOST_VERSION >= 105300)
+#  if (!defined(ASIO_STANDALONE) && BOOST_VERSION >= 105300)
 #   define ASIO_NOEXCEPT BOOST_NOEXCEPT
 #   define ASIO_NOEXCEPT_OR_NOTHROW BOOST_NOEXCEPT_OR_NOTHROW
 #  elif defined(__clang__)


### PR DESCRIPTION
The project including this header may be using boost but asio as a
standalone. In this case BOOST_NOEXCEPT_OR_NOTHROW may not be resolved
properly and fail.

This patch checks the boost version only if ASIO_STANDALONE is not set.

Signed-off-by: Markus Pargmann <scosu@quobyte.com>