### PR TITLE
Call {shutdown,destroy} on priority_scheduler destruction

### DIFF
--- a/asio/src/examples/cpp14/executors/priority_scheduler.cpp
+++ b/asio/src/examples/cpp14/executors/priority_scheduler.cpp
@@ -78,6 +78,12 @@ public:
     int priority_;
   };
 
+  ~priority_scheduler() noexcept
+  {
+    shutdown();
+    destroy();
+  }
+
   executor_type get_executor(int pri = 0) noexcept
   {
     return executor_type(*const_cast<priority_scheduler*>(this), pri);


### PR DESCRIPTION
This makes example of custom execution context more completed and allows easy reuse in real-world application. As it's quite uneasy to understand why application crashes after move from asio::io_context to custom execution context.