### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/asio/src/doc/using.qbk
+++ b/asio/src/doc/using.qbk
@@ -110,6 +110,17 @@ following steps in a Command Prompt window:
 * Execute the command `nmake -f Makefile.msc check` to run a suite of tests to
   confirm that asio is working correctly.
 
+Alternatively, you can build and install asio using vcpkg dependency manager:
+
+  git clone https://github.com/Microsoft/vcpkg.git
+  cd vcpkg
+  ./bootstrap-vcpkg.sh
+  ./vcpkg integrate install
+  ./vcpkg install asio
+
+The asio port in vcpkg is kept up to date by microsoft team members and community contributors.
+If the version is out of date, please create an issue or pull request on the vcpkg repository.
+
 [heading Building the tests and examples with MinGW]
 
 To build using the MinGW g++ compiler from the command line, perform the


### PR DESCRIPTION
asio is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build asio, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for asio and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.
