### PR TITLE
Added wolfSSL Compatability for Asio

### DIFF
--- a/asio/configure.ac
+++ b/asio/configure.ac
@@ -10,7 +10,6 @@ AC_LANG(C++)
 AC_PROG_RANLIB
 
 AC_DEFINE(_REENTRANT, [1], [Define this])
-
 AC_ARG_WITH(boost,
   AC_HELP_STRING([--with-boost=DIR],[location of boost distribution]),
 [
@@ -47,23 +46,47 @@ if test "$STANDALONE" != yes; then
   ],[])
 fi
 
-AC_ARG_WITH(openssl,
-  AC_HELP_STRING([--with-openssl=DIR],[location of openssl]),
+# Setup for wolfSSL.
+AC_ARG_WITH(wolfssl,
+  AC_HELP_STRING([--with-wolfssl=DIR],[location of wolfssl]),
 [
-  CPPFLAGS="$CPPFLAGS -I${withval}/include"
+  CPPFLAGS="$CPPFLAGS -I${withval}/include/wolfssl -DASIO_USE_WOLFSSL"
   LIBS="$LIBS -L${withval}/lib"
+  WOLFSSL_USE=no
 ],[])
 
-AC_CHECK_HEADER([openssl/ssl.h],,
-[
-  OPENSSL_FOUND=no
-],[])
+if test x$WOLFSSL_USE == xno; then
+    AC_CHECK_HEADER([wolfssl/options.h],,
+    [
+      WOLFSSL_FOUND=no
+    ],[])
 
-if test x$OPENSSL_FOUND != xno; then
-  LIBS="$LIBS -lssl -lcrypto"
+    if test x$WOLFSSL_FOUND != xno; then
+      LIBS="$LIBS -lwolfssl"
+    fi
+    AM_CONDITIONAL(HAVE_OPENSSL,test x$WOLFSSL_FOUND != xno)
 fi
 
-AM_CONDITIONAL(HAVE_OPENSSL,test x$OPENSSL_FOUND != xno)
+# Setup for OpenSSL.
+if test x$WOLFSSL_USE != xno; then
+    AC_ARG_WITH(openssl,
+      AC_HELP_STRING([--with-openssl=DIR],[location of openssl]),
+    [
+      CPPFLAGS="$CPPFLAGS -I${withval}/include"
+      LIBS="$LIBS -L${withval}/lib"
+    ],[])
+
+    AC_CHECK_HEADER([openssl/ssl.h],,
+    [
+      OPENSSL_FOUND=no
+    ],[])
+
+    if test x$OPENSSL_FOUND != xno; then
+      LIBS="$LIBS -lssl -lcrypto"
+    fi
+
+    AM_CONDITIONAL(HAVE_OPENSSL,test x$OPENSSL_FOUND != xno)
+fi
 
 WINDOWS=no
 case $host in

--- a/asio/include/asio/ssl/detail/impl/openssl_init.ipp
+++ b/asio/include/asio/ssl/detail/impl/openssl_init.ipp
@@ -85,9 +85,9 @@ public:
 #endif // (OPENSSL_VERSION_NUMBER >= 0x10002000L)
        // && (OPENSSL_VERSION_NUMBER < 0x10100000L)
        // && !defined(SSL_OP_NO_COMPRESSION)
-#if !defined(OPENSSL_IS_BORINGSSL)
+#if !defined(OPENSSL_IS_BORINGSSL) && !defined(ASIO_USE_WOLFSSL)
     ::CONF_modules_unload(1);
-#endif // !defined(OPENSSL_IS_BORINGSSL)
+#endif // !defined(OPENSSL_IS_BORINGSSL) && !defined(ASIO_USE_WOLFSSL)
 #if !defined(OPENSSL_NO_ENGINE) \
   && (OPENSSL_VERSION_NUMBER < 0x10100000L)
     ::ENGINE_cleanup();

--- a/asio/include/asio/ssl/detail/openssl_types.hpp
+++ b/asio/include/asio/ssl/detail/openssl_types.hpp
@@ -17,6 +17,9 @@
 
 #include "asio/detail/config.hpp"
 #include "asio/detail/socket_types.hpp"
+#if defined(ASIO_USE_WOLFSSL)
+#include <wolfssl/options.h>
+#endif
 #include <openssl/conf.h>
 #include <openssl/ssl.h>
 #if !defined(OPENSSL_NO_ENGINE)

--- a/asio/include/asio/ssl/error.hpp
+++ b/asio/include/asio/ssl/error.hpp
@@ -54,7 +54,8 @@ enum stream_errors
   /// call.
   unexpected_result
 #else // defined(GENERATING_DOCUMENTATION)
-# if (OPENSSL_VERSION_NUMBER < 0x10100000L) && !defined(OPENSSL_IS_BORINGSSL)
+# if (OPENSSL_VERSION_NUMBER < 0x10100000L) && !defined(OPENSSL_IS_BORINGSSL) \
+  && !defined(ASIO_USE_WOLFSSL)
   stream_truncated = ERR_PACK(ERR_LIB_SSL, 0, SSL_R_SHORT_READ),
 # else
   stream_truncated = 1,

--- a/asio/include/asio/ssl/impl/context.ipp
+++ b/asio/include/asio/ssl/impl/context.ipp
@@ -386,7 +386,8 @@ context::~context()
 {
   if (handle_)
   {
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if ((OPENSSL_VERSION_NUMBER >= 0x10100000L) \
+ && !defined(LIBRESSL_VERSION_NUMBER)) || defined(ASIO_USE_WOLFSSL)
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
     void* cb_userdata = handle_->default_passwd_callback_userdata;
@@ -397,7 +398,8 @@ context::~context()
         static_cast<detail::password_callback_base*>(
             cb_userdata);
       delete callback;
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if ((OPENSSL_VERSION_NUMBER >= 0x10100000L) \
+ && !defined(LIBRESSL_VERSION_NUMBER)) || defined(ASIO_USE_WOLFSSL)
       ::SSL_CTX_set_default_passwd_cb_userdata(handle_, 0);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
       handle_->default_passwd_callback_userdata = 0;
@@ -734,7 +736,8 @@ ASIO_SYNC_OP_VOID context::use_certificate_chain(
   bio_cleanup bio = { make_buffer_bio(chain) };
   if (bio.p)
   {
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if ((OPENSSL_VERSION_NUMBER >= 0x10100000L) \
+ && !defined(LIBRESSL_VERSION_NUMBER)) || defined(ASIO_USE_WOLFSSL)
     pem_password_cb* callback = ::SSL_CTX_get_default_passwd_cb(handle_);
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
@@ -761,7 +764,8 @@ ASIO_SYNC_OP_VOID context::use_certificate_chain(
       ASIO_SYNC_OP_VOID_RETURN(ec);
     }
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10002000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if ((OPENSSL_VERSION_NUMBER >= 0x10002000L) \
+ && !defined(LIBRESSL_VERSION_NUMBER)) || defined(ASIO_USE_WOLFSSL)
     ::SSL_CTX_clear_chain_certs(handle_);
 #else
     if (handle_->extra_certs)
@@ -838,7 +842,8 @@ ASIO_SYNC_OP_VOID context::use_private_key(
 {
   ::ERR_clear_error();
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if ((OPENSSL_VERSION_NUMBER >= 0x10100000L) \
+ && !defined(LIBRESSL_VERSION_NUMBER)) || defined(ASIO_USE_WOLFSSL)
     pem_password_cb* callback = ::SSL_CTX_get_default_passwd_cb(handle_);
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
@@ -905,7 +910,8 @@ ASIO_SYNC_OP_VOID context::use_rsa_private_key(
 {
   ::ERR_clear_error();
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if ((OPENSSL_VERSION_NUMBER >= 0x10100000L) \
+ && !defined(LIBRESSL_VERSION_NUMBER)) || defined(ASIO_USE_WOLFSSL)
     pem_password_cb* callback = ::SSL_CTX_get_default_passwd_cb(handle_);
     void* cb_userdata = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
@@ -1144,7 +1150,8 @@ int context::verify_callback_function(int preverified, X509_STORE_CTX* ctx)
 ASIO_SYNC_OP_VOID context::do_set_password_callback(
     detail::password_callback_base* callback, asio::error_code& ec)
 {
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#if ((OPENSSL_VERSION_NUMBER >= 0x10100000L) \
+ && !defined(LIBRESSL_VERSION_NUMBER)) || defined(ASIO_USE_WOLFSSL)
   void* old_callback = ::SSL_CTX_get_default_passwd_cb_userdata(handle_);
   ::SSL_CTX_set_default_passwd_cb_userdata(handle_, callback);
 #else // (OPENSSL_VERSION_NUMBER >= 0x10100000L)


### PR DESCRIPTION
This PR enables the user to compile a program using Asio with the current version of wolfSSL instead of OpenSSL.

To build wolfSSL and configure wolfSSL for Asio use, clone the [wolfSSL repo](https://github.com/wolfssl) from Github and execute the following commands from the root directory.
```
$ ./autogen.sh
$ ./configure --enable-asio
$ make
$ sudo make install
```

After, to build Asio with wolfSSL to make use of the Asio unit tests, run the following commands from the asio/asio/ directory.
```
$ ./autogen.sh
$ ./configure --with-wolfssl=/usr/local  (change path according to where wolfSSL was installed)
$ make
$ make check

```
To build an application using wolfSSL with Asio, do it the same, except add #include<wolfssl/options.h> to the top of an application file that uses SSL or TLS. An example command to compile the application correctly is as follows.
`g++ app.cpp -I/usr/local/include/wolfssl -lwolfssl -lpthread`

For more questions or to learn more about wolfSSL please visit our [website.](https://www.wolfssl.com/)