### PR TITLE
Check for and enable local Unix sockets on Windows.

### DIFF
--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -1120,6 +1120,7 @@
 #   define ASIO_HAS_LOCAL_SOCKETS 1
 #  elif defined(ASIO_WINDOWS) \
   && defined(NTDDI_VERSION) \
+  && defined(NTDDI_WIN10_RS3) \
   && (NTDDI_VERSION >= NTDDI_WIN10_RS3)
 #   define ASIO_HAS_LOCAL_SOCKETS 1
 #  endif // !defined(ASIO_WINDOWS)

--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -1120,8 +1120,8 @@
 #   define ASIO_HAS_LOCAL_SOCKETS 1
 #  elif defined(ASIO_WINDOWS) \
   && defined(NTDDI_VERSION) \
-  && defined(NTDDI_WIN10_RS3) \
-  && (NTDDI_VERSION >= NTDDI_WIN10_RS3)
+  && defined(NTDDI_WIN10_RS4) \
+  && (NTDDI_VERSION >= NTDDI_WIN10_RS4)
 #   define ASIO_HAS_LOCAL_SOCKETS 1
 #  endif // !defined(ASIO_WINDOWS)
          //   && !defined(ASIO_WINDOWS_RUNTIME)

--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -1118,6 +1118,10 @@
   && !defined(ASIO_WINDOWS_RUNTIME) \
   && !defined(__CYGWIN__)
 #   define ASIO_HAS_LOCAL_SOCKETS 1
+#  elif defined(ASIO_WINDOWS) \
+  && defined(NTDDI_VERSION) \
+  && (NTDDI_VERSION >= NTDDI_WIN10_RS3)
+#   define ASIO_HAS_LOCAL_SOCKETS 1
 #  endif // !defined(ASIO_WINDOWS)
          //   && !defined(ASIO_WINDOWS_RUNTIME)
          //   && !defined(__CYGWIN__)

--- a/asio/include/asio/detail/socket_types.hpp
+++ b/asio/include/asio/detail/socket_types.hpp
@@ -39,6 +39,9 @@
 # endif // defined(WINAPI_FAMILY)
 # if !defined(ASIO_WINDOWS_APP)
 #  include <mswsock.h>
+#  if defined(ASIO_HAS_LOCAL_SOCKETS)
+#   include <afunix.h>
+#  endif
 # endif // !defined(ASIO_WINDOWS_APP)
 # if defined(ASIO_WSPIAPI_H_DEFINED)
 #  undef _WSPIAPI_H_
@@ -188,6 +191,9 @@ typedef sockaddr socket_addr_type;
 typedef in_addr in4_addr_type;
 typedef ip_mreq in4_mreq_type;
 typedef sockaddr_in sockaddr_in4_type;
+# if defined(ASIO_HAS_LOCAL_SOCKETS)
+typedef sockaddr_un sockaddr_un_type;
+# endif
 # if defined(ASIO_HAS_OLD_WIN_SDK)
 typedef in6_addr_emulation in6_addr_type;
 typedef ipv6_mreq_emulation in6_mreq_type;

--- a/asio/include/asio/local/connect_pair.hpp
+++ b/asio/include/asio/local/connect_pair.hpp
@@ -17,7 +17,8 @@
 
 #include "asio/detail/config.hpp"
 
-#if defined(ASIO_HAS_LOCAL_SOCKETS) \
+#if (defined(ASIO_HAS_LOCAL_SOCKETS) \
+  && !defined(ASIO_WINDOWS)) \
   || defined(GENERATING_DOCUMENTATION)
 
 #include "asio/basic_socket.hpp"

--- a/asio/include/asio/local/datagram_protocol.hpp
+++ b/asio/include/asio/local/datagram_protocol.hpp
@@ -17,7 +17,8 @@
 
 #include "asio/detail/config.hpp"
 
-#if defined(ASIO_HAS_LOCAL_SOCKETS) \
+#if (defined(ASIO_HAS_LOCAL_SOCKETS) \
+  && !defined(ASIO_WINDOWS)) \
   || defined(GENERATING_DOCUMENTATION)
 
 #include "asio/basic_datagram_socket.hpp"

--- a/asio/src/Makefile.msc
+++ b/asio/src/Makefile.msc
@@ -158,6 +158,8 @@ UNIT_TEST_EXES = \
 	tests\unit\ip\v6_only.exe \
 	tests\unit\is_read_buffered.exe \
 	tests\unit\is_write_buffered.exe \
+	tests\unit\local\basic_endpoint.exe \
+	tests\unit\local\stream_protocol.exe \
 	tests\unit\placeholders.exe \
 	tests\unit\raw_socket_service.exe \
 	tests\unit\read.exe \
@@ -307,6 +309,9 @@ tests\unit\unit_test.obj: tests\unit\unit_test.cpp
 	cl -Fe$@ -Fo$(<:.cpp=.obj) $(CXXFLAGS) $(DEFINES) $< $(LIBS) -link -opt:ref
 
 {tests\unit\ip}.cpp{tests\unit\ip}.exe:
+	cl -Fe$@ -Fo$(<:.cpp=.obj) $(CXXFLAGS) $(DEFINES) $< $(LIBS) -link -opt:ref
+
+{tests\unit\local}.cpp{tests\unit\local}.exe:
 	cl -Fe$@ -Fo$(<:.cpp=.obj) $(CXXFLAGS) $(DEFINES) $< $(LIBS) -link -opt:ref
 
 {tests\unit\ssl}.cpp{tests\unit\ssl}.exe:

--- a/asio/src/tests/unit/local/stream_protocol.cpp
+++ b/asio/src/tests/unit/local/stream_protocol.cpp
@@ -13,6 +13,14 @@
 #define BOOST_ALL_NO_LIB 1
 #endif // !defined(BOOST_ALL_NO_LIB)
 
+// Check for a new enough Windows SDK to test AF_UNIX support.
+#if defined(_WIN32_WINNT)
+ #include <SdkDdkVer.h>
+ #if defined(NTDDI_WIN10_RS3)
+  #define ASIO_HAS_LOCAL_SOCKETS
+ #endif
+#endif
+
 // Test that header file is self-contained.
 #include "asio/local/stream_protocol.hpp"
 

--- a/asio/src/tests/unit/local/stream_protocol.cpp
+++ b/asio/src/tests/unit/local/stream_protocol.cpp
@@ -14,9 +14,11 @@
 #endif // !defined(BOOST_ALL_NO_LIB)
 
 // Check for a new enough Windows SDK to test AF_UNIX support.
+// Technically, the Fall Creator's update added some support, but
+// it was a weird non-standard definition of sockaddr_un.
 #if defined(_WIN32_WINNT)
- #include <SdkDdkVer.h>
- #if defined(NTDDI_WIN10_RS3)
+ #include <sdkddkver.h>
+ #if defined(NTDDI_WIN10_RS4)
   #define ASIO_HAS_LOCAL_SOCKETS
  #endif
 #endif


### PR DESCRIPTION
Rough draft of enabling Unix domain socket support on Windows, when possible.

It's not full feature set, yet, but it's more than enough to be useful: https://blogs.msdn.microsoft.com/commandline/2017/12/19/af_unix-comes-to-windows/



