### PR TITLE
Use std::move in basic_resolver_results::begin() to avoid copying

### DIFF
--- a/asio/include/asio/ip/basic_resolver_results.hpp
+++ b/asio/include/asio/ip/basic_resolver_results.hpp
@@ -252,7 +252,7 @@ public:
   {
     basic_resolver_results tmp(*this);
     tmp.index_ = 0;
-    return tmp;
+    return std::move(tmp);
   }
 
   /// Obtain an end iterator for the results range.


### PR DESCRIPTION
This is reported as `-Wreturn-std-move` warning by recent versions of Clang.