### PR TITLE
Fixed bug of async_read_until not completing immediately

### DIFF
--- a/asio/include/asio/impl/read_until.hpp
+++ b/asio/include/asio/impl/read_until.hpp
@@ -1118,6 +1118,7 @@ namespace detail
               // Full match. We're done.
               search_position_ = result.first - begin + delim_.length();
               bytes_to_read = 0;
+              start = 0;
             }
 
             // No match yet. Check if buffer is full.


### PR DESCRIPTION
Fixed bug of async_read_until not completing immediately when a provided `streambuf` already contains the delimiter.