### PR TITLE
Pass MSG_NOSIGNAL to sendmsg on OpenBSD

### DIFF
--- a/asio/include/asio/detail/impl/socket_ops.ipp
+++ b/asio/include/asio/detail/impl/socket_ops.ipp
@@ -1387,9 +1387,9 @@ signed_size_type send(socket_type s, const buf* bufs, size_t count,
   msghdr msg = msghdr();
   msg.msg_iov = const_cast<buf*>(bufs);
   msg.msg_iovlen = static_cast<int>(count);
-#if defined(__linux__)
+#if defined(__linux__) || defined(__OpenBSD__)
   flags |= MSG_NOSIGNAL;
-#endif // defined(__linux__)
+#endif // defined(__linux__) || defined(__OpenBSD__)
   signed_size_type result = ::sendmsg(s, &msg, flags);
   get_last_error(ec, result < 0);
   return result;
@@ -1418,9 +1418,9 @@ signed_size_type send1(socket_type s, const void* data, size_t size,
   ec.assign(0, ec.category());
   return bytes_transferred;
 #else // defined(ASIO_WINDOWS) || defined(__CYGWIN__)
-#if defined(__linux__)
+#if defined(__linux__) || defined(__OpenBSD__)
   flags |= MSG_NOSIGNAL;
-#endif // defined(__linux__)
+#endif // defined(__linux__) || defined(__OpenBSD__)
   signed_size_type result = ::send(s,
       static_cast<const char*>(data), size, flags);
   get_last_error(ec, result < 0);
@@ -1616,9 +1616,9 @@ signed_size_type sendto(socket_type s, const buf* bufs, size_t count,
   msg.msg_namelen = static_cast<int>(addrlen);
   msg.msg_iov = const_cast<buf*>(bufs);
   msg.msg_iovlen = static_cast<int>(count);
-#if defined(__linux__)
+#if defined(__linux__) || defined(__OpenBSD__)
   flags |= MSG_NOSIGNAL;
-#endif // defined(__linux__)
+#endif // defined(__linux__) || defined(__OpenBSD__)
   signed_size_type result = ::sendmsg(s, &msg, flags);
   get_last_error(ec, result < 0);
   return result;
@@ -1656,9 +1656,9 @@ signed_size_type sendto1(socket_type s, const void* data, size_t size,
   ec.assign(0, ec.category());
   return bytes_transferred;
 #else // defined(ASIO_WINDOWS) || defined(__CYGWIN__)
-#if defined(__linux__)
+#if defined(__linux__) || defined(__OpenBSD__)
   flags |= MSG_NOSIGNAL;
-#endif // defined(__linux__)
+#endif // defined(__linux__) || defined(__OpenBSD__)
   signed_size_type result = call_sendto(&msghdr::msg_namelen,
       s, data, size, flags, addr, addrlen);
   get_last_error(ec, result < 0);


### PR DESCRIPTION
This avoids Asio applications exiting with unexpected SIGPIPEs on
OpenBSD. Note that FreeBSD has the SO_NOSIGPIPE socket option so doesn't
need this.