### PR TITLE
Added wolfSSL compatibility with apps and tests

### DIFF
--- a/asio/configure.ac
+++ b/asio/configure.ac
@@ -55,6 +55,28 @@ if test "$STANDALONE" != yes; then
   ],[])
 fi
 
+# Use wolfSSL instead of openSSL, if not defined openSSL is the default.
+# Allows users to run unit tests using wolfSSL.
+AC_ARG_WITH(wolfssl,
+  AC_HELP_STRING([--with-wolfssl=DIR],[location of wolfssl]),
+[
+  CPPFLAGS="$CPPFLAGS -I${withval}/include/wolfssl -lwolfssl -DWOLFSSL_ASIO"
+  LIBS="$LIBS -I${withval}/include/wolfssl -L${withval}/lib"
+  WOLFSSL_USE=no
+],[])
+
+if test x$WOLFSSL_USE == xno; then
+    AC_CHECK_HEADER([wolfssl/options.h],,
+    [
+      WOLFSSL_FOUND=no
+    ],[])
+
+    if test x$WOLFSSL_FOUND != xno; then
+      LIBS="$LIBS -lwolfssl"
+    fi
+    AM_CONDITIONAL(HAVE_OPENSSL,test x$WOLFSSL_FOUND != xno)
+fi
+
 AC_ARG_WITH(openssl,
   AC_HELP_STRING([--with-openssl=DIR],[location of openssl]),
 [
@@ -62,23 +84,25 @@ AC_ARG_WITH(openssl,
   LIBS="$LIBS -L${withval}/lib"
 ],[])
 
-AC_CHECK_HEADER([openssl/ssl.h],,
-[
-  OPENSSL_FOUND=no
-],[])
+# Don't use openSSL if wolfSSL is being used.
+if test x$WOLFSSL_USE != xno; then
+    AC_CHECK_HEADER([openssl/ssl.h],,
+    [
+      OPENSSL_FOUND=no
+    ],[])
 
-if test x$OPENSSL_FOUND != xno; then
-  LIBS="$LIBS -lssl -lcrypto"
+    if test x$OPENSSL_FOUND != xno; then
+      LIBS="$LIBS -lssl -lcrypto"
+    fi
+    AM_CONDITIONAL(HAVE_OPENSSL,test x$OPENSSL_FOUND != xno)
 fi
-
-AM_CONDITIONAL(HAVE_OPENSSL,test x$OPENSSL_FOUND != xno)
 
 WINDOWS=no
 case $host in
   *-*-linux*)
     CXXFLAGS="$CXXFLAGS -pthread"
     LDFLAGS="$LDFLAGS -pthread"
-    LIBS="$LIBS -lrt"
+    LIBS="$LIBS -lboost_system -lboost_timer -lboost_chrono -lrt"
     ;;
   *-*-solaris*)
     if test "$GXX" = yes; then

--- a/asio/configure.ac
+++ b/asio/configure.ac
@@ -102,7 +102,7 @@ case $host in
   *-*-linux*)
     CXXFLAGS="$CXXFLAGS -pthread"
     LDFLAGS="$LDFLAGS -pthread"
-    LIBS="$LIBS -lboost_system -lboost_timer -lboost_chrono -lrt"
+    LIBS="$LIBS -lrt"
     ;;
   *-*-solaris*)
     if test "$GXX" = yes; then

--- a/asio/include/asio/ssl/context_base.hpp
+++ b/asio/include/asio/ssl/context_base.hpp
@@ -15,6 +15,10 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
+#if defined(WOLFSSL_ASIO)
+#include "wolfssl/options.h"
+#endif
+
 #include "asio/detail/config.hpp"
 #include "asio/ssl/detail/openssl_types.hpp"
 

--- a/asio/include/asio/ssl/detail/impl/openssl_init.ipp
+++ b/asio/include/asio/ssl/detail/impl/openssl_init.ipp
@@ -85,7 +85,7 @@ public:
 #endif // (OPENSSL_VERSION_NUMBER >= 0x10002000L)
        // && (OPENSSL_VERSION_NUMBER < 0x10100000L)
        // && !defined(SSL_OP_NO_COMPRESSION)
-#if !defined(OPENSSL_IS_BORINGSSL)
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(WOLFSSL_ASIO)
     ::CONF_modules_unload(1);
 #endif // !defined(OPENSSL_IS_BORINGSSL)
 #if !defined(OPENSSL_NO_ENGINE) \

--- a/asio/include/asio/ssl/error.hpp
+++ b/asio/include/asio/ssl/error.hpp
@@ -15,6 +15,10 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
+#if defined(WOLFSSL_ASIO)
+#include "wolfssl/options.h"
+#endif
+
 #include "asio/detail/config.hpp"
 #include "asio/error_code.hpp"
 #include "asio/ssl/detail/openssl_types.hpp"
@@ -45,7 +49,7 @@ enum stream_errors
 #if defined(GENERATING_DOCUMENTATION)
   /// The underlying stream closed before the ssl stream gracefully shut down.
   stream_truncated
-#elif (OPENSSL_VERSION_NUMBER < 0x10100000L) && !defined(OPENSSL_IS_BORINGSSL)
+#elif (OPENSSL_VERSION_NUMBER < 0x10100000L) && !defined(OPENSSL_IS_BORINGSSL) && !defined(WOLFSSL_ASIO)
   stream_truncated = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_SHORT_READ)
 #else
   stream_truncated = 1

