### PR TITLE
Start handler work again in case of restarting accept operation

### DIFF
--- a/asio/include/asio/detail/win_iocp_socket_accept_op.hpp
+++ b/asio/include/asio/detail/win_iocp_socket_accept_op.hpp
@@ -99,6 +99,7 @@ public:
       if (ec == asio::error::connection_aborted
           && !o->enable_connection_aborted_)
       {
+        handler_work<Handler, IoExecutor>::start(o->handler_, o->io_executor_);
         o->reset();
         o->socket_service_.restart_accept_op(o->socket_,
             o->new_socket_, o->protocol_.family(),
@@ -228,6 +229,7 @@ public:
       if (ec == asio::error::connection_aborted
           && !o->enable_connection_aborted_)
       {
+        handler_work<Handler, IoExecutor>::start(o->handler_, o->io_executor_);
         o->reset();
         o->socket_service_.restart_accept_op(o->socket_,
             o->new_socket_, o->protocol_.family(),


### PR DESCRIPTION
When connection is aborted during accept operation, before restart_accept_op() handler_work should be restarted also. In other case win_iocp_io_context.outstanding_work_ is not incremented as it should be.