### PR TITLE
Replace OSMemoryBarrier() atomic fence

### DIFF
--- a/asio/include/asio/detail/macos_fenced_block.hpp
+++ b/asio/include/asio/detail/macos_fenced_block.hpp
@@ -19,6 +19,7 @@
 
 #if defined(__MACH__) && defined(__APPLE__)
 
+#include <atomic>
 #include <libkern/OSAtomic.h>
 #include "asio/detail/noncopyable.hpp"
 
@@ -42,13 +43,13 @@ public:
   // Constructor for a full fenced block.
   explicit macos_fenced_block(full_t)
   {
-    OSMemoryBarrier();
+    std::atomic_thread_fence(std::memory_order_seq_cst);
   }
 
   // Destructor.
   ~macos_fenced_block()
   {
-    OSMemoryBarrier();
+    std::atomic_thread_fence(std::memory_order_seq_cst);
   }
 };
 


### PR DESCRIPTION
Since macOS 10.12 OSMemoryBarrier() is deprecated so replace it with
std::atomic_thread_fence()