--- a/asio/include/asio/ssl/impl/context.ipp
+++ b/asio/include/asio/ssl/impl/context.ipp
@@ -67,14 +67,14 @@ context::context(context::method m)
   switch (m)
   {
     // SSL v2.
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) || defined(OPENSSL_NO_SSL2)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) || defined(OPENSSL_NO_SSL2) || defined(WOLFSSL_ASIO)
   case context::sslv2:
   case context::sslv2_client:
   case context::sslv2_server:
     asio::detail::throw_error(
         asio::error::invalid_argument, "context");
     break;
-#else // (OPENSSL_VERSION_NUMBER >= 0x10100000L) || defined(OPENSSL_NO_SSL2)
+#else // (OPENSSL_VERSION_NUMBER >= 0x10100000L) || defined(OPENSSL_NO_SSL2) || defined(WOLFSSL_ASIO)
   case context::sslv2:
     handle_ = ::SSL_CTX_new(::SSLv2_method());
     break;
@@ -87,7 +87,7 @@ context::context(context::method m)
 #endif // (OPENSSL_VERSION_NUMBER >= 0x10100000L) || defined(OPENSSL_NO_SSL2)
 
     // SSL v3.
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) && !defined(WOLFSSL_ASIO)
   case context::sslv3:
     handle_ = ::SSL_CTX_new(::TLS_method());
     if (handle_)
@@ -112,14 +112,14 @@ context::context(context::method m)
       SSL_CTX_set_max_proto_version(handle_, SSL3_VERSION);
     }
     break;
-#elif defined(OPENSSL_NO_SSL3)
+#elif defined(OPENSSL_NO_SSL3) || defined(WOLFSSL_ASIO)
   case context::sslv3:
   case context::sslv3_client:
   case context::sslv3_server:
     asio::detail::throw_error(
         asio::error::invalid_argument, "context");
     break;
-#else // defined(OPENSSL_NO_SSL3)
+#else // defined(OPENSSL_NO_SSL3) || defined(WOLFSSL_ASIO)
   case context::sslv3:
     handle_ = ::SSL_CTX_new(::SSLv3_method());
     break;
@@ -129,7 +129,7 @@ context::context(context::method m)
   case context::sslv3_server:
     handle_ = ::SSL_CTX_new(::SSLv3_server_method());
     break;
-#endif // defined(OPENSSL_NO_SSL3)
+#endif // defined(OPENSSL_NO_SSL3) || defined(WOLFSSL_ASIO)
 
     // TLS v1.0.
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
@@ -341,7 +341,7 @@ context::~context()
 {
   if (handle_)
   {
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) || defined(WOLFSSL_ASIO)
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
     void* cb_userdata = handle_->default_passwd_callback_userdata;
@@ -352,7 +352,7 @@ context::~context()
         static_cast<detail::password_callback_base*>(
             cb_userdata);
       delete callback;
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) || defined(WOLFSSL_ASIO)
       ::SSL_CTX_set_default_passwd_cb_userdata(handle_, 0);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
       handle_->default_passwd_callback_userdata = 0;
@@ -689,7 +689,7 @@ ASIO_SYNC_OP_VOID context::use_certificate_chain(
   bio_cleanup bio = { make_buffer_bio(chain) };
   if (bio.p)
   {
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) || defined(WOLFSSL_ASIO)
     pem_password_cb* callback = ::SSL_CTX_get_default_passwd_cb(handle_);
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
@@ -716,7 +716,7 @@ ASIO_SYNC_OP_VOID context::use_certificate_chain(
       ASIO_SYNC_OP_VOID_RETURN(ec);
     }
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10002000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10002000L) && !defined(LIBRESSL_VERSION_NUMBER) || defined(WOLFSSL_ASIO)
     ::SSL_CTX_clear_chain_certs(handle_);
 #else
     if (handle_->extra_certs)
@@ -793,7 +793,7 @@ ASIO_SYNC_OP_VOID context::use_private_key(
 {
   ::ERR_clear_error();
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) || defined(WOLFSSL_ASIO)
     pem_password_cb* callback = ::SSL_CTX_get_default_passwd_cb(handle_);
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
@@ -860,7 +860,7 @@ ASIO_SYNC_OP_VOID context::use_rsa_private_key(
 {
   ::ERR_clear_error();
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) || defined(WOLFSSL_ASIO)
     pem_password_cb* callback = ::SSL_CTX_get_default_passwd_cb(handle_);
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
@@ -1099,7 +1099,7 @@ int context::verify_callback_function(int preverified, X509_STORE_CTX* ctx)
 ASIO_SYNC_OP_VOID context::do_set_password_callback(
     detail::password_callback_base* callback, asio::error_code& ec)
 {
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) || defined(WOLFSSL_ASIO)
   void* old_callback = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
   ::SSL_CTX_set_default_passwd_cb_userdata(handle_, callback);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)

--- a/asio/include/asio/ssl/rfc2818_verification.hpp
+++ b/asio/include/asio/ssl/rfc2818_verification.hpp
@@ -15,6 +15,10 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
+#if defined(WOLFSSL_ASIO)
+#include "wolfssl/options.h"
+#endif
+
 #include "asio/detail/config.hpp"
 
 #include <string>


### PR DESCRIPTION
Added wolfSSL compatibility to replace openSSL if the user desires. Changes to configure.ac were made to allow unit tests to be run with wolfSSL. Currently works with the below pull request to wolfSSL. https://github.com/wolfSSL/wolfssl/pull/1655