### PR TITLE
Correctly enabling multicast on QNX

### DIFF
--- a/asio/include/asio/detail/impl/socket_ops.ipp
+++ b/asio/include/asio/detail/impl/socket_ops.ipp
@@ -1502,7 +1502,7 @@ int setsockopt(socket_type s, state_type& state, int level, int optname,
     ec = asio::error_code();
 
 #if defined(__MACH__) && defined(__APPLE__) \
-  || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+  || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__QNX__)
     // To implement portable behaviour for SO_REUSEADDR with UDP sockets we
     // need to also set SO_REUSEPORT on BSD-based platforms.
     if ((state & datagram_oriented)


### PR DESCRIPTION
As QNX has a BSD-styled reuse address/port behavior, this small patch adds SO_REUSEPORT for QNX systems.