### PR TITLE
Added wolfSSL Compatability for Asio instead of OpenSSL

### DIFF
--- a/asio/configure.ac
+++ b/asio/configure.ac
@@ -55,6 +55,28 @@ if test "$STANDALONE" != yes; then
   ],[])
 fi
 
+# Use wolfSSL instead of openSSL, if not defined openSSL is the default.
+# Allows users to run unit tests using wolfSSL.
+AC_ARG_WITH(wolfssl,
+  AC_HELP_STRING([--with-wolfssl=DIR],[location of wolfssl]),
+[
+  CPPFLAGS="$CPPFLAGS -I${withval}/include/wolfssl -lwolfssl -DWOLFSSL_ASIO"
+  LIBS="$LIBS -I${withval}/include/wolfssl -L${withval}/lib"
+  WOLFSSL_USE=no
+],[])
+
+if test x$WOLFSSL_USE == xno; then
+    AC_CHECK_HEADER([wolfssl/options.h],,
+    [
+      WOLFSSL_FOUND=no
+    ],[])
+
+    if test x$WOLFSSL_FOUND != xno; then
+      LIBS="$LIBS -lwolfssl"
+    fi
+    AM_CONDITIONAL(HAVE_OPENSSL,test x$WOLFSSL_FOUND != xno)
+fi
+
 AC_ARG_WITH(openssl,
   AC_HELP_STRING([--with-openssl=DIR],[location of openssl]),
 [
@@ -62,16 +84,18 @@ AC_ARG_WITH(openssl,
   LIBS="$LIBS -L${withval}/lib"
 ],[])
 
-AC_CHECK_HEADER([openssl/ssl.h],,
-[
-  OPENSSL_FOUND=no
-],[])
+# Don't use openSSL if wolfSSL is being used.
+if test x$WOLFSSL_USE != xno; then
+    AC_CHECK_HEADER([openssl/ssl.h],,
+    [
+      OPENSSL_FOUND=no
+    ],[])
 
-if test x$OPENSSL_FOUND != xno; then
-  LIBS="$LIBS -lssl -lcrypto"
+    if test x$OPENSSL_FOUND != xno; then
+      LIBS="$LIBS -lssl -lcrypto"
+    fi
+    AM_CONDITIONAL(HAVE_OPENSSL,test x$OPENSSL_FOUND != xno)
 fi
-
-AM_CONDITIONAL(HAVE_OPENSSL,test x$OPENSSL_FOUND != xno)
 
 WINDOWS=no
 case $host in

--- a/asio/configure.ac
+++ b/asio/configure.ac
@@ -55,13 +55,12 @@ if test "$STANDALONE" != yes; then
   ],[])
 fi
 
-# Use wolfSSL instead of openSSL, if not defined openSSL is the default.
-# Allows users to run unit tests using wolfSSL.
+# Allows use of unit tests with wolfSSL instead of OpenSSL
 AC_ARG_WITH(wolfssl,
   AC_HELP_STRING([--with-wolfssl=DIR],[location of wolfssl]),
 [
-  CPPFLAGS="$CPPFLAGS -I${withval}/include/wolfssl -lwolfssl -DWOLFSSL_ASIO"
-  LIBS="$LIBS -I${withval}/include/wolfssl -L${withval}/lib"
+  CPPFLAGS="$CPPFLAGS -I${withval}/include/wolfssl -DASIO_USE_WOLFSSL"
+  LIBS="$LIBS -L${withval}/lib"
   WOLFSSL_USE=no
 ],[])
 
@@ -84,7 +83,7 @@ AC_ARG_WITH(openssl,
   LIBS="$LIBS -L${withval}/lib"
 ],[])
 
