### PR TITLE
Fix build with Embarcadero C++Builder 10.3.2

### DIFF
--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -1354,9 +1354,9 @@
 #   if (__GNUC__ >= 3)
 #    define ASIO_HAS_HANDLER_HOOKS 1
 #   endif // (__GNUC__ >= 3)
-#  elif !defined(__BORLANDC__)
+#  elif !defined(__BORLANDC__) || defined(__clang__)
 #   define ASIO_HAS_HANDLER_HOOKS 1
-#  endif // !defined(__BORLANDC__)
+#  endif // !defined(__BORLANDC__) || defined(__clang__)
 # endif // !defined(ASIO_DISABLE_HANDLER_HOOKS)
 #endif // !defined(ASIO_HAS_HANDLER_HOOKS)
 

--- a/asio/include/asio/detail/consuming_buffers.hpp
+++ b/asio/include/asio/detail/consuming_buffers.hpp
@@ -291,8 +291,8 @@ public:
   // Get the buffer for a single transfer, with a size.
   boost::array<Buffer, 2> prepare(std::size_t max_size)
   {
-    boost::array<Buffer, 2> result = {{
-      Buffer(buffers_[0]), Buffer(buffers_[1]) }};
+    boost::array<Buffer, 2> result = {
+      Buffer(buffers_[0]), Buffer(buffers_[1]) };
     std::size_t buffer0_size = result[0].size();
     result[0] = asio::buffer(result[0] + total_consumed_, max_size);
     result[1] = asio::buffer(
@@ -343,8 +343,8 @@ public:
   // Get the buffer for a single transfer, with a size.
   std::array<Buffer, 2> prepare(std::size_t max_size)
   {
-    std::array<Buffer, 2> result = {{
-      Buffer(buffers_[0]), Buffer(buffers_[1]) }};
+    std::array<Buffer, 2> result = {
+      Buffer(buffers_[0]), Buffer(buffers_[1]) };
     std::size_t buffer0_size = result[0].size();
     result[0] = asio::buffer(result[0] + total_consumed_, max_size);
     result[1] = asio::buffer(

--- a/asio/include/asio/detail/impl/dev_poll_reactor.ipp
+++ b/asio/include/asio/detail/impl/dev_poll_reactor.ipp
@@ -284,7 +284,7 @@ void dev_poll_reactor::run(long usec, op_queue<operation>& ops)
   lock.unlock();
 
   // Block on the /dev/poll descriptor.
-  ::pollfd events[128] = { { 0, 0, 0 } };
+  ::pollfd events[128] = { 0, 0, 0 };
   ::dvpoll dp = { 0, 0, 0 };
   dp.dp_fds = events;
   dp.dp_nfds = 128;

--- a/asio/include/asio/ip/impl/address_v6.ipp
+++ b/asio/include/asio/ip/impl/address_v6.ipp
@@ -132,8 +132,8 @@ address_v4 address_v6::to_v4() const
     asio::detail::throw_exception(ex);
   }
 
-  address_v4::bytes_type v4_bytes = { { addr_.s6_addr[12],
-    addr_.s6_addr[13], addr_.s6_addr[14], addr_.s6_addr[15] } };
+  address_v4::bytes_type v4_bytes = { addr_.s6_addr[12],
+    addr_.s6_addr[13], addr_.s6_addr[14], addr_.s6_addr[15] };
   return address_v4(v4_bytes);
 }
 #endif // !defined(ASIO_NO_DEPRECATED)
@@ -259,16 +259,16 @@ address_v6 address_v6::loopback() ASIO_NOEXCEPT
 address_v6 address_v6::v4_mapped(const address_v4& addr)
 {
   address_v4::bytes_type v4_bytes = addr.to_bytes();
-  bytes_type v6_bytes = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF,
-    v4_bytes[0], v4_bytes[1], v4_bytes[2], v4_bytes[3] } };
+  bytes_type v6_bytes = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF,
+    v4_bytes[0], v4_bytes[1], v4_bytes[2], v4_bytes[3] };
   return address_v6(v6_bytes);
 }
 
 address_v6 address_v6::v4_compatible(const address_v4& addr)
 {
   address_v4::bytes_type v4_bytes = addr.to_bytes();
-  bytes_type v6_bytes = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    v4_bytes[0], v4_bytes[1], v4_bytes[2], v4_bytes[3] } };
+  bytes_type v6_bytes = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    v4_bytes[0], v4_bytes[1], v4_bytes[2], v4_bytes[3] };
   return address_v6(v6_bytes);
 }
 #endif // !defined(ASIO_NO_DEPRECATED)
