### PR TITLE
scheduler.ipp: add null pointer check

### DIFF
--- a/asio/include/asio/detail/impl/scheduler.ipp
+++ b/asio/include/asio/detail/impl/scheduler.ipp
@@ -270,8 +270,10 @@ void scheduler::restart()
 
 void scheduler::compensating_work_started()
 {
-  thread_info_base* this_thread = thread_call_stack::contains(this);
-  ++static_cast<thread_info*>(this_thread)->private_outstanding_work;
+  if (thread_info_base* this_thread = thread_call_stack::contains(this))
+  {
+    ++static_cast<thread_info*>(this_thread)->private_outstanding_work;
+  }
 }
 
 void scheduler::post_immediate_completion(


### PR DESCRIPTION
This takes care of the ticker [#13562](https://svn.boost.org/trac10/ticket/13562) from the old boost bug tracker.

I experience SIGSEGV with the following (pseudo) code:
```cpp
asio::posix::stream_descriptor fd_;
std::vector<char> buffer_(20);
...

fd_.assign(<open-raw-descriptor>);
sched_read();

...
void sched_read()
{
    asio::async_read(fd_, asio::buffer(buffer_),
        [&](const asio::error_code& ec, std::size_t)
        {
            if(ec) return;
            // read buffer_
            sched_read();
        }
    );
}
```
Other parts of `scheduler.ipp` check for null pointer:

https://github.com/chriskohlhoff/asio/blob/b0926b61b057ce563241d609cae5768ed3a4e1b1/asio/include/asio/detail/impl/scheduler.ipp#L283-L288

https://github.com/chriskohlhoff/asio/blob/b0926b61b057ce563241d609cae5768ed3a4e1b1/asio/include/asio/detail/impl/scheduler.ipp#L305-L309

https://github.com/chriskohlhoff/asio/blob/b0926b61b057ce563241d609cae5768ed3a4e1b1/asio/include/asio/detail/impl/scheduler.ipp#L326-L330

So, my immediate knee-jerk reaction is to add a similar check.