### PR TITLE
Fix Visual Studio 2017 warning: 'argument': conversion from 'size_t' to 'int', possible loss of data

### DIFF
--- a/asio/include/asio/impl/thread_pool.ipp
+++ b/asio/include/asio/impl/thread_pool.ipp
@@ -45,7 +45,7 @@ thread_pool::thread_pool()
 
 thread_pool::thread_pool(std::size_t num_threads)
   : scheduler_(add_scheduler(new detail::scheduler(*this, num_threads == 1
-          ? ASIO_CONCURRENCY_HINT_1 : num_threads, false)))
+          ? ASIO_CONCURRENCY_HINT_1 : static_cast<int>(num_threads), false)))
 {
   scheduler_.work_started();
 


### PR DESCRIPTION
thread_pool.ipp(48): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data