### PR TITLE
Use eventfd() function with uClibc

### DIFF
--- a/asio/include/asio/detail/impl/eventfd_select_interrupter.ipp
+++ b/asio/include/asio/detail/impl/eventfd_select_interrupter.ipp
@@ -23,7 +23,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <fcntl.h>
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 8
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 8 && !defined(__UCLIBC__)
 # include <asm/unistd.h>
 #else // __GLIBC__ == 2 && __GLIBC_MINOR__ < 8
 # include <sys/eventfd.h>
@@ -45,7 +45,7 @@ eventfd_select_interrupter::eventfd_select_interrupter()
 
 void eventfd_select_interrupter::open_descriptors()
 {
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 8
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 8 && !defined(__UCLIBC__)
   write_descriptor_ = read_descriptor_ = syscall(__NR_eventfd, 0);
   if (read_descriptor_ != -1)
   {


### PR DESCRIPTION
The Boost eventfd code either directly makes the eventfd system call
using __NR_eventfd (when __GLIBC_MINOR is less than 8), or otherwise
uses the eventfd() function provided by the C library.

However, since uClibc pretends to be glibc 2.2, the Boost eventfd code
directly uses the system call. While it works fine on most
architectures, it doesn't on ARC since __NR_eventfd is not defined on
this architecture. However, eventfd() is properly implemented.

So, this patch adjusts the logic used by Boost to consider uClibc as a
C library providing the eventfd() function.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/boost/0001-fix-uclibc-eventfd.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>