### PR TITLE
Add ssl::context constructor from native type (SSL_CTX*)

### DIFF
--- a/asio/include/asio/ssl/context.hpp
+++ b/asio/include/asio/ssl/context.hpp
@@ -42,6 +42,9 @@ public:
 
   /// Constructor.
   ASIO_DECL explicit context(method m);
+  
+  /// Constructor from native type
+  ASIO_DECL explicit context(SSL_CTX* ctx);
 
 #if defined(ASIO_HAS_MOVE) || defined(GENERATING_DOCUMENTATION)
   /// Move-construct a context from another.

--- a/asio/include/asio/ssl/impl/context.ipp
+++ b/asio/include/asio/ssl/impl/context.ipp
@@ -365,6 +365,11 @@ context::context(context::method m)
 
   set_options(no_compression);
 }
+  
+context::context(SSL_CTX* ctx): handle_(ctx) {
+  if (!ctx) asio::detail::throw_error(
+        asio::error::invalid_argument, "context");
+}
 
 #if defined(ASIO_HAS_MOVE) || defined(GENERATING_DOCUMENTATION)
 context::context(context&& other)


### PR DESCRIPTION
// context.hpp

context(SSL_CTX* ctx)

// context.ipp

context::context(SSL_CTX* ctx): handle_(ctx) {
  if (!ctx) asio::detail::throw_error(
        asio::error::invalid_argument, "context");
}