### PR TITLE
Fix typo in examples/multicast IPv6 broadcast addresses

### DIFF
--- a/asio/src/examples/cpp03/multicast/receiver.cpp
+++ b/asio/src/examples/cpp03/multicast/receiver.cpp
@@ -74,7 +74,7 @@ int main(int argc, char* argv[])
       std::cerr << "  For IPv4, try:\n";
       std::cerr << "    receiver 0.0.0.0 239.255.0.1\n";
       std::cerr << "  For IPv6, try:\n";
-      std::cerr << "    receiver 0::0 ff31::8000:1234\n";
+      std::cerr << "    receiver 0::0 ff13::8000:1234\n";
       return 1;
     }
 

--- a/asio/src/examples/cpp03/multicast/sender.cpp
+++ b/asio/src/examples/cpp03/multicast/sender.cpp
@@ -81,7 +81,7 @@ int main(int argc, char* argv[])
       std::cerr << "  For IPv4, try:\n";
       std::cerr << "    sender 239.255.0.1\n";
       std::cerr << "  For IPv6, try:\n";
-      std::cerr << "    sender ff31::8000:1234\n";
+      std::cerr << "    sender ff13::8000:1234\n";
       return 1;
     }
 

--- a/asio/src/examples/cpp11/multicast/receiver.cpp
+++ b/asio/src/examples/cpp11/multicast/receiver.cpp
@@ -69,7 +69,7 @@ int main(int argc, char* argv[])
       std::cerr << "  For IPv4, try:\n";
       std::cerr << "    receiver 0.0.0.0 239.255.0.1\n";
       std::cerr << "  For IPv6, try:\n";
-      std::cerr << "    receiver 0::0 ff31::8000:1234\n";
+      std::cerr << "    receiver 0::0 ff13::8000:1234\n";
       return 1;
     }
 

--- a/asio/src/examples/cpp11/multicast/sender.cpp
+++ b/asio/src/examples/cpp11/multicast/sender.cpp
@@ -74,7 +74,7 @@ int main(int argc, char* argv[])
       std::cerr << "  For IPv4, try:\n";
       std::cerr << "    sender 239.255.0.1\n";
       std::cerr << "  For IPv6, try:\n";
-      std::cerr << "    sender ff31::8000:1234\n";
+      std::cerr << "    sender ff13::8000:1234\n";
       return 1;
     }
 


### PR DESCRIPTION
Current addresses are interface-local as per
https://en.wikipedia.org/wiki/Multicast_address#IPv6
whereas the intention was to have IPv4 local scope.