### PR TITLE
Make the executor_work_guard move constructor noexcept

### DIFF
--- a/asio/include/asio/executor_work_guard.hpp
+++ b/asio/include/asio/executor_work_guard.hpp
@@ -55,7 +55,7 @@ public:
 
 #if defined(ASIO_HAS_MOVE) || defined(GENERATING_DOCUMENTATION)
   /// Move constructor.
-  executor_work_guard(executor_work_guard&& other)
+  executor_work_guard(executor_work_guard&& other) ASIO_NOEXCEPT
     : executor_(ASIO_MOVE_CAST(Executor)(other.executor_)),
       owns_(other.owns_)
   {


### PR DESCRIPTION
If I got it right https://www.boost.org/doc/libs/1_69_0/doc/html/boost_asio/reference/Executor1.html says the executors are guaranteed to be move-noexcept and so the executor_work_guard is free to also be?
