### PR TITLE
Preliminary Haiku support

### DIFF
--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -1248,6 +1248,8 @@
 #   define ASIO_HAS_THREADS 1
 #  elif defined(__APPLE__)
 #   define ASIO_HAS_THREADS 1
+#  elif defined(__HAIKU__)
+#   define ASIO_HAS_THREADS 1
 #  elif defined(_POSIX_THREADS) && (_POSIX_THREADS + 0 >= 0)
 #   define ASIO_HAS_THREADS 1
 #  elif defined(_PTHREADS)
@@ -1262,6 +1264,8 @@
 #  if defined(ASIO_HAS_BOOST_CONFIG) && defined(BOOST_HAS_PTHREADS)
 #   define ASIO_HAS_PTHREADS 1
 #  elif defined(_POSIX_THREADS) && (_POSIX_THREADS + 0 >= 0)
+#   define ASIO_HAS_PTHREADS 1
+#  elif defined(__HAIKU__)
 #   define ASIO_HAS_PTHREADS 1
 #  endif // defined(ASIO_HAS_BOOST_CONFIG) && defined(BOOST_HAS_PTHREADS)
 # endif // defined(ASIO_HAS_THREADS)


### PR DESCRIPTION
Haiku have pthread support.

This patch extracted from the mame patchset: https://github.com/mamedev/mame/pull/5053