### PR TITLE
Remove unnecessary copy when looping iterators

### DIFF
--- a/asio/include/asio/detail/posix_fd_set_adapter.hpp
+++ b/asio/include/asio/detail/posix_fd_set_adapter.hpp
@@ -62,14 +62,12 @@ public:
 
   void set(reactor_op_queue<socket_type>& operations, op_queue<operation>& ops)
   {
-    reactor_op_queue<socket_type>::iterator i = operations.begin();
-    while (i != operations.end())
+    for (reactor_op_queue<socket_type>::iterator i = operations.begin(); i != operations.end(); ++i)
     {
-      reactor_op_queue<socket_type>::iterator op_iter = i++;
-      if (!set(op_iter->first))
+      if (!set(i->first))
       {
-        asio::error_code ec(error::fd_set_failure);
-        operations.cancel_operations(op_iter, ops, ec);
+        boost::system::error_code ec(error::fd_set_failure);
+        operations.cancel_operations(i, ops, ec);
       }
     }
   }
@@ -92,12 +90,10 @@ public:
   void perform(reactor_op_queue<socket_type>& operations,
       op_queue<operation>& ops) const
   {
-    reactor_op_queue<socket_type>::iterator i = operations.begin();
-    while (i != operations.end())
+    for (reactor_op_queue<socket_type>::iterator i = operations.begin(); i != operations.end(); ++i)
     {
-      reactor_op_queue<socket_type>::iterator op_iter = i++;
-      if (is_set(op_iter->first))
-        operations.perform_operations(op_iter, ops);
+      if (is_set(i->first))
+        operations.perform_operations(i, ops);
     }
   }
 

--- a/asio/include/asio/detail/posix_fd_set_adapter.hpp
+++ b/asio/include/asio/detail/posix_fd_set_adapter.hpp
@@ -66,7 +66,7 @@ public:
     {
       if (!set(i->first))
       {
-        boost::system::error_code ec(error::fd_set_failure);
+        asio::error_code ec(error::fd_set_failure);
         operations.cancel_operations(i, ops, ec);
       }
     }

--- a/asio/include/asio/detail/reactor_op_queue.hpp
+++ b/asio/include/asio/detail/reactor_op_queue.hpp
@@ -146,12 +146,10 @@ public:
   // Get all operations owned by the queue.
   void get_all_operations(op_queue<operation>& ops)
   {
-    iterator i = operations_.begin();
-    while (i != operations_.end())
+    for (iterator i = operations_.begin(); i != operations_.end(); ++i)
     {
-      iterator op_iter = i++;
-      ops.push(op_iter->second);
-      operations_.erase(op_iter);
+      ops.push(i->second);
+      operations_.erase(i);
     }
   }
 

--- a/asio/include/asio/detail/win_fd_set_adapter.hpp
+++ b/asio/include/asio/detail/win_fd_set_adapter.hpp
@@ -68,12 +68,10 @@ public:
 
   void set(reactor_op_queue<socket_type>& operations, op_queue<operation>&)
   {
-    reactor_op_queue<socket_type>::iterator i = operations.begin();
-    while (i != operations.end())
+    for (reactor_op_queue<socket_type>::iterator i = operations.begin(); i != operations.end(); ++i)
     {
-      reactor_op_queue<socket_type>::iterator op_iter = i++;
       reserve(fd_set_->fd_count + 1);
-      fd_set_->fd_array[fd_set_->fd_count++] = op_iter->first;
+      fd_set_->fd_array[fd_set_->fd_count++] = i->first;
     }
   }
 


### PR DESCRIPTION
The logic is identical, avoids a copy of an iterator, and uses less code.