### PR TITLE
Reduce lock contention for cancel_timer

### DIFF
--- a/asio/include/asio/detail/impl/win_iocp_io_context.hpp
+++ b/asio/include/asio/detail/impl/win_iocp_io_context.hpp
@@ -76,6 +76,7 @@ std::size_t win_iocp_io_context::cancel_timer(timer_queue<Time_Traits>& queue,
   mutex::scoped_lock lock(dispatch_mutex_);
   op_queue<win_iocp_operation> ops;
   std::size_t n = queue.cancel_timer(timer, ops, max_cancelled);
+  lock.unlock(); // reduce contention on global lock
   post_deferred_completions(ops);
   return n;
 }


### PR DESCRIPTION
Lock should not be held while executing post_deferred_completions.
The unlock call is present everywhere (in all implementations, including in this file) except in this function.
Lock contention has been observed via Windows Performance Analyzer:

ntdll.dll!RtlpWaitOnCriticalSection
ntdll.dll!RtlpEnterCriticalSectionContended
ntdll.dll!RtlEnterCriticalSection
IxServer.exe!boost::asio::detail::win_iocp_io_context::cancel_timer<boost::asio::detail::chrono_time_traits<boost::chrono::steady_clock,boost::asio::wait_traits<boost::chrono::steady_clock> > >
IxServer.exe!boost::asio::detail::deadline_timer_service<boost::asio::detail::chrono_time_traits<boost::chrono::steady_clock,boost::asio::wait_traits<boost::chrono::steady_clock> > >::expires_at