-# Don't use openSSL if wolfSSL is being used.
+# Link OpenSSL libs if wolfSSL is not being used
 if test x$WOLFSSL_USE != xno; then
     AC_CHECK_HEADER([openssl/ssl.h],,
     [

--- a/asio/include/asio/ssl.hpp
+++ b/asio/include/asio/ssl.hpp
@@ -15,6 +15,10 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
+#if defined(ASIO_USE_WOLFSSL)
+#include <wolfssl/options.h>
+#endif
+
 #include "asio/ssl/context.hpp"
 #include "asio/ssl/context_base.hpp"
 #include "asio/ssl/error.hpp"

--- a/asio/include/asio/ssl/context_base.hpp
+++ b/asio/include/asio/ssl/context_base.hpp
@@ -15,7 +15,7 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
-#if defined(WOLFSSL_ASIO)
+#if defined(ASIO_USE_WOLFSSL)
 #include <wolfssl/options.h>
 #endif
 

--- a/asio/include/asio/ssl/context_base.hpp
+++ b/asio/include/asio/ssl/context_base.hpp
@@ -15,6 +15,10 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
+#if defined(WOLFSSL_ASIO)
+#include <wolfssl/options.h>
+#endif
+
 #include "asio/detail/config.hpp"
 #include "asio/ssl/detail/openssl_types.hpp"
 

--- a/asio/include/asio/ssl/detail/impl/openssl_init.ipp
+++ b/asio/include/asio/ssl/detail/impl/openssl_init.ipp
@@ -85,7 +85,7 @@ public:
 #endif // (OPENSSL_VERSION_NUMBER >= 0x10002000L)
        // && (OPENSSL_VERSION_NUMBER < 0x10100000L)
        // && !defined(SSL_OP_NO_COMPRESSION)
-#if !defined(OPENSSL_IS_BORINGSSL) && !defined(WOLFSSL_ASIO)
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(ASIO_USE_WOLFSSL)
     ::CONF_modules_unload(1);
 #endif // !defined(OPENSSL_IS_BORINGSSL)
 #if !defined(OPENSSL_NO_ENGINE) \

--- a/asio/include/asio/ssl/detail/impl/openssl_init.ipp
+++ b/asio/include/asio/ssl/detail/impl/openssl_init.ipp
@@ -85,7 +85,7 @@ public:
 #endif // (OPENSSL_VERSION_NUMBER >= 0x10002000L)
        // && (OPENSSL_VERSION_NUMBER < 0x10100000L)
        // && !defined(SSL_OP_NO_COMPRESSION)
-#if !defined(OPENSSL_IS_BORINGSSL)
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(WOLFSSL_ASIO)
     ::CONF_modules_unload(1);
 #endif // !defined(OPENSSL_IS_BORINGSSL)
 #if !defined(OPENSSL_NO_ENGINE) \

--- a/asio/include/asio/ssl/detail/openssl_init.hpp
+++ b/asio/include/asio/ssl/detail/openssl_init.hpp
@@ -15,7 +15,7 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
-#if defined(WOLFSSL_ASIO)
+#if defined(ASIO_USE_WOLFSSL)
 #include <wolfssl/options.h>
 #endif
 

--- a/asio/include/asio/ssl/detail/openssl_init.hpp
+++ b/asio/include/asio/ssl/detail/openssl_init.hpp
@@ -15,6 +15,10 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
+#if defined(WOLFSSL_ASIO)
+#include <wolfssl/options.h>
+#endif
+
 #include "asio/detail/config.hpp"
 #include <cstring>
 #include "asio/detail/memory.hpp"

--- a/asio/include/asio/ssl/error.hpp
+++ b/asio/include/asio/ssl/error.hpp
@@ -15,7 +15,7 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
-#if defined(WOLFSSL_ASIO)
+#if defined(ASIO_USE_WOLFSSL)
 #include <wolfssl/options.h>
 #endif
 
@@ -50,7 +50,7 @@ enum stream_errors
   /// The underlying stream closed before the ssl stream gracefully shut down.
   stream_truncated
 #elif (OPENSSL_VERSION_NUMBER < 0x10100000L) && !defined(OPENSSL_IS_BORINGSSL) \
-                                                       && !defined(WOLFSSL_ASIO)
+                                                   && !defined(ASIO_USE_WOLFSSL)
   stream_truncated = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_SHORT_READ)
 #else
   stream_truncated = 1

--- a/asio/include/asio/ssl/error.hpp
+++ b/asio/include/asio/ssl/error.hpp
@@ -15,6 +15,10 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
+#if defined(WOLFSSL_ASIO)
+#include <wolfssl/options.h>
+#endif
+
 #include "asio/detail/config.hpp"
 #include "asio/error_code.hpp"
 #include "asio/ssl/detail/openssl_types.hpp"
@@ -45,7 +49,8 @@ enum stream_errors
 #if defined(GENERATING_DOCUMENTATION)
   /// The underlying stream closed before the ssl stream gracefully shut down.
   stream_truncated
-#elif (OPENSSL_VERSION_NUMBER < 0x10100000L) && !defined(OPENSSL_IS_BORINGSSL)
+#elif (OPENSSL_VERSION_NUMBER < 0x10100000L) && !defined(OPENSSL_IS_BORINGSSL) \
+                                                       && !defined(WOLFSSL_ASIO)
   stream_truncated = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_SHORT_READ)
 #else
   stream_truncated = 1

