### PR TITLE
Enable ASIO builds without RTTI post 1.17.0

### DIFF
--- a/asio/include/asio/execution/any_executor.hpp
+++ b/asio/include/asio/execution/any_executor.hpp
@@ -619,7 +619,11 @@ public:
     return static_cast<Executor*>(target_);
   }
 
+#if !defined(ASIO_NO_TYPEID)
   const std::type_info& target_type() const
+#else // !defined(ASIO_NO_TYPEID)
+  const void* target_type() const
+#endif // !defined(ASIO_NO_TYPEID)
   {
     return target_fns_->target_type();
   }
@@ -799,16 +803,27 @@ protected:
 
   struct target_fns
   {
+#if !defined(ASIO_NO_TYPEID)
     const std::type_info& (*target_type)();
+#else // !defined(ASIO_NO_TYPEID)
+    const void* (*target_type)();
+#endif // !defined(ASIO_NO_TYPEID)
     bool (*equal)(const any_executor_base&, const any_executor_base&);
     void (*execute)(const any_executor_base&, ASIO_MOVE_ARG(function));
     void (*blocking_execute)(const any_executor_base&, function_view);
   };
 
+#if !defined(ASIO_NO_TYPEID)
   static const std::type_info& target_type_void()
   {
     return typeid(void);
   }
+#else // !defined(ASIO_NO_TYPEID)
+  static const void* target_type_void()
+  {
+    return 0;
+  }
+#endif // !defined(ASIO_NO_TYPEID)
 
   static bool equal_void(const any_executor_base&, const any_executor_base&)
   {
@@ -844,11 +859,19 @@ protected:
     return &fns;
   }
 
+#if !defined(ASIO_NO_TYPEID)
   template <typename Ex>
   static const std::type_info& target_type_ex()
   {
     return typeid(Ex);
   }
+#else // !defined(ASIO_NO_TYPEID)
+  template <typename Ex>
+  static const void* target_type_ex()
+  {
+    return Ex::type_id();
+  }
+#endif // !defined(ASIO_NO_TYPEID)
 
   template <typename Ex>
   static bool equal_ex(const any_executor_base& ex1,

--- a/asio/include/asio/io_context.hpp
+++ b/asio/include/asio/io_context.hpp
@@ -713,6 +713,18 @@ public:
       basic_executor_type&& other) ASIO_NOEXCEPT;
 #endif // defined(ASIO_HAS_MOVE) || defined(GENERATING_DOCUMENTATION)
 
+#if !defined(ASIO_NO_TYPEID)
+  static const std::type_info& type_id()
+  {
+    return typeid(basic_executor_type);
+#else // !defined(ASIO_NO_TYPEID)
+  static const void* type_id()
+  {
+    static int unique_id;
+    return &unique_id;
+#endif // !defined(ASIO_NO_TYPEID)
+  }
+
   /// Obtain an executor with the @c blocking.possibly property.
   /**
    * Do not call this function directly. It is intended for use with the


### PR DESCRIPTION
Fixes compilation issues for systems without RTTI support. Though ASIO has `ASIO_NO_TYPEID` define, it hasn't been used e.g. in commit 6505157d2eef35dc5909b8c7c92c9c26f922f429.

Fixes https://github.com/chriskohlhoff/asio/issues/533.