### PR TITLE
Test for is_buffer_sequence: false positives

### DIFF
--- a/asio/include/asio/detail/is_buffer_sequence.hpp
+++ b/asio/include/asio/detail/is_buffer_sequence.hpp
@@ -214,8 +214,8 @@ char mutable_buffers_type_typedef_helper(
 template <typename T, typename Buffer>
 struct is_buffer_sequence_class
   : integral_constant<bool,
-      sizeof(buffer_sequence_begin_helper<T>(0)) != 1 &&
-      sizeof(buffer_sequence_end_helper<T>(0)) != 1 &&
+      sizeof(buffer_sequence_begin_helper<T>(0, 0)) != 1 &&
+      sizeof(buffer_sequence_end_helper<T>(0, 0)) != 1 &&
       sizeof(buffer_sequence_element_type_helper<T, Buffer>(0, 0)) == 1>
 {
 };

--- a/asio/include/asio/detail/is_buffer_sequence.hpp
+++ b/asio/include/asio/detail/is_buffer_sequence.hpp
@@ -53,18 +53,21 @@ struct buffer_sequence_memfns_check
 {
 };
 
-template <typename>
-char (&buffer_sequence_begin_helper(...))[2];
-
 #if defined(ASIO_HAS_DECLTYPE)
 
+template <typename>
+char buffer_sequence_begin_helper(...);
+
 template <typename T>
-char buffer_sequence_begin_helper(T* t,
+char (&buffer_sequence_begin_helper(T* t,
     typename enable_if<!is_same<
       decltype(asio::buffer_sequence_begin(*t)),
-        void>::value>::type*);
+        void>::value>::type*))[2];
 
 #else // defined(ASIO_HAS_DECLTYPE)
+
+template <typename>
+char (&buffer_sequence_begin_helper(...))[2];
 
 template <typename T>
 char buffer_sequence_begin_helper(T* t,
@@ -74,18 +77,21 @@ char buffer_sequence_begin_helper(T* t,
 
 #endif // defined(ASIO_HAS_DECLTYPE)
 
-template <typename>
-char (&buffer_sequence_end_helper(...))[2];
-
 #if defined(ASIO_HAS_DECLTYPE)
 
+template <typename>
+char buffer_sequence_end_helper(...);
+
 template <typename T>
-char buffer_sequence_end_helper(T* t,
+char (&buffer_sequence_end_helper(T* t,
     typename enable_if<!is_same<
       decltype(asio::buffer_sequence_end(*t)),
-        void>::value>::type*);
+        void>::value>::type*))[2];
 
 #else // defined(ASIO_HAS_DECLTYPE)
+
+template <typename>
+char (&buffer_sequence_end_helper(...))[2];
 
 template <typename T>
 char buffer_sequence_end_helper(T* t,

--- a/asio/src/Makefile.mgw
+++ b/asio/src/Makefile.mgw
@@ -54,6 +54,7 @@ UNIT_TEST_EXES = \
 	tests/unit/ip/unicast.exe \
 	tests/unit/ip/v6_only.exe \
 	tests/unit/is_buffer_sequence.exe \
+	tests/unit/is_buffer_sequence_no_decltype.exe \
 	tests/unit/is_read_buffered.exe \
 	tests/unit/is_write_buffered.exe \
 	tests/unit/placeholders.exe \

--- a/asio/src/Makefile.mgw
+++ b/asio/src/Makefile.mgw
@@ -53,6 +53,7 @@ UNIT_TEST_EXES = \
 	tests/unit/ip/udp.exe \
 	tests/unit/ip/unicast.exe \
 	tests/unit/ip/v6_only.exe \
+	tests/unit/is_buffer_sequence.exe \
 	tests/unit/is_read_buffered.exe \
 	tests/unit/is_write_buffered.exe \
 	tests/unit/placeholders.exe \

--- a/asio/src/Makefile.msc
+++ b/asio/src/Makefile.msc
@@ -174,6 +174,7 @@ UNIT_TEST_EXES = \
 	tests\unit\ip\udp.exe \
 	tests\unit\ip\unicast.exe \
 	tests\unit\ip\v6_only.exe \
+	tests\unit\is_buffer_sequence.exe \
 	tests\unit\is_read_buffered.exe \
 	tests\unit\is_write_buffered.exe \
 	tests\unit\packaged_task.exe \

--- a/asio/src/Makefile.msc
+++ b/asio/src/Makefile.msc
@@ -175,6 +175,7 @@ UNIT_TEST_EXES = \
 	tests\unit\ip\unicast.exe \
 	tests\unit\ip\v6_only.exe \
 	tests\unit\is_buffer_sequence.exe \
+	tests\unit\is_buffer_sequence_no_decltype.exe \
 	tests\unit\is_read_buffered.exe \
 	tests\unit\is_write_buffered.exe \
 	tests\unit\packaged_task.exe \

--- a/asio/src/tests/Makefile.am
+++ b/asio/src/tests/Makefile.am
@@ -75,6 +75,7 @@ check_PROGRAMS = \
 	unit/ip/unicast \
 	unit/ip/v6_only \
 	unit/is_buffer_sequence \
+	unit/is_buffer_sequence_no_decltype \
 	unit/is_read_buffered \
 	unit/is_write_buffered \
 	unit/local/basic_endpoint \
@@ -210,6 +211,7 @@ TESTS = \
 	unit/ip/unicast \
 	unit/ip/v6_only \
 	unit/is_buffer_sequence \
+	unit/is_buffer_sequence_no_decltype \
 	unit/is_read_buffered \
 	unit/is_write_buffered \
 	unit/local/basic_endpoint \
@@ -355,6 +357,7 @@ unit_ip_udp_SOURCES = unit/ip/udp.cpp
 unit_ip_unicast_SOURCES = unit/ip/unicast.cpp
 unit_ip_v6_only_SOURCES = unit/ip/v6_only.cpp
 unit_is_buffer_sequence_SOURCES = unit/is_buffer_sequence.cpp
+unit_is_buffer_sequence_no_decltype_SOURCES = unit/is_buffer_sequence_no_decltype.cpp
 unit_is_read_buffered_SOURCES = unit/is_read_buffered.cpp
 unit_is_write_buffered_SOURCES = unit/is_write_buffered.cpp
 unit_local_basic_endpoint_SOURCES = unit/local/basic_endpoint.cpp

--- a/asio/src/tests/Makefile.am
+++ b/asio/src/tests/Makefile.am
@@ -74,6 +74,7 @@ check_PROGRAMS = \
 	unit/ip/udp \
 	unit/ip/unicast \
 	unit/ip/v6_only \
+	unit/is_buffer_sequence \
 	unit/is_read_buffered \
 	unit/is_write_buffered \
 	unit/local/basic_endpoint \
@@ -208,6 +209,7 @@ TESTS = \
 	unit/ip/udp \
 	unit/ip/unicast \
 	unit/ip/v6_only \
+	unit/is_buffer_sequence \
 	unit/is_read_buffered \
 	unit/is_write_buffered \
 	unit/local/basic_endpoint \
@@ -352,6 +354,7 @@ unit_ip_tcp_SOURCES = unit/ip/tcp.cpp
 unit_ip_udp_SOURCES = unit/ip/udp.cpp
 unit_ip_unicast_SOURCES = unit/ip/unicast.cpp
 unit_ip_v6_only_SOURCES = unit/ip/v6_only.cpp
+unit_is_buffer_sequence_SOURCES = unit/is_buffer_sequence.cpp
 unit_is_read_buffered_SOURCES = unit/is_read_buffered.cpp
 unit_is_write_buffered_SOURCES = unit/is_write_buffered.cpp
 unit_local_basic_endpoint_SOURCES = unit/local/basic_endpoint.cpp

--- a/asio/src/tests/unit/is_buffer_sequence.cpp
+++ b/asio/src/tests/unit/is_buffer_sequence.cpp
@@ -8,13 +8,16 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
+#include <vector>
 #include "asio/buffer.hpp"
 #include "unit_test.hpp"
 
 #ifdef ASIO_HAS_DECLTYPE
 # define ASIO_HAS_DECLTYPE_MSG "ASIO_HAS_DECLTYPE is defined"
+# define ASIO_HAS_DECLTYPE_FLAG true
 #else
 # define ASIO_HAS_DECLTYPE_MSG "ASIO_HAS_DECLTYPE is not defined"
+# define ASIO_HAS_DECLTYPE_FLAG false
 #endif
 
 using namespace asio;
@@ -50,6 +53,33 @@ struct X1
   const mutable_buffer* end() const;
 };
 
+struct B2
+{
+  typedef mutable_buffer value_type;
+  typedef void const_iterator; // (!)
+
+  const mutable_buffer* begin() const;
+  const mutable_buffer* end() const;
+};
+
+struct B3
+{
+  typedef mutable_buffer value_type;
+  typedef const mutable_buffer* const_iterator;
+
+  int begin; // (!)
+  const mutable_buffer* end() const;
+};
+
+struct C1
+{
+  typedef mutable_buffer value_type;
+  typedef const mutable_buffer* const_iterator;
+
+  const mutable_buffer* begin() const;
+  int end() const; // (!)
+};
+
 void run()
 {
   ASIO_TEST_IOSTREAM << ASIO_HAS_DECLTYPE_MSG << std::endl;
@@ -57,6 +87,27 @@ void run()
   ASIO_CHECK(!is_mutable_buffer_sequence<A1>::value);
   ASIO_CHECK(!is_mutable_buffer_sequence<B1>::value);
   ASIO_CHECK( is_mutable_buffer_sequence<X1>::value);
+  ASIO_CHECK( is_mutable_buffer_sequence<B2>::value == ASIO_HAS_DECLTYPE_FLAG);
+  ASIO_CHECK(!is_mutable_buffer_sequence<B3>::value);
+  ASIO_CHECK(!is_mutable_buffer_sequence<C1>::value);
+
+  ASIO_CHECK(!is_mutable_buffer_sequence<void>::value);
+  ASIO_CHECK(!is_const_buffer_sequence<void>::value);
+
+  ASIO_CHECK(!is_mutable_buffer_sequence<int>::value);
+  ASIO_CHECK(!is_const_buffer_sequence<int>::value);
+
+  ASIO_CHECK( is_mutable_buffer_sequence<mutable_buffer>::value);
+  ASIO_CHECK( is_const_buffer_sequence<mutable_buffer>::value);
+
+  ASIO_CHECK(!is_mutable_buffer_sequence<const_buffer>::value);
+  ASIO_CHECK( is_const_buffer_sequence<const_buffer>::value);
+
+  ASIO_CHECK( is_mutable_buffer_sequence<std::vector<mutable_buffer> >::value);
+  ASIO_CHECK( is_const_buffer_sequence<std::vector<mutable_buffer> >::value);
+
+  ASIO_CHECK(!is_mutable_buffer_sequence<std::vector<const_buffer> >::value);
+  ASIO_CHECK( is_const_buffer_sequence<std::vector<const_buffer> >::value);
 }
 
 } // namespace

--- a/asio/src/tests/unit/is_buffer_sequence.cpp
+++ b/asio/src/tests/unit/is_buffer_sequence.cpp
@@ -22,7 +22,7 @@
 
 using namespace asio;
 
-namespace {
+namespace case1 {
 
 struct A1
 {
@@ -110,10 +110,27 @@ void run()
   ASIO_CHECK( is_const_buffer_sequence<std::vector<const_buffer> >::value);
 }
 
-} // namespace
+} // namespace case1
+
+namespace case2 {
+ 
+template <typename T>
+struct S : dynamic_vector_buffer<char, std::allocator<char> >
+{
+  T size() const;
+};
+
+void run()
+{
+  ASIO_CHECK( is_dynamic_buffer<S<std::size_t> >::value);
+  ASIO_CHECK(!is_dynamic_buffer<S<void> >::value);
+}
+
+} // 
 
 ASIO_TEST_SUITE
 (
   "is_buffer_sequence",
-  ASIO_TEST_CASE(run)
+  ASIO_TEST_CASE(case1::run)
+  ASIO_TEST_CASE(case2::run)
 )

--- a/asio/src/tests/unit/is_buffer_sequence.cpp
+++ b/asio/src/tests/unit/is_buffer_sequence.cpp
@@ -8,10 +8,14 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
 
-//#define ASIO_DISABLE_DECLTYPE
-
 #include "asio/buffer.hpp"
 #include "unit_test.hpp"
+
+#ifdef ASIO_HAS_DECLTYPE
+# define ASIO_HAS_DECLTYPE_MSG "ASIO_HAS_DECLTYPE is defined"
+#else
+# define ASIO_HAS_DECLTYPE_MSG "ASIO_HAS_DECLTYPE is not defined"
+#endif
 
 using namespace asio;
 
@@ -39,6 +43,8 @@ struct B1
 
 void run()
 {
+  ASIO_TEST_IOSTREAM << ASIO_HAS_DECLTYPE_MSG << std::endl;
+
   ASIO_CHECK(!is_mutable_buffer_sequence<A1>::value);
   ASIO_CHECK(!is_mutable_buffer_sequence<B1>::value);
 }

--- a/asio/src/tests/unit/is_buffer_sequence.cpp
+++ b/asio/src/tests/unit/is_buffer_sequence.cpp
@@ -1,0 +1,52 @@
+//
+// is_buffer_sequence.cpp
+// ~~~~~~~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2019 Alexander Karzhenkov
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+//#define ASIO_DISABLE_DECLTYPE
+
+#include "asio/buffer.hpp"
+#include "unit_test.hpp"
+
+using namespace asio;
+
+namespace {
+
+struct A1
+{
+  mutable_buffer* begin();
+
+  // no "value_type" type
+  // no "const_iterator" type
+  // no "end" member function
+};
+
+struct B1
+{
+  typedef mutable_buffer value_type;
+
+  // bad "const_iterator" type
+  typedef void const_iterator;
+
+  // no "begin" member function
+  // no "end" member function
+};
+
+void run()
+{
+  ASIO_CHECK(!is_mutable_buffer_sequence<A1>::value);
+  ASIO_CHECK(!is_mutable_buffer_sequence<B1>::value);
+}
+
+} // namespace
+
+ASIO_TEST_SUITE
+(
+  "is_buffer_sequence",
+  ASIO_TEST_CASE(run)
+)

--- a/asio/src/tests/unit/is_buffer_sequence.cpp
+++ b/asio/src/tests/unit/is_buffer_sequence.cpp
@@ -41,12 +41,22 @@ struct B1
   // no "end" member function
 };
 
+struct X1
+{
+  typedef mutable_buffer value_type;
+  typedef const mutable_buffer* const_iterator;
+
+  const mutable_buffer* begin() const;
+  const mutable_buffer* end() const;
+};
+
 void run()
 {
   ASIO_TEST_IOSTREAM << ASIO_HAS_DECLTYPE_MSG << std::endl;
 
   ASIO_CHECK(!is_mutable_buffer_sequence<A1>::value);
   ASIO_CHECK(!is_mutable_buffer_sequence<B1>::value);
+  ASIO_CHECK( is_mutable_buffer_sequence<X1>::value);
 }
 
 } // namespace

--- a/asio/src/tests/unit/is_buffer_sequence_no_decltype.cpp
+++ b/asio/src/tests/unit/is_buffer_sequence_no_decltype.cpp
@@ -1,0 +1,12 @@
+//
+// is_buffer_sequence_no_decltype.cpp
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2019 Alexander Karzhenkov
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#define ASIO_DISABLE_DECLTYPE
+#include "is_buffer_sequence.cpp"


### PR DESCRIPTION
Simple test cases indicate that the `is_buffer_sequence` template is implemented incorrectly:
- `struct A1` with single member is recognized as a _MutableBufferSequence_ when compile with the `decltype` available;
- `struct B1` with inappropriate typedefs and no member functions is recognized as a _MutableBufferSequence_ when the `decltype` is unavailable or disabled.