--- a/asio/include/asio/ssl/impl/context.ipp
+++ b/asio/include/asio/ssl/impl/context.ipp
@@ -349,7 +349,7 @@ context::~context()
   if (handle_)
   {
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) \
-                                                        || defined(WOLFSSL_ASIO)
+                                                    || defined(ASIO_USE_WOLFSSL)
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
     void* cb_userdata = handle_->default_passwd_callback_userdata;
@@ -361,7 +361,7 @@ context::~context()
             cb_userdata);
       delete callback;
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) \
-                                                        || defined(WOLFSSL_ASIO)
+                                                    || defined(ASIO_USE_WOLFSSL)
       ::SSL_CTX_set_default_passwd_cb_userdata(handle_, 0);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
       handle_->default_passwd_callback_userdata = 0;
@@ -699,7 +699,7 @@ ASIO_SYNC_OP_VOID context::use_certificate_chain(
   if (bio.p)
   {
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) \
-                                                        || defined(WOLFSSL_ASIO)
+                                                    || defined(ASIO_USE_WOLFSSL)
     pem_password_cb* callback = ::SSL_CTX_get_default_passwd_cb(handle_);
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
@@ -727,7 +727,7 @@ ASIO_SYNC_OP_VOID context::use_certificate_chain(
     }
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10002000L) && !defined(LIBRESSL_VERSION_NUMBER) \
-                                                        || defined(WOLFSSL_ASIO)
+                                                    || defined(ASIO_USE_WOLFSSL)
     ::SSL_CTX_clear_chain_certs(handle_);
 #else
     if (handle_->extra_certs)
@@ -805,7 +805,7 @@ ASIO_SYNC_OP_VOID context::use_private_key(
   ::ERR_clear_error();
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) \
-                                                        || defined(WOLFSSL_ASIO)
+                                                    || defined(ASIO_USE_WOLFSSL)
     pem_password_cb* callback = ::SSL_CTX_get_default_passwd_cb(handle_);
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
@@ -873,7 +873,7 @@ ASIO_SYNC_OP_VOID context::use_rsa_private_key(
   ::ERR_clear_error();
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) \
-                                                        || defined(WOLFSSL_ASIO)
+                                                    || defined(ASIO_USE_WOLFSSL)
     pem_password_cb* callback = ::SSL_CTX_get_default_passwd_cb(handle_);
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
@@ -1113,7 +1113,7 @@ ASIO_SYNC_OP_VOID context::do_set_password_callback(
     detail::password_callback_base* callback, asio::error_code& ec)
 {
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) \
-                                                        || defined(WOLFSSL_ASIO)
+                                                    || defined(ASIO_USE_WOLFSSL)
   void* old_callback = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
   ::SSL_CTX_set_default_passwd_cb_userdata(handle_, callback);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)

--- a/asio/include/asio/ssl/impl/context.ipp
+++ b/asio/include/asio/ssl/impl/context.ipp
@@ -157,7 +157,7 @@ context::context(context::method m)
       SSL_CTX_set_max_proto_version(handle_, TLS1_VERSION);
     }
     break;
-#else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#elif defined(SSL_TXT_TLSV1)
   case context::tlsv1:
     handle_ = ::SSL_CTX_new(::TLSv1_method());
     break;
@@ -167,7 +167,14 @@ context::context(context::method m)
   case context::tlsv1_server:
     handle_ = ::SSL_CTX_new(::TLSv1_server_method());
     break;
-#endif // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#else // defined(SSL_TXT_TLSV1)
+  case context::tlsv1:
+  case context::tlsv1_client:
+  case context::tlsv1_server:
+    asio::detail::throw_error(
+        asio::error::invalid_argument, "context");
+    break;
+#endif // defined(SSL_TXT_TLSV1)
 
     // TLS v1.1.
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
@@ -240,7 +247,7 @@ context::context(context::method m)
       SSL_CTX_set_max_proto_version(handle_, TLS1_2_VERSION);
     }
     break;
-#elif defined(SSL_TXT_TLSV1_1)
+#elif defined(SSL_TXT_TLSV1_2)
   case context::tlsv12:
     handle_ = ::SSL_CTX_new(::TLSv1_2_method());
     break;