@@ -328,8 +328,8 @@ address_v4 make_address_v4(
   }
 
   address_v6::bytes_type v6_bytes = v6_addr.to_bytes();
-  address_v4::bytes_type v4_bytes = { { v6_bytes[12],
-    v6_bytes[13], v6_bytes[14], v6_bytes[15] } };
+  address_v4::bytes_type v4_bytes = { v6_bytes[12],
+    v6_bytes[13], v6_bytes[14], v6_bytes[15] };
   return address_v4(v4_bytes);
 }
 
@@ -337,8 +337,8 @@ address_v6 make_address_v6(
     v4_mapped_t, const address_v4& v4_addr)
 {
   address_v4::bytes_type v4_bytes = v4_addr.to_bytes();
-  address_v6::bytes_type v6_bytes = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0xFF, 0xFF, v4_bytes[0], v4_bytes[1], v4_bytes[2], v4_bytes[3] } };
+  address_v6::bytes_type v6_bytes = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0xFF, 0xFF, v4_bytes[0], v4_bytes[1], v4_bytes[2], v4_bytes[3] };
   return address_v6(v6_bytes);
 }
 

--- a/asio/src/examples/cpp03/icmp/ipv4_header.hpp
+++ b/asio/src/examples/cpp03/icmp/ipv4_header.hpp
@@ -68,14 +68,14 @@ public:
   asio::ip::address_v4 source_address() const
   {
     asio::ip::address_v4::bytes_type bytes
-      = { { rep_[12], rep_[13], rep_[14], rep_[15] } };
+      = { rep_[12], rep_[13], rep_[14], rep_[15] };
     return asio::ip::address_v4(bytes);
   }
 
   asio::ip::address_v4 destination_address() const
   {
     asio::ip::address_v4::bytes_type bytes
-      = { { rep_[16], rep_[17], rep_[18], rep_[19] } };
+      = { rep_[16], rep_[17], rep_[18], rep_[19] };
     return asio::ip::address_v4(bytes);
   }
 

--- a/asio/src/examples/cpp03/porthopper/protocol.hpp
+++ b/asio/src/examples/cpp03/porthopper/protocol.hpp
@@ -72,7 +72,7 @@ public:
   boost::array<asio::mutable_buffer, 1> to_buffers()
   {
     boost::array<asio::mutable_buffer, 1> buffers
-      = { { asio::buffer(data_) } };
+      = { asio::buffer(data_) };
     return buffers;
   }
 
@@ -137,7 +137,7 @@ public:
   boost::array<asio::mutable_buffer, 1> to_buffers()
   {
     boost::array<asio::mutable_buffer, 1> buffers
-      = { { asio::buffer(data_) } };
+      = { asio::buffer(data_) };
     return buffers;
   }
 

--- a/asio/src/examples/cpp11/executors/.gitignore
+++ b/asio/src/examples/cpp11/executors/.gitignore
@@ -3,3 +3,5 @@ bank_account_[0-9]
 fork_join
 pipeline
 priority_scheduler
+*.tds
+*.exe

--- a/asio/src/examples/cpp11/executors/fork_join.cpp
+++ b/asio/src/examples/cpp11/executors/fork_join.cpp
@@ -309,7 +309,7 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-  std::vector<double> vec(std::atoll(argv[1]));
+  std::vector<double> vec(std::atoll(argv[1]), 0);
   std::iota(vec.begin(), vec.end(), 0);
 
   std::random_device rd;

--- a/asio/src/examples/cpp11/futures/daytime_client.cpp
+++ b/asio/src/examples/cpp11/futures/daytime_client.cpp
@@ -34,7 +34,7 @@ void get_daytime(asio::io_context& io_context, const char* hostname)
 
     udp::socket socket(io_context, udp::v4());
 
