### PR TITLE
Update type_traits.hpp

### DIFF
--- a/asio/include/asio/detail/type_traits.hpp
+++ b/asio/include/asio/detail/type_traits.hpp
@@ -19,7 +19,7 @@
 
 #if defined(ASIO_HAS_STD_TYPE_TRAITS)
 # include <type_traits>
-#else // defined(ASIO_HAS_TYPE_TRAITS)
+#else // defined(ASIO_HAS_STD_TYPE_TRAITS)
 # include <boost/type_traits/add_const.hpp>
 # include <boost/type_traits/conditional.hpp>
 # include <boost/type_traits/decay.hpp>
@@ -34,7 +34,7 @@
 # include <boost/type_traits/remove_reference.hpp>
 # include <boost/utility/enable_if.hpp>
 # include <boost/utility/result_of.hpp>
-#endif // defined(ASIO_HAS_TYPE_TRAITS)
+#endif // defined(ASIO_HAS_STD_TYPE_TRAITS)
 
 namespace asio {
 


### PR DESCRIPTION
corrected two confusing comments with wrong macro  ASIO_HAS_TYPE_TRAITS to ASIO_HAS_STD_TYPE_TRAITS
**came here looking for an error with asio-standalone 1.30 and gcc9 after including <asio.hpp> in source code: cannot open source file "boost/type_traits/add_const.hpp" (dependency of "asio.hpp")