### PR TITLE
rfc2818 validation

### DIFF
--- a/asio/include/asio/ssl/impl/rfc2818_verification.ipp
+++ b/asio/include/asio/ssl/impl/rfc2818_verification.ipp
@@ -22,6 +22,7 @@
 #include "asio/ip/address.hpp"
 #include "asio/ssl/rfc2818_verification.hpp"
 #include "asio/ssl/detail/openssl_types.hpp"
+#include <openssl/x509.h>
 
 #include "asio/detail/push_options.hpp"
 
@@ -46,110 +47,21 @@ bool rfc2818_verification::operator()(
   // need to look for an IP address in the certificate rather than a host name.
   asio::error_code ec;
   ip::address address = ip::make_address(host_, ec);
-  bool is_address = !ec;
+  bool const is_address = !ec;
 
   X509* cert = X509_STORE_CTX_get_current_cert(ctx.native_handle());
 
-  // Go through the alternate names in the certificate looking for matching DNS
-  // or IP address entries.
-  GENERAL_NAMES* gens = static_cast<GENERAL_NAMES*>(
-      X509_get_ext_d2i(cert, NID_subject_alt_name, 0, 0));
-  for (int i = 0; i < sk_GENERAL_NAME_num(gens); ++i)
+  if (is_address)
   {
-    GENERAL_NAME* gen = sk_GENERAL_NAME_value(gens, i);
-    if (gen->type == GEN_DNS && !is_address)
-    {
-      ASN1_IA5STRING* domain = gen->d.dNSName;
-      if (domain->type == V_ASN1_IA5STRING && domain->data && domain->length)
-      {
-        const char* pattern = reinterpret_cast<const char*>(domain->data);
-        std::size_t pattern_length = domain->length;
-        if (match_pattern(pattern, pattern_length, host_.c_str()))
-        {
-          GENERAL_NAMES_free(gens);
-          return true;
-        }
-      }
-    }
-    else if (gen->type == GEN_IPADD && is_address)
-    {
-      ASN1_OCTET_STRING* ip_address = gen->d.iPAddress;
-      if (ip_address->type == V_ASN1_OCTET_STRING && ip_address->data)
-      {
-        if (address.is_v4() && ip_address->length == 4)
-        {
-          ip::address_v4::bytes_type bytes = address.to_v4().to_bytes();
-          if (memcmp(bytes.data(), ip_address->data, 4) == 0)
-          {
-            GENERAL_NAMES_free(gens);
-            return true;
-          }
-        }
-        else if (address.is_v6() && ip_address->length == 16)
-        {
-          ip::address_v6::bytes_type bytes = address.to_v6().to_bytes();
-          if (memcmp(bytes.data(), ip_address->data, 16) == 0)
-          {
-            GENERAL_NAMES_free(gens);
-            return true;
-          }
-        }
-      }
-    }
+  	return X509_check_ip_asc(cert, host_.c_str(), 0) == 1;
   }
-  GENERAL_NAMES_free(gens);
-
-  // No match in the alternate names, so try the common names. We should only
-  // use the "most specific" common name, which is the last one in the list.
-  X509_NAME* name = X509_get_subject_name(cert);
-  int i = -1;
-  ASN1_STRING* common_name = 0;
-  while ((i = X509_NAME_get_index_by_NID(name, NID_commonName, i)) >= 0)
+  else
   {
-    X509_NAME_ENTRY* name_entry = X509_NAME_get_entry(name, i);
-    common_name = X509_NAME_ENTRY_get_data(name_entry);
+	char* peername = nullptr;
+  	int const ret = X509_check_host(cert, host_.c_str(), host_.size(), 0, &peername);
+	OPENSSL_free(peername);
+	return ret == 1;
   }
-  if (common_name && common_name->data && common_name->length)
-  {
-    const char* pattern = reinterpret_cast<const char*>(common_name->data);
-    std::size_t pattern_length = common_name->length;
-    if (match_pattern(pattern, pattern_length, host_.c_str()))
-      return true;
-  }
-
-  return false;
-}
-
-bool rfc2818_verification::match_pattern(const char* pattern,
-    std::size_t pattern_length, const char* host)
-{
-  using namespace std; // For tolower.
-
-  const char* p = pattern;
-  const char* p_end = p + pattern_length;
-  const char* h = host;
-
-  while (p != p_end && *h)
-  {
-    if (*p == '*')
-    {
-      ++p;
-      while (*h && *h != '.')
-        if (match_pattern(p, p_end - p, h++))
-          return true;
-    }
-    else if (tolower(*p) == tolower(*h))
-    {
-      ++p;
-      ++h;
-    }
-    else
-    {
-      return false;
-    }
-  }
-
-  return p == p_end && !*h;
 }
 
 } // namespace ssl

--- a/asio/include/asio/ssl/rfc2818_verification.hpp
+++ b/asio/include/asio/ssl/rfc2818_verification.hpp
@@ -73,9 +73,6 @@ public:
   ASIO_DECL bool operator()(bool preverified, verify_context& ctx) const;
 
 private:
-  // Helper function to check a host name against a pattern.
-  ASIO_DECL static bool match_pattern(const char* pattern,
-      std::size_t pattern_length, const char* host);
 
   // Helper function to check a host name against an IPv4 address
   // The host name to be checked.


### PR DESCRIPTION
instead of implementing certificate hostname pattern matching in rfc2818_verification, rely on X509_check_ip_asc and X509_check_host from openssl.

As far as I can tell, this requires openssl 1.0.2 ( [docs](https://www.openssl.org/docs/man1.0.2/man3/X509_check_host.html) )