### PR TITLE
Fix unit test for is_*_buffer_sequence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,21 @@ matrix:
         - MATRIX_EVAL="CC=gcc-6 CXX=g++-6"
       compiler: gcc
     #
+    # Linux / g++-6 / -O2 / standalone / decltype disabled
+    #
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - CXXFLAGS="-Wall -Wextra -O2 -DASIO_DISABLE_DECLTYPE"
+        - CONFIGFLAGS="--with-boost=no"
+        - MATRIX_EVAL="CC=gcc-6 CXX=g++-6"
+      compiler: gcc
+    #
     # Linux / g++-6 / -O0 / standalone / handler tracking
     #
     - os: linux

--- a/asio/src/tests/unit/buffer.cpp
+++ b/asio/src/tests/unit/buffer.cpp
@@ -616,6 +616,12 @@ struct valid_mutable_a
   mutable_buffer* end() { return 0; }
 };
 
+void check_valid_mutable_a()
+{
+  valid_mutable_a x;
+  buffer_sequence_begin(x);
+}
+
 #if defined(ASIO_HAS_DECLTYPE)
 struct valid_mutable_b
 {

--- a/asio/src/tests/unit/buffer.cpp
+++ b/asio/src/tests/unit/buffer.cpp
@@ -612,8 +612,8 @@ struct valid_mutable_a
 {
   typedef mutable_buffer* const_iterator;
   typedef mutable_buffer value_type;
-  mutable_buffer* begin() { return 0; }
-  mutable_buffer* end() { return 0; }
+  mutable_buffer* begin() const { return 0; }
+  mutable_buffer* end() const { return 0; }
 };
 
 void check_valid_mutable_a()


### PR DESCRIPTION
The following causes a compiler error when `ASIO_DISABLE_DECLTYPE` is defined (or when `decltype` is unavailable):

	valid_mutable_a x;
	buffer_sequence_begin(x);

Here `valid_mutable_a` is a type defined in the unit test and approved by `is_const_buffer_sequence` and `is_mutable_buffer_sequence` templates.