@@ -250,14 +257,14 @@ context::context(context::method m)
   case context::tlsv12_server:
     handle_ = ::SSL_CTX_new(::TLSv1_2_server_method());
     break;
-#else // defined(SSL_TXT_TLSV1_1)
+#else // defined(SSL_TXT_TLSV1_2)
   case context::tlsv12:
   case context::tlsv12_client:
   case context::tlsv12_server:
     asio::detail::throw_error(
         asio::error::invalid_argument, "context");
     break;
-#endif // defined(SSL_TXT_TLSV1_1)
+#endif // defined(SSL_TXT_TLSV1_2)
 
     // Any supported SSL/TLS version.
   case context::sslv23:
@@ -341,7 +348,8 @@ context::~context()
 {
   if (handle_)
   {
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) \
+                                                        || defined(WOLFSSL_ASIO)
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
     void* cb_userdata = handle_->default_passwd_callback_userdata;
@@ -352,7 +360,8 @@ context::~context()
         static_cast<detail::password_callback_base*>(
             cb_userdata);
       delete callback;
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) \
+                                                        || defined(WOLFSSL_ASIO)
       ::SSL_CTX_set_default_passwd_cb_userdata(handle_, 0);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
       handle_->default_passwd_callback_userdata = 0;
@@ -689,7 +698,8 @@ ASIO_SYNC_OP_VOID context::use_certificate_chain(
   bio_cleanup bio = { make_buffer_bio(chain) };
   if (bio.p)
   {
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) \
+                                                        || defined(WOLFSSL_ASIO)
     pem_password_cb* callback = ::SSL_CTX_get_default_passwd_cb(handle_);
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
@@ -716,7 +726,8 @@ ASIO_SYNC_OP_VOID context::use_certificate_chain(
       ASIO_SYNC_OP_VOID_RETURN(ec);
     }
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10002000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10002000L) && !defined(LIBRESSL_VERSION_NUMBER) \
+                                                        || defined(WOLFSSL_ASIO)
     ::SSL_CTX_clear_chain_certs(handle_);
 #else
     if (handle_->extra_certs)
@@ -793,7 +804,8 @@ ASIO_SYNC_OP_VOID context::use_private_key(
 {
   ::ERR_clear_error();
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) \
+                                                        || defined(WOLFSSL_ASIO)
     pem_password_cb* callback = ::SSL_CTX_get_default_passwd_cb(handle_);
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
@@ -860,7 +872,8 @@ ASIO_SYNC_OP_VOID context::use_rsa_private_key(
 {
   ::ERR_clear_error();
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) \
+                                                        || defined(WOLFSSL_ASIO)
     pem_password_cb* callback = ::SSL_CTX_get_default_passwd_cb(handle_);
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
@@ -1099,7 +1112,8 @@ int context::verify_callback_function(int preverified, X509_STORE_CTX* ctx)
 ASIO_SYNC_OP_VOID context::do_set_password_callback(
     detail::password_callback_base* callback, asio::error_code& ec)
 {
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER) \
+                                                        || defined(WOLFSSL_ASIO)
   void* old_callback = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
   ::SSL_CTX_set_default_passwd_cb_userdata(handle_, callback);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)

--- a/asio/include/asio/ssl/rfc2818_verification.hpp
+++ b/asio/include/asio/ssl/rfc2818_verification.hpp
@@ -15,7 +15,7 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
-#if defined(WOLFSSL_ASIO)
+#if defined(ASIO_USE_WOLFSSL)
 #include <wolfssl/options.h>
 #endif
 

--- a/asio/include/asio/ssl/rfc2818_verification.hpp
+++ b/asio/include/asio/ssl/rfc2818_verification.hpp
@@ -15,6 +15,10 @@
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
+#if defined(WOLFSSL_ASIO)
+#include <wolfssl/options.h>
+#endif
+
 #include "asio/detail/config.hpp"
 
 #include <string>


### PR DESCRIPTION
This PR enables the user to compile a program using Asio with the most current version of [wolfSSL](https://github.com/wolfSSL/wolfssl) instead of OpenSSL. Changes to configure.ac enable the user to run the included unit tests with wolfSSL. You can build wolfSSL on a unix type environment with Asio compatibility by executing the following commands from the downloaded wolfSSL root directory:
    **$ ./autogen.sh
    $ ./configure --enable-asio
    $ make
    $ sudo make install**