-    std::array<char, 1> send_buf  = {{ 0 }};
+    std::array<char, 1> send_buf  = { 0 };
     std::future<std::size_t> send_length =
       socket.async_send_to(asio::buffer(send_buf),
           *endpoints.get().begin(), // ... until here. This call may block.

--- a/asio/src/examples/cpp11/socks4/socks4.hpp
+++ b/asio/src/examples/cpp11/socks4/socks4.hpp
@@ -56,7 +56,6 @@ public:
   {
     return
     {
-      {
         asio::buffer(&version_, 1),
         asio::buffer(&command_, 1),
         asio::buffer(&port_high_byte_, 1),
@@ -64,7 +63,6 @@ public:
         asio::buffer(address_),
         asio::buffer(user_id_),
         asio::buffer(&null_byte_, 1)
-      }
     };
   }
 
@@ -99,13 +97,11 @@ public:
   {
     return
     {
-      {
         asio::buffer(&null_byte_, 1),
         asio::buffer(&status_, 1),
         asio::buffer(&port_high_byte_, 1),
         asio::buffer(&port_low_byte_, 1),
         asio::buffer(address_)
-      }
     };
   }
 

--- a/asio/src/examples/cpp14/executors/.gitignore
+++ b/asio/src/examples/cpp14/executors/.gitignore
@@ -4,3 +4,5 @@ bank_account_[0-9]
 fork_join
 pipeline
 priority_scheduler
+*.tds
+*.exe

--- a/asio/src/examples/cpp14/executors/fork_join.cpp
+++ b/asio/src/examples/cpp14/executors/fork_join.cpp
@@ -308,7 +308,7 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-  std::vector<double> vec(std::atoll(argv[1]));
+  std::vector<double> vec(std::atoll(argv[1]), 0);
   std::iota(vec.begin(), vec.end(), 0);
 
   std::random_device rd;

--- a/asio/src/tests/unit/buffer.cpp
+++ b/asio/src/tests/unit/buffer.cpp
@@ -48,12 +48,12 @@ void test()
 #if defined(ASIO_HAS_BOOST_ARRAY)
     boost::array<char, 1024> array_data;
     const boost::array<char, 1024>& const_array_data_1 = array_data;
-    boost::array<const char, 1024> const_array_data_2 = { { 0 } };
+    boost::array<const char, 1024> const_array_data_2 = { 0 };
 #endif // defined(ASIO_HAS_BOOST_ARRAY)
 #if defined(ASIO_HAS_STD_ARRAY)
     std::array<char, 1024> std_array_data;
     const std::array<char, 1024>& const_std_array_data_1 = std_array_data;
-    std::array<const char, 1024> const_std_array_data_2 = { { 0 } };
+    std::array<const char, 1024> const_std_array_data_2 = { 0 };
 #endif // defined(ASIO_HAS_STD_ARRAY)
     std::vector<char> vector_data(1024);
     const std::vector<char>& const_vector_data = vector_data;

--- a/asio/src/tests/unit/buffered_read_stream.cpp
+++ b/asio/src/tests/unit/buffered_read_stream.cpp
@@ -66,12 +66,12 @@ void test_compile()
     io_context ioc;
     char mutable_char_buffer[128] = "";
     const char const_char_buffer[128] = "";
-    array<asio::mutable_buffer, 2> mutable_buffers = {{
+    array<asio::mutable_buffer, 2> mutable_buffers = {
         asio::buffer(mutable_char_buffer, 10),
-        asio::buffer(mutable_char_buffer + 10, 10) }};
-    array<asio::const_buffer, 2> const_buffers = {{
+        asio::buffer(mutable_char_buffer + 10, 10) };
+    array<asio::const_buffer, 2> const_buffers = {
         asio::buffer(const_char_buffer, 10),
-        asio::buffer(const_char_buffer + 10, 10) }};
+        asio::buffer(const_char_buffer + 10, 10) };
     archetypes::lazy_handler lazy;
     asio::error_code ec;
 

--- a/asio/src/tests/unit/buffered_stream.cpp
+++ b/asio/src/tests/unit/buffered_stream.cpp
@@ -70,12 +70,12 @@ void test_compile()
     io_context ioc;
     char mutable_char_buffer[128] = "";
     const char const_char_buffer[128] = "";
-    array<asio::mutable_buffer, 2> mutable_buffers = {{
+    array<asio::mutable_buffer, 2> mutable_buffers = {
         asio::buffer(mutable_char_buffer, 10),
-        asio::buffer(mutable_char_buffer + 10, 10) }};
-    array<asio::const_buffer, 2> const_buffers = {{
+        asio::buffer(mutable_char_buffer + 10, 10) };
+    array<asio::const_buffer, 2> const_buffers = {
         asio::buffer(const_char_buffer, 10),
-        asio::buffer(const_char_buffer + 10, 10) }};
+        asio::buffer(const_char_buffer + 10, 10) };
     archetypes::lazy_handler lazy;
     asio::error_code ec;
 

--- a/asio/src/tests/unit/buffered_write_stream.cpp
+++ b/asio/src/tests/unit/buffered_write_stream.cpp
@@ -66,12 +66,12 @@ void test_compile()
     io_context ioc;
     char mutable_char_buffer[128] = "";
     const char const_char_buffer[128] = "";
-    array<asio::mutable_buffer, 2> mutable_buffers = {{
+    array<asio::mutable_buffer, 2> mutable_buffers = {
         asio::buffer(mutable_char_buffer, 10),
-        asio::buffer(mutable_char_buffer + 10, 10) }};
-    array<asio::const_buffer, 2> const_buffers = {{
+        asio::buffer(mutable_char_buffer + 10, 10) };
+    array<asio::const_buffer, 2> const_buffers = {
         asio::buffer(const_char_buffer, 10),
-        asio::buffer(const_char_buffer + 10, 10) }};
+        asio::buffer(const_char_buffer + 10, 10) };
     archetypes::lazy_handler lazy;
     asio::error_code ec;
 

--- a/asio/src/tests/unit/buffers_iterator.cpp
+++ b/asio/src/tests/unit/buffers_iterator.cpp
@@ -51,11 +51,11 @@ void test()
     char data1[16], data2[16];
     const char cdata1[16] = "", cdata2[16] = "";
     mutable_buffer mb1 = buffer(data1);
-    array<mutable_buffer, 2> mb2 = {{ buffer(data1), buffer(data2) }};
+    array<mutable_buffer, 2> mb2 = { buffer(data1), buffer(data2) };
     std::vector<mutable_buffer> mb3;
     mb3.push_back(buffer(data1));
     const_buffer cb1 = buffer(cdata1);
-    array<const_buffer, 2> cb2 = {{ buffer(cdata1), buffer(cdata2) }};
+    array<const_buffer, 2> cb2 = { buffer(cdata1), buffer(cdata2) };
     vector<const_buffer> cb3;
     cb3.push_back(buffer(cdata1));
 

--- a/asio/src/tests/unit/ip/address_v4.cpp
+++ b/asio/src/tests/unit/ip/address_v4.cpp
@@ -40,7 +40,7 @@ void test()
     // address_v4 constructors.
 
     ip::address_v4 addr1;
-    const ip::address_v4::bytes_type const_bytes_value = { { 127, 0, 0, 1 } };
+    const ip::address_v4::bytes_type const_bytes_value = { 127, 0, 0, 1 };
     ip::address_v4 addr2(const_bytes_value);
     const unsigned long const_ulong_value = 0x7F000001;
     ip::address_v4 addr3(const_ulong_value);
@@ -182,7 +182,7 @@ void test()
   ASIO_CHECK(a1.to_ulong() == 0);
 #endif // !defined(ASIO_NO_DEPRECATED)
 
-  address_v4::bytes_type b1 = {{ 1, 2, 3, 4 }};
+  address_v4::bytes_type b1 = { 1, 2, 3, 4 };
   address_v4 a2(b1);
   ASIO_CHECK(a2.to_bytes()[0] == 1);
   ASIO_CHECK(a2.to_bytes()[1] == 2);

--- a/asio/src/tests/unit/ip/address_v6.cpp
+++ b/asio/src/tests/unit/ip/address_v6.cpp
@@ -40,7 +40,7 @@ void test()
     // address_v6 constructors.
 
     ip::address_v6 addr1;
-    const ip::address_v6::bytes_type const_bytes_value = { { 0 } };
+    const ip::address_v6::bytes_type const_bytes_value = { 0 };
     ip::address_v6 addr2(const_bytes_value);
 
     // address_v6 functions.
@@ -195,8 +195,8 @@ void test()
   ASIO_CHECK(a1.is_unspecified());
   ASIO_CHECK(a1.scope_id() == 0);
 
-  address_v6::bytes_type b1 = {{ 1, 2, 3, 4, 5,
-    6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }};
+  address_v6::bytes_type b1 = { 1, 2, 3, 4, 5,
+    6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
   address_v6 a2(b1, 12345);
   ASIO_CHECK(a2.to_bytes()[0] == 1);
   ASIO_CHECK(a2.to_bytes()[1] == 2);
@@ -221,31 +221,31 @@ void test()
   ASIO_CHECK(a3.scope_id() == 12345);
 
   address_v6 unspecified_address;
-  address_v6::bytes_type loopback_bytes = {{ 0 }};
+  address_v6::bytes_type loopback_bytes = { 0 };
   loopback_bytes[15] = 1;
   address_v6 loopback_address(loopback_bytes);
-  address_v6::bytes_type link_local_bytes = {{ 0xFE, 0x80, 1 }};
+  address_v6::bytes_type link_local_bytes = { 0xFE, 0x80, 1 };
   address_v6 link_local_address(link_local_bytes);
-  address_v6::bytes_type site_local_bytes = {{ 0xFE, 0xC0, 1 }};
+  address_v6::bytes_type site_local_bytes = { 0xFE, 0xC0, 1 };
   address_v6 site_local_address(site_local_bytes);
-  address_v6::bytes_type v4_mapped_bytes = {{ 0 }};
+  address_v6::bytes_type v4_mapped_bytes = { 0 };
   v4_mapped_bytes[10] = 0xFF, v4_mapped_bytes[11] = 0xFF;
   v4_mapped_bytes[12] = 1, v4_mapped_bytes[13] = 2;
   v4_mapped_bytes[14] = 3, v4_mapped_bytes[15] = 4;
   address_v6 v4_mapped_address(v4_mapped_bytes);
-  address_v6::bytes_type v4_compat_bytes = {{ 0 }};
+  address_v6::bytes_type v4_compat_bytes = { 0 };
   v4_compat_bytes[12] = 1, v4_compat_bytes[13] = 2;
   v4_compat_bytes[14] = 3, v4_compat_bytes[15] = 4;
   address_v6 v4_compat_address(v4_compat_bytes);
-  address_v6::bytes_type mcast_global_bytes = {{ 0xFF, 0x0E, 1 }};
+  address_v6::bytes_type mcast_global_bytes = { 0xFF, 0x0E, 1 };
   address_v6 mcast_global_address(mcast_global_bytes);
-  address_v6::bytes_type mcast_link_local_bytes = {{ 0xFF, 0x02, 1 }};
+  address_v6::bytes_type mcast_link_local_bytes = { 0xFF, 0x02, 1 };
   address_v6 mcast_link_local_address(mcast_link_local_bytes);
-  address_v6::bytes_type mcast_node_local_bytes = {{ 0xFF, 0x01, 1 }};
+  address_v6::bytes_type mcast_node_local_bytes = { 0xFF, 0x01, 1 };
   address_v6 mcast_node_local_address(mcast_node_local_bytes);
-  address_v6::bytes_type mcast_org_local_bytes = {{ 0xFF, 0x08, 1 }};
+  address_v6::bytes_type mcast_org_local_bytes = { 0xFF, 0x08, 1 };
   address_v6 mcast_org_local_address(mcast_org_local_bytes);
-  address_v6::bytes_type mcast_site_local_bytes = {{ 0xFF, 0x05, 1 }};
+  address_v6::bytes_type mcast_site_local_bytes = { 0xFF, 0x05, 1 };
   address_v6 mcast_site_local_address(mcast_site_local_bytes);
 
   ASIO_CHECK(!unspecified_address.is_loopback());

--- a/asio/src/tests/unit/ip/tcp.cpp
+++ b/asio/src/tests/unit/ip/tcp.cpp
@@ -220,12 +220,12 @@ void test()
     const io_context::executor_type ioc_ex = ioc.get_executor();
     char mutable_char_buffer[128] = "";
     const char const_char_buffer[128] = "";
-    array<asio::mutable_buffer, 2> mutable_buffers = {{
+    array<asio::mutable_buffer, 2> mutable_buffers = {
         asio::buffer(mutable_char_buffer, 10),
-        asio::buffer(mutable_char_buffer + 10, 10) }};
-    array<asio::const_buffer, 2> const_buffers = {{
+        asio::buffer(mutable_char_buffer + 10, 10) };
+    array<asio::const_buffer, 2> const_buffers = {
         asio::buffer(const_char_buffer, 10),
-        asio::buffer(const_char_buffer + 10, 10) }};
+        asio::buffer(const_char_buffer + 10, 10) };
     socket_base::message_flags in_flags = 0;
     archetypes::settable_socket_option<void> settable_socket_option1;
     archetypes::settable_socket_option<int> settable_socket_option2;

--- a/asio/src/tests/unit/read.cpp
+++ b/asio/src/tests/unit/read.cpp
@@ -2547,9 +2547,9 @@ void test_3_arg_boost_array_buffers_async_read()
   asio::io_context ioc;
   test_stream s(ioc);
   char read_buf[sizeof(read_data)];
-  boost::array<asio::mutable_buffer, 2> buffers = { {
+  boost::array<asio::mutable_buffer, 2> buffers = {
     asio::buffer(read_buf, 32),
-    asio::buffer(read_buf) + 32 } };
+    asio::buffer(read_buf) + 32 };
 
   s.reset(read_data, sizeof(read_data));
   memset(read_buf, 0, sizeof(read_buf));
@@ -2610,9 +2610,9 @@ void test_3_arg_std_array_buffers_async_read()
   asio::io_context ioc;
   test_stream s(ioc);
   char read_buf[sizeof(read_data)];
-  std::array<asio::mutable_buffer, 2> buffers = { {
+  std::array<asio::mutable_buffer, 2> buffers = {
     asio::buffer(read_buf, 32),
-    asio::buffer(read_buf) + 32 } };
+    asio::buffer(read_buf) + 32 };
 
   s.reset(read_data, sizeof(read_data));
   memset(read_buf, 0, sizeof(read_buf));
@@ -3205,9 +3205,9 @@ void test_4_arg_boost_array_buffers_async_read()
   asio::io_context ioc;
   test_stream s(ioc);
   char read_buf[sizeof(read_data)];
-  boost::array<asio::mutable_buffer, 2> buffers = { {
+  boost::array<asio::mutable_buffer, 2> buffers = {
     asio::buffer(read_buf, 32),
-    asio::buffer(read_buf) + 32 } };
+    asio::buffer(read_buf) + 32 };
 
   s.reset(read_data, sizeof(read_data));
   memset(read_buf, 0, sizeof(read_buf));
@@ -3549,9 +3549,9 @@ void test_4_arg_std_array_buffers_async_read()
   asio::io_context ioc;
   test_stream s(ioc);
   char read_buf[sizeof(read_data)];
-  std::array<asio::mutable_buffer, 2> buffers = { {
+  std::array<asio::mutable_buffer, 2> buffers = {
     asio::buffer(read_buf, 32),
-    asio::buffer(read_buf) + 32 } };
+    asio::buffer(read_buf) + 32 };
 
   s.reset(read_data, sizeof(read_data));
   memset(read_buf, 0, sizeof(read_buf));

--- a/asio/src/tests/unit/read_at.cpp
+++ b/asio/src/tests/unit/read_at.cpp
@@ -3544,9 +3544,9 @@ void test_4_arg_boost_array_buffers_async_read_at()
   asio::io_context ioc;
   test_random_access_device s(ioc);
   char read_buf[sizeof(read_data)];
-  boost::array<asio::mutable_buffer, 2> buffers = { {
+  boost::array<asio::mutable_buffer, 2> buffers = {
     asio::buffer(read_buf, 32),
-    asio::buffer(read_buf) + 32 } };
+    asio::buffer(read_buf) + 32 };
 
   s.reset(read_data, sizeof(read_data));
   memset(read_buf, 0, sizeof(read_buf));
@@ -3643,9 +3643,9 @@ void test_4_arg_std_array_buffers_async_read_at()
   asio::io_context ioc;
   test_random_access_device s(ioc);
   char read_buf[sizeof(read_data)];
-  std::array<asio::mutable_buffer, 2> buffers = { {
+  std::array<asio::mutable_buffer, 2> buffers = {
     asio::buffer(read_buf, 32),
-    asio::buffer(read_buf) + 32 } };
+    asio::buffer(read_buf) + 32 };
 
   s.reset(read_data, sizeof(read_data));
   memset(read_buf, 0, sizeof(read_buf));
@@ -4637,9 +4637,9 @@ void test_5_arg_boost_array_buffers_async_read_at()
   asio::io_context ioc;
   test_random_access_device s(ioc);
   char read_buf[sizeof(read_data)];
-  boost::array<asio::mutable_buffer, 2> buffers = { {
+  boost::array<asio::mutable_buffer, 2> buffers = {
     asio::buffer(read_buf, 32),
-    asio::buffer(read_buf) + 32 } };
+    asio::buffer(read_buf) + 32 };
 
   s.reset(read_data, sizeof(read_data));
   memset(read_buf, 0, sizeof(read_buf));
@@ -5338,9 +5338,9 @@ void test_5_arg_std_array_buffers_async_read_at()
   asio::io_context ioc;
   test_random_access_device s(ioc);
   char read_buf[sizeof(read_data)];
-  std::array<asio::mutable_buffer, 2> buffers = { {
+  std::array<asio::mutable_buffer, 2> buffers = {
     asio::buffer(read_buf, 32),
-    asio::buffer(read_buf) + 32 } };
+    asio::buffer(read_buf) + 32 };
 
   s.reset(read_data, sizeof(read_data));
   memset(read_buf, 0, sizeof(read_buf));

--- a/asio/src/tests/unit/unit_test.hpp
+++ b/asio/src/tests/unit/unit_test.hpp
@@ -19,7 +19,7 @@
 # include <stdlib.h> // Needed for lrand48.
 #endif // defined(__sun)
 
-#if defined(__BORLANDC__)
+#if defined(__BORLANDC__) && !defined(__clang__)
 
 // Prevent use of intrinsic for strcmp.
 # include <cstring>
@@ -28,7 +28,7 @@
 // Suppress error about condition always being true.
 # pragma option -w-ccc
 
-#endif // defined(__BORLANDC__)
+#endif // defined(__BORLANDC__) && !defined(__clang__)
 
 #if defined(ASIO_MSVC)
 # pragma warning (disable:4127)

--- a/asio/src/tests/unit/write.cpp
+++ b/asio/src/tests/unit/write.cpp
@@ -2294,9 +2294,9 @@ void test_3_arg_boost_array_buffers_async_write()
 #if defined(ASIO_HAS_BOOST_ARRAY)
   asio::io_context ioc;
   test_stream s(ioc);
-  boost::array<asio::const_buffer, 2> buffers = { {
+  boost::array<asio::const_buffer, 2> buffers = {
     asio::buffer(write_data, 32),
-    asio::buffer(write_data) + 32 } };
+    asio::buffer(write_data) + 32 };
 
   s.reset();
   bool called = false;
@@ -2352,9 +2352,9 @@ void test_3_arg_std_array_buffers_async_write()
 #if defined(ASIO_HAS_STD_ARRAY)
   asio::io_context ioc;
   test_stream s(ioc);
-  std::array<asio::const_buffer, 2> buffers = { {
+  std::array<asio::const_buffer, 2> buffers = {
     asio::buffer(write_data, 32),
-    asio::buffer(write_data) + 32 } };
+    asio::buffer(write_data) + 32 };
 
   s.reset();
   bool called = false;
@@ -3220,9 +3220,9 @@ void test_4_arg_boost_array_buffers_async_write()
 #if defined(ASIO_HAS_BOOST_ARRAY)
   asio::io_context ioc;
   test_stream s(ioc);
-  boost::array<asio::const_buffer, 2> buffers = { {
+  boost::array<asio::const_buffer, 2> buffers = {
     asio::buffer(write_data, 32),
-    asio::buffer(write_data) + 32 } };
+    asio::buffer(write_data) + 32 };
 
   s.reset();
   bool called = false;
@@ -3535,9 +3535,9 @@ void test_4_arg_std_array_buffers_async_write()
 #if defined(ASIO_HAS_STD_ARRAY)
   asio::io_context ioc;
   test_stream s(ioc);
-  std::array<asio::const_buffer, 2> buffers = { {
+  std::array<asio::const_buffer, 2> buffers = {
     asio::buffer(write_data, 32),
-    asio::buffer(write_data) + 32 } };
+    asio::buffer(write_data) + 32 };
 
   s.reset();
   bool called = false;

--- a/asio/src/tests/unit/write_at.cpp
+++ b/asio/src/tests/unit/write_at.cpp
@@ -3156,9 +3156,9 @@ void test_4_arg_boost_array_buffers_async_write_at()
 #if defined(ASIO_HAS_BOOST_ARRAY)
   asio::io_context ioc;
   test_random_access_device s(ioc);
-  boost::array<asio::const_buffer, 2> buffers = { {
+  boost::array<asio::const_buffer, 2> buffers = {
     asio::buffer(write_data, 32),
-    asio::buffer(write_data) + 32 } };
+    asio::buffer(write_data) + 32 };
 
   s.reset();
   bool called = false;
@@ -3258,9 +3258,9 @@ void test_4_arg_std_array_buffers_async_write_at()
 #if defined(ASIO_HAS_STD_ARRAY)
   asio::io_context ioc;
   test_random_access_device s(ioc);
-  std::array<asio::const_buffer, 2> buffers = { {
+  std::array<asio::const_buffer, 2> buffers = {
     asio::buffer(write_data, 32),
-    asio::buffer(write_data) + 32 } };
+    asio::buffer(write_data) + 32 };
 
   s.reset();
   bool called = false;
@@ -4860,9 +4860,9 @@ void test_5_arg_boost_array_buffers_async_write_at()
 #if defined(ASIO_HAS_BOOST_ARRAY)
   asio::io_context ioc;
   test_random_access_device s(ioc);
-  boost::array<asio::const_buffer, 2> buffers = { {
+  boost::array<asio::const_buffer, 2> buffers = {
     asio::buffer(write_data, 32),
-    asio::buffer(write_data) + 32 } };
+    asio::buffer(write_data) + 32 };
 
   s.reset();
   bool called = false;
@@ -5505,9 +5505,9 @@ void test_5_arg_std_array_buffers_async_write_at()
 #if defined(ASIO_HAS_STD_ARRAY)
   asio::io_context ioc;
   test_random_access_device s(ioc);
-  std::array<asio::const_buffer, 2> buffers = { {
+  std::array<asio::const_buffer, 2> buffers = {
     asio::buffer(write_data, 32),
-    asio::buffer(write_data) + 32 } };
+    asio::buffer(write_data) + 32 };
 
   s.reset();
   bool called = false;


### PR DESCRIPTION
Fix several build issues with [Embarcadero C++Builder v10.3.2 Community Edition](https://www.embarcadero.com/products/cbuilder/starter). I managed to use the existing Autotools-based build system inside a MSYS2 (mingw64) window using the [`bcc32x.exe` frontend](https://community.idera.com/developer-tools/b/blog/posts/new-in-c-builder-10-2-3-a-new-win32-compiler-front-end-bcc32x) (it helpfully has a Clang-like command-line interface):

```bash
$ cd asio
$ ./autogen.sh
$ TMP=`pwd` \
    MAKE=mingw32-make \
    CC="bcc32x.exe -q -x c" \
    CXX="bcc32x.exe -q" \
    CPPFLAGS="-tMR -DASIO_DISABLE_NOEXCEPT -D_WIN32_WINNT=0x0601 -Wno-unused-command-line-argument" \
    LDFLAGS="-tMR -Wno-unused-command-line-argument" \
    ./configure --disable-dependency-tracking
$ TMP=`pwd` mingw32-make -kj `nproc` check
```

It's mostly working, except for a couple of issues that may be C++Builder's fault, so I haven't worked around them here:

 - In `asio/src/examples/cpp1{1,4}/echo/blocking_tcp_echo_server.cpp`, the return value of `a.accept()` (i.e. a `tcp::socket`) cannot be moved into the `std::thread` constructor. The compiler complains that `tcp::socket` is implicitly non-copy-constructible -- due to there being a user-defined move-constructor. (I managed to make it compile by changing the `session()` function to have a reference parameter and using `std::ref()` at the `std::thread` construction, but that would invoke UB at runtime.)

 - The `unit/use_future.exe` test is failing, with this in the logfile:
```
FAIL: unit/use_future
=====================

use_future test suite begins
unit\use_future.cpp(65): use_future_0_test: check 'false' failed
unit\use_future.cpp(82): use_future_0_test: check 'false' failed
use_future_0_test failed
unit\use_future.cpp(136): use_future_1_test: check 'false' failed
unit\use_future.cpp(154): use_future_1_test: check 'false' failed
use_future_1_test failed
unit\use_future.cpp(215): use_future_2_test: check 'false' failed
unit\use_future.cpp(236): use_future_2_test: check 'false' failed
use_future_2_test failed
unit\use_future.cpp(301): use_future_3_test: check 'false' failed
unit\use_future.cpp(324): use_future_3_test: check 'false' failed
use_future_3_test failed
unit\use_future.cpp(407): use_future_package_0_test: check 'i == 0' failed
use_future_package_0_test failed
use_future_package_1_test passed
use_future_package_2_test passed
use_future_package_3_test passed
use_future test suite ends

*** 9 errors detected.

FAIL unit/use_future.exe (exit status: 1)
```

The usual build with `g++` still works correctly with these changes.

Obsoletes: boostorg/asio#210