### PR TITLE
Return on unfinished connect() of non-blocking socket

### DIFF
--- a/asio/include/asio/detail/impl/socket_ops.ipp
+++ b/asio/include/asio/detail/impl/socket_ops.ipp
@@ -490,13 +490,16 @@ int connect(socket_type s, const socket_addr_type* addr,
   return result;
 }
 
-void sync_connect(socket_type s, const socket_addr_type* addr,
+void sync_connect(socket_type s, state_type state, const socket_addr_type* addr,
     std::size_t addrlen, asio::error_code& ec)
 {
   // Perform the connect operation.
   socket_ops::connect(s, addr, addrlen, ec);
-  if (ec != asio::error::in_progress
-      && ec != asio::error::would_block)
+
+  // If the user wants non-blocking behaviour, give it to them.
+  if ((state & user_set_non_blocking)
+      || (ec != asio::error::would_block
+          && ec != asio::error::in_progress))
   {
     // The connect operation finished immediately.
     return;

--- a/asio/include/asio/detail/reactive_socket_service.hpp
+++ b/asio/include/asio/detail/reactive_socket_service.hpp
@@ -466,7 +466,7 @@ public:
   asio::error_code connect(implementation_type& impl,
       const endpoint_type& peer_endpoint, asio::error_code& ec)
   {
-    socket_ops::sync_connect(impl.socket_,
+    socket_ops::sync_connect(impl.socket_, impl.state_,
         peer_endpoint.data(), peer_endpoint.size(), ec);
     return ec;
   }

--- a/asio/include/asio/detail/socket_ops.hpp
+++ b/asio/include/asio/detail/socket_ops.hpp
@@ -103,7 +103,8 @@ ASIO_DECL int shutdown(socket_type s,
 ASIO_DECL int connect(socket_type s, const socket_addr_type* addr,
     std::size_t addrlen, asio::error_code& ec);
 
-ASIO_DECL void sync_connect(socket_type s, const socket_addr_type* addr,
+ASIO_DECL void sync_connect(socket_type s, state_type state,
+    const socket_addr_type* addr,
     std::size_t addrlen, asio::error_code& ec);
 
 #if defined(ASIO_HAS_IOCP)

--- a/asio/include/asio/detail/win_iocp_socket_service.hpp
+++ b/asio/include/asio/detail/win_iocp_socket_service.hpp
@@ -545,7 +545,7 @@ public:
   asio::error_code connect(implementation_type& impl,
       const endpoint_type& peer_endpoint, asio::error_code& ec)
   {
-    socket_ops::sync_connect(impl.socket_,
+    socket_ops::sync_connect(impl.socket_, impl.state_,
         peer_endpoint.data(), peer_endpoint.size(), ec);
     return ec;
   }


### PR DESCRIPTION
When a socket is set to be non-blocking with `socket.non_blocking(true)`, its synchronous functions such as `read()` or `write()` return `would_block` or `try_again`.  This seems to be true for all of the functions I've encountered, plus others like `accept()` on an acceptor.  This behaviour is useful when you need to separately wait on the socket (with ASIO or even directly with the native handle).  For example, makes it possible to interoperate with code that cannot easily be made to use ASIO.

It seems, though, that `connect()` will always block until the connection operation completes before returning.  So, if you have a socket on which you've set `non_blocking(true)`, it blocks when you `connect()` it.  This isn't as useful, because if you find yourself in a situation where you need to externally wait, you can't.

Comparing the implementation of the functions that return `would_block` with that of `connect()`, I found that the check of the `user_set_non_blocking` flag seems to be missing, perhaps as an oversight.  Adding the check produces the useful behaviour: `connect()` returns `would_block` and you can externally wait for the socket to be writable, and makes `connect()` behave like the other non-`async_` functions.  If, instead, you want `connect()` to block until the operation completes, you can set `non_blocking(false)` on the socket and get that behaviour.

This patch makes `connect()` return without blocking on non-blocking sockets.  The existing `make check` tests all pass (on Linux) with this change.  Perhaps a new test is warranted, but I thought it was better to share this and get feedback before writing one.

Thanks!