### PR TITLE
Let asio build on Haiku OS

### DIFF
--- a/asio/configure.ac
+++ b/asio/configure.ac
@@ -118,6 +118,10 @@ case $host in
     CXXFLAGS="$CXXFLAGS -pthread"
     LDFLAGS="$LDFLAGS -pthread"
     ;;
+  *-*-haiku*)
+    CXXFLAGS="$CXXFLAGS -lnetwork"
+    LDFLAGS="$LDFLAGS -lnetwork"
+
 esac
 
 if test "$GXX" = yes; then

--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -1003,7 +1003,8 @@
    || defined(__FreeBSD__) \
    || defined(__NetBSD__) \
    || defined(__OpenBSD__) \
-   || defined(__linux__)
+   || defined(__linux__) \
+   || defined(__HAIKU__)
 #   define ASIO_HAS_UNISTD_H 1
 #  endif
 # endif // !defined(ASIO_HAS_BOOST_CONFIG)


### PR DESCRIPTION
Hi, I added some changes to be able to build ASIO on Haiku OS.
Currently all tests pass, except 3: multicast, v6only and socket_base.

Will investigate these problems, but I think the first two fail because of missing support in the network stack,