### PR TITLE
Allow using libpthread on Windows

### DIFF
--- a/asio/include/asio/detail/thread.hpp
+++ b/asio/include/asio/detail/thread.hpp
@@ -19,6 +19,8 @@
 
 #if !defined(ASIO_HAS_THREADS)
 # include "asio/detail/null_thread.hpp"
+#elif defined(ASIO_HAS_PTHREADS)
+# include "asio/detail/posix_thread.hpp"
 #elif defined(ASIO_WINDOWS)
 # if defined(UNDER_CE)
 #  include "asio/detail/wince_thread.hpp"
@@ -27,8 +29,6 @@
 # else
 #  include "asio/detail/win_thread.hpp"
 # endif
-#elif defined(ASIO_HAS_PTHREADS)
-# include "asio/detail/posix_thread.hpp"
 #elif defined(ASIO_HAS_STD_THREAD)
 # include "asio/detail/std_thread.hpp"
 #else
@@ -40,6 +40,8 @@ namespace detail {
 
 #if !defined(ASIO_HAS_THREADS)
 typedef null_thread thread;
+#elif defined(ASIO_HAS_PTHREADS)
+typedef posix_thread thread;
 #elif defined(ASIO_WINDOWS)
 # if defined(UNDER_CE)
 typedef wince_thread thread;
@@ -48,8 +50,6 @@ typedef winapp_thread thread;
 # else
 typedef win_thread thread;
 # endif
-#elif defined(ASIO_HAS_PTHREADS)
-typedef posix_thread thread;
 #elif defined(ASIO_HAS_STD_THREAD)
 typedef std_thread thread;
 #endif


### PR DESCRIPTION
In some cases, using libpthread on Windows is desired, for example
when porting software that's already using libpthread, avoiding
mixing the two libraries, which can be troublesome.

This change will allow using libthread when targetting Windows and
ASIO_HAS_PTHREADS is set.

Boost change: https://github.com/boostorg/asio/pull/366