### PR TITLE
Add support for configuring symbol visibility using macro

### DIFF
--- a/asio/include/asio/detail/pop_options.hpp
+++ b/asio/include/asio/detail/pop_options.hpp
@@ -23,7 +23,7 @@
 
 // Intel C++
 
-# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
+# if !defined(ASIO_USE_CLIENT_VISIBILITY) && (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4) 
 #  pragma GCC visibility pop
 # endif // (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
 
@@ -41,7 +41,7 @@
 #  endif
 # endif
 
-# if !defined(_WIN32) && !defined(__WIN32__) && !defined(WIN32)
+# if !defined(ASIO_USE_CLIENT_VISIBILITY) && !defined(_WIN32) && !defined(__WIN32__) && !defined(WIN32)
 #  pragma GCC visibility pop
 # endif // !defined(_WIN32) && !defined(__WIN32__) && !defined(WIN32)
 
@@ -63,7 +63,7 @@
 #  endif
 # endif
 
-# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
+# if !defined(ASIO_USE_CLIENT_VISIBILITY) && (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
 #  pragma GCC visibility pop
 # endif // (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
 

--- a/asio/include/asio/detail/push_options.hpp
+++ b/asio/include/asio/detail/push_options.hpp
@@ -23,7 +23,7 @@
 
 // Intel C++
 
-# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
+# if !defined(ASIO_USE_CLIENT_VISIBILITY) && (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
 #  pragma GCC visibility push (default)
 # endif // (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
 
@@ -43,7 +43,7 @@
 #  endif
 # endif
 
-# if !defined(_WIN32) && !defined(__WIN32__) && !defined(WIN32)
+# if !defined(ASIO_USE_CLIENT_VISIBILITY) && !defined(_WIN32) && !defined(__WIN32__) && !defined(WIN32)
 #  pragma GCC visibility push (default)
 # endif // !defined(_WIN32) && !defined(__WIN32__) && !defined(WIN32)
 
@@ -67,7 +67,7 @@
 #  endif
 # endif
 
-# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
+# if !defined(ASIO_USE_CLIENT_VISIBILITY) && (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
 #  pragma GCC visibility push (default)
 # endif // (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
 


### PR DESCRIPTION
As of now all the symbols are exported by asio , since in push_options.hpp we always set symbol visibility to default i.e.https://github.com/chriskohlhoff/asio/blob/master/asio/include/asio/detail/push_options.hpp#L27

We have a requirement where we don't want to export symbols from our dylib but since asio always exports symbols we are facing issues.