### PR TITLE
address valgrind false-positive warnings

### DIFF
--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -1819,4 +1819,12 @@
 # define ASIO_NODISCARD
 #endif // !defined(ASIO_NODISCARD)
 
+// Turn off valgrind false-positive warnings when branching on uninitialized data
+#if defined(HAVE_VALGRIND)
+#include <valgrind/memcheck.h>
+#define ASIO_MAKE_MEM_DEFINED(addr, len) VALGRIND_MAKE_MEM_DEFINED(addr, len)
+#else
+#define ASIO_MAKE_MEM_DEFINED(addr, len)
+#endif // defined(HAVE_VALGRIND)
+
 #endif // ASIO_DETAIL_CONFIG_HPP

--- a/asio/include/asio/detail/thread_info_base.hpp
+++ b/asio/include/asio/detail/thread_info_base.hpp
@@ -58,6 +58,9 @@ public:
 #endif // defined(ASIO_HAS_STD_EXCEPTION_PTR)
        // && !defined(ASIO_NO_EXCEPTIONS)
   {
+    // avoid valgrind warning for branching on uninitialized data
+    ASIO_MAKE_MEM_DEFINED(reusable_memory_, sizeof(reusable_memory_));
+
     for (int i = 0; i < max_mem_index; ++i)
     {
       // The following test for non-null pointers is technically redundant, but


### PR DESCRIPTION
Added ASIO_MAKE_MEM_DEFINED macro to turn off valgrind false-positive
warnings when branching on uninitialized data.

Signed-off-by: James Yonan <james@openvpn.net>