### PR TITLE
Added constructor for local::basic_endpoint from string_view

### DIFF
--- a/asio/include/asio/local/basic_endpoint.hpp
+++ b/asio/include/asio/local/basic_endpoint.hpp
@@ -76,6 +76,16 @@ public:
   {
   }
 
+
+  #if defined(ASIO_HAS_STRING_VIEW)
+  /// Construct an endpoint using the specified path name.
+  basic_endpoint(string_view path_name)
+    : impl_(path_name)
+  {
+  }
+  #endif // defined(ASIO_HAS_STRING_VIEW)
+
+
   /// Copy constructor.
   basic_endpoint(const basic_endpoint& other)
     : impl_(other.impl_)

--- a/asio/include/asio/local/detail/endpoint.hpp
+++ b/asio/include/asio/local/detail/endpoint.hpp
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <string>
 #include "asio/detail/socket_types.hpp"
+#include "asio/detail/string_view.hpp"
 
 #include "asio/detail/push_options.hpp"
 
@@ -42,6 +43,12 @@ public:
 
   // Construct an endpoint using the specified path name.
   ASIO_DECL endpoint(const std::string& path_name);
+
+  #if defined(ASIO_HAS_STRING_VIEW)
+  // Construct an endpoint using the specified path name.
+  ASIO_DECL endpoint(string_view path_name);
+
+  #endif // defined(ASIO_HAS_STRING_VIEW)
 
   // Copy constructor.
   endpoint(const endpoint& other)

--- a/asio/include/asio/local/detail/impl/endpoint.ipp
+++ b/asio/include/asio/local/detail/impl/endpoint.ipp
@@ -48,6 +48,15 @@ endpoint::endpoint(const std::string& path_name)
   init(path_name.data(), path_name.length());
 }
 
+#if defined(ASIO_HAS_STRING_VIEW)
+endpoint::endpoint(string_view path_name)
+{
+  init(path_name.data(), path_name.length());
+}
+
+#endif // defined(ASIO_HAS_STRING_VIEW)
+
+
 void endpoint::resize(std::size_t new_size)
 {
   if (new_size > sizeof(asio::detail::sockaddr_un_type))


### PR DESCRIPTION
This PR add a new constructor to asio::local::basic_endpoint<> that takes string_view. 
It appears there is no need to use std::string or NULL-terminated string. This PR also brings creation options of local::basic_endpoint on par with ip::address make_address.