### PR TITLE
Use ASIO_NULLPTR instead of 0 to silence "-Wzero-as-null-pointer-constant" warnings

### DIFF
--- a/asio/include/asio/associated_executor.hpp
+++ b/asio/include/asio/associated_executor.hpp
@@ -110,7 +110,7 @@ inline typename associated_executor<T, Executor>::type
 get_associated_executor(const T& t, const Executor& ex,
     typename enable_if<
       is_executor<Executor>::value || execution::is_executor<Executor>::value
-    >::type* = 0) ASIO_NOEXCEPT
+    >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
 {
   return associated_executor<T, Executor>::get(t, ex);
 }
@@ -125,7 +125,7 @@ inline typename associated_executor<T,
   typename ExecutionContext::executor_type>::type
 get_associated_executor(const T& t, ExecutionContext& ctx,
     typename enable_if<is_convertible<ExecutionContext&,
-      execution_context&>::value>::type* = 0) ASIO_NOEXCEPT
+      execution_context&>::value>::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
 {
   return associated_executor<T,
     typename ExecutionContext::executor_type>::get(t, ctx.get_executor());

--- a/asio/include/asio/basic_datagram_socket.hpp
+++ b/asio/include/asio/basic_datagram_socket.hpp
@@ -102,7 +102,7 @@ public:
   explicit basic_datagram_socket(ExecutionContext& context,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(context)
   {
   }
@@ -140,7 +140,7 @@ public:
       const protocol_type& protocol,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(context, protocol)
   {
   }
@@ -186,7 +186,7 @@ public:
       const endpoint_type& endpoint,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(context, endpoint)
   {
   }
@@ -231,7 +231,7 @@ public:
       const protocol_type& protocol, const native_handle_type& native_socket,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(context, protocol, native_socket)
   {
   }
@@ -288,7 +288,7 @@ public:
       typename enable_if<
         is_convertible<Protocol1, Protocol>::value
           && is_convertible<Executor1, Executor>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(std::move(other))
   {
   }

--- a/asio/include/asio/basic_deadline_timer.hpp
+++ b/asio/include/asio/basic_deadline_timer.hpp
@@ -177,7 +177,7 @@ public:
   explicit basic_deadline_timer(ExecutionContext& context,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
   }
@@ -215,7 +215,7 @@ public:
   basic_deadline_timer(ExecutionContext& context, const time_type& expiry_time,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;
@@ -259,7 +259,7 @@ public:
       const duration_type& expiry_time,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;

--- a/asio/include/asio/basic_raw_socket.hpp
+++ b/asio/include/asio/basic_raw_socket.hpp
@@ -102,7 +102,7 @@ public:
   explicit basic_raw_socket(ExecutionContext& context,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(context)
   {
   }
@@ -139,7 +139,7 @@ public:
   basic_raw_socket(ExecutionContext& context, const protocol_type& protocol,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(context, protocol)
   {
   }
@@ -184,7 +184,7 @@ public:
   basic_raw_socket(ExecutionContext& context, const endpoint_type& endpoint,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(context, endpoint)
   {
   }
@@ -229,7 +229,7 @@ public:
       const protocol_type& protocol, const native_handle_type& native_socket,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(context, protocol, native_socket)
   {
   }
@@ -285,7 +285,7 @@ public:
       typename enable_if<
         is_convertible<Protocol1, Protocol>::value
           && is_convertible<Executor1, Executor>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(std::move(other))
   {
   }

--- a/asio/include/asio/basic_seq_packet_socket.hpp
+++ b/asio/include/asio/basic_seq_packet_socket.hpp
@@ -102,7 +102,7 @@ public:
   explicit basic_seq_packet_socket(ExecutionContext& context,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(context)
   {
   }
@@ -145,7 +145,7 @@ public:
       const protocol_type& protocol,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(context, protocol)
   {
   }
@@ -192,7 +192,7 @@ public:
       const endpoint_type& endpoint,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(context, endpoint)
   {
   }
@@ -237,7 +237,7 @@ public:
       const protocol_type& protocol, const native_handle_type& native_socket,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(context, protocol, native_socket)
   {
   }
@@ -296,7 +296,7 @@ public:
       typename enable_if<
         is_convertible<Protocol1, Protocol>::value
           && is_convertible<Executor1, Executor>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(std::move(other))
   {
   }

--- a/asio/include/asio/basic_serial_port.hpp
+++ b/asio/include/asio/basic_serial_port.hpp
@@ -111,7 +111,7 @@ public:
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value,
         basic_serial_port
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
   }
@@ -152,7 +152,7 @@ public:
   basic_serial_port(ExecutionContext& context, const char* device,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;
@@ -196,7 +196,7 @@ public:
   basic_serial_port(ExecutionContext& context, const std::string& device,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;
@@ -245,7 +245,7 @@ public:
       const native_handle_type& native_serial_port,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;

--- a/asio/include/asio/basic_signal_set.hpp
+++ b/asio/include/asio/basic_signal_set.hpp
@@ -132,7 +132,7 @@ public:
   explicit basic_signal_set(ExecutionContext& context,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
   }
@@ -177,7 +177,7 @@ public:
   basic_signal_set(ExecutionContext& context, int signal_number_1,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;
@@ -235,7 +235,7 @@ public:
       int signal_number_2,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;
@@ -303,7 +303,7 @@ public:
       int signal_number_2, int signal_number_3,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;

--- a/asio/include/asio/basic_socket.hpp
+++ b/asio/include/asio/basic_socket.hpp
@@ -127,7 +127,7 @@ public:
   explicit basic_socket(ExecutionContext& context,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
   }
@@ -167,7 +167,7 @@ public:
   basic_socket(ExecutionContext& context, const protocol_type& protocol,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;
@@ -221,7 +221,7 @@ public:
   basic_socket(ExecutionContext& context, const endpoint_type& endpoint,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;
@@ -274,7 +274,7 @@ public:
       const native_handle_type& native_socket,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;
@@ -334,7 +334,7 @@ public:
       typename enable_if<
         is_convertible<Protocol1, Protocol>::value
           && is_convertible<Executor1, Executor>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(std::move(other.impl_))
   {
   }

--- a/asio/include/asio/basic_socket_acceptor.hpp
+++ b/asio/include/asio/basic_socket_acceptor.hpp
@@ -137,7 +137,7 @@ public:
   explicit basic_socket_acceptor(ExecutionContext& context,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
   }
@@ -179,7 +179,7 @@ public:
       const protocol_type& protocol,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;
@@ -267,7 +267,7 @@ public:
       const endpoint_type& endpoint, bool reuse_addr = true,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;
@@ -332,7 +332,7 @@ public:
       const protocol_type& protocol, const native_handle_type& native_acceptor,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;
@@ -396,7 +396,7 @@ public:
       typename enable_if<
         is_convertible<Protocol1, Protocol>::value
           && is_convertible<Executor1, Executor>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(std::move(other.impl_))
   {
   }
@@ -1254,7 +1254,7 @@ public:
   void accept(basic_socket<Protocol1, Executor1>& peer,
       typename enable_if<
         is_convertible<Protocol, Protocol1>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     asio::error_code ec;
     impl_.get_service().accept(impl_.get_implementation(),
@@ -1290,7 +1290,7 @@ public:
       basic_socket<Protocol1, Executor1>& peer, asio::error_code& ec,
       typename enable_if<
         is_convertible<Protocol, Protocol1>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     impl_.get_service().accept(impl_.get_implementation(),
         peer, static_cast<endpoint_type*>(0), ec);
@@ -1345,7 +1345,7 @@ public:
         ASIO_DEFAULT_COMPLETION_TOKEN(executor_type),
       typename enable_if<
         is_convertible<Protocol, Protocol1>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     return async_initiate<AcceptHandler, void (asio::error_code)>(
         initiate_async_accept(this), handler,
@@ -1621,7 +1621,7 @@ public:
       typename enable_if<
         is_executor<Executor1>::value
           || execution::is_executor<Executor1>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     asio::error_code ec;
     typename Protocol::socket::template
@@ -1660,7 +1660,7 @@ public:
   accept(ExecutionContext& context,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     asio::error_code ec;
     typename Protocol::socket::template rebind_executor<
@@ -1704,7 +1704,7 @@ public:
       typename enable_if<
         is_executor<Executor1>::value
           || execution::is_executor<Executor1>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     typename Protocol::socket::template
       rebind_executor<Executor1>::other peer(ex);
@@ -1746,7 +1746,7 @@ public:
   accept(ExecutionContext& context, asio::error_code& ec,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     typename Protocol::socket::template rebind_executor<
         typename ExecutionContext::executor_type>::other peer(context);
@@ -1811,7 +1811,7 @@ public:
       typename enable_if<
         is_executor<Executor1>::value
           || execution::is_executor<Executor1>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     typedef typename Protocol::socket::template rebind_executor<
       Executor1>::other other_socket_type;
@@ -1880,7 +1880,7 @@ public:
         ASIO_DEFAULT_COMPLETION_TOKEN(executor_type),
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     typedef typename Protocol::socket::template rebind_executor<
       typename ExecutionContext::executor_type>::other other_socket_type;
@@ -2070,7 +2070,7 @@ public:
       typename enable_if<
         is_executor<Executor1>::value
           || execution::is_executor<Executor1>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     asio::error_code ec;
     typename Protocol::socket::template
@@ -2115,7 +2115,7 @@ public:
   accept(ExecutionContext& context, endpoint_type& peer_endpoint,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     asio::error_code ec;
     typename Protocol::socket::template rebind_executor<
@@ -2166,7 +2166,7 @@ public:
       typename enable_if<
         is_executor<Executor1>::value
           || execution::is_executor<Executor1>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     typename Protocol::socket::template
       rebind_executor<Executor1>::other peer(ex);
@@ -2215,7 +2215,7 @@ public:
       endpoint_type& peer_endpoint, asio::error_code& ec,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     typename Protocol::socket::template rebind_executor<
         typename ExecutionContext::executor_type>::other peer(context);
@@ -2287,7 +2287,7 @@ public:
       typename enable_if<
         is_executor<Executor1>::value
           || execution::is_executor<Executor1>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     typedef typename Protocol::socket::template rebind_executor<
       Executor1>::other other_socket_type;
@@ -2363,7 +2363,7 @@ public:
         ASIO_DEFAULT_COMPLETION_TOKEN(executor_type),
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     typedef typename Protocol::socket::template rebind_executor<
       typename ExecutionContext::executor_type>::other other_socket_type;

--- a/asio/include/asio/basic_stream_socket.hpp
+++ b/asio/include/asio/basic_stream_socket.hpp
@@ -107,7 +107,7 @@ public:
   explicit basic_stream_socket(ExecutionContext& context,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(context)
   {
   }
@@ -146,7 +146,7 @@ public:
   basic_stream_socket(ExecutionContext& context, const protocol_type& protocol,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(context, protocol)
   {
   }
@@ -191,7 +191,7 @@ public:
   basic_stream_socket(ExecutionContext& context, const endpoint_type& endpoint,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(context, endpoint)
   {
   }
@@ -236,7 +236,7 @@ public:
       const protocol_type& protocol, const native_handle_type& native_socket,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(context, protocol, native_socket)
   {
   }
@@ -292,7 +292,7 @@ public:
       typename enable_if<
         is_convertible<Protocol1, Protocol>::value
           && is_convertible<Executor1, Executor>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_socket<Protocol, Executor>(std::move(other))
   {
   }

--- a/asio/include/asio/basic_waitable_timer.hpp
+++ b/asio/include/asio/basic_waitable_timer.hpp
@@ -193,7 +193,7 @@ public:
   explicit basic_waitable_timer(ExecutionContext& context,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
   }
@@ -232,7 +232,7 @@ public:
       const time_point& expiry_time,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;
@@ -275,7 +275,7 @@ public:
       const duration& expiry_time,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;
@@ -339,7 +339,7 @@ public:
       basic_waitable_timer<Clock, WaitTraits, Executor1>&& other,
       typename enable_if<
           is_convertible<Executor1, Executor>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(std::move(other.impl_))
   {
   }

--- a/asio/include/asio/bind_executor.hpp
+++ b/asio/include/asio/bind_executor.hpp
@@ -490,7 +490,7 @@ inline executor_binder<typename decay<T>::type, Executor>
 bind_executor(const Executor& ex, ASIO_MOVE_ARG(T) t,
     typename enable_if<
       is_executor<Executor>::value || execution::is_executor<Executor>::value
-    >::type* = 0)
+    >::type* = ASIO_NULLPTR)
 {
   return executor_binder<typename decay<T>::type, Executor>(
       executor_arg_t(), ex, ASIO_MOVE_CAST(T)(t));
@@ -502,7 +502,7 @@ inline executor_binder<typename decay<T>::type,
   typename ExecutionContext::executor_type>
 bind_executor(ExecutionContext& ctx, ASIO_MOVE_ARG(T) t,
     typename enable_if<is_convertible<
-      ExecutionContext&, execution_context&>::value>::type* = 0)
+      ExecutionContext&, execution_context&>::value>::type* = ASIO_NULLPTR)
 {
   return executor_binder<typename decay<T>::type,
     typename ExecutionContext::executor_type>(

--- a/asio/include/asio/buffer.hpp
+++ b/asio/include/asio/buffer.hpp
@@ -388,7 +388,7 @@ template <typename MutableBuffer>
 inline const mutable_buffer* buffer_sequence_begin(const MutableBuffer& b,
     typename enable_if<
       is_convertible<const MutableBuffer*, const mutable_buffer*>::value
-    >::type* = 0) ASIO_NOEXCEPT
+    >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
 {
   return static_cast<const mutable_buffer*>(detail::addressof(b));
 }
@@ -398,7 +398,7 @@ template <typename ConstBuffer>
 inline const const_buffer* buffer_sequence_begin(const ConstBuffer& b,
     typename enable_if<
       is_convertible<const ConstBuffer*, const const_buffer*>::value
-    >::type* = 0) ASIO_NOEXCEPT
+    >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
 {
   return static_cast<const const_buffer*>(detail::addressof(b));
 }
@@ -411,7 +411,7 @@ inline auto buffer_sequence_begin(C& c,
     typename enable_if<
       !is_convertible<const C*, const mutable_buffer*>::value
         && !is_convertible<const C*, const const_buffer*>::value
-    >::type* = 0) ASIO_NOEXCEPT -> decltype(c.begin())
+    >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT -> decltype(c.begin())
 {
   return c.begin();
 }
@@ -422,7 +422,7 @@ inline auto buffer_sequence_begin(const C& c,
     typename enable_if<
       !is_convertible<const C*, const mutable_buffer*>::value
         && !is_convertible<const C*, const const_buffer*>::value
-    >::type* = 0) ASIO_NOEXCEPT -> decltype(c.begin())
+    >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT -> decltype(c.begin())
 {
   return c.begin();
 }
@@ -434,7 +434,7 @@ inline typename C::iterator buffer_sequence_begin(C& c,
     typename enable_if<
       !is_convertible<const C*, const mutable_buffer*>::value
         && !is_convertible<const C*, const const_buffer*>::value
-    >::type* = 0) ASIO_NOEXCEPT
+    >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
 {
   return c.begin();
 }
@@ -444,7 +444,7 @@ inline typename C::const_iterator buffer_sequence_begin(const C& c,
     typename enable_if<
       !is_convertible<const C*, const mutable_buffer*>::value
         && !is_convertible<const C*, const const_buffer*>::value
-    >::type* = 0) ASIO_NOEXCEPT
+    >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
 {
   return c.begin();
 }
@@ -465,7 +465,7 @@ template <typename MutableBuffer>
 inline const mutable_buffer* buffer_sequence_end(const MutableBuffer& b,
     typename enable_if<
       is_convertible<const MutableBuffer*, const mutable_buffer*>::value
-    >::type* = 0) ASIO_NOEXCEPT
+    >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
 {
   return static_cast<const mutable_buffer*>(detail::addressof(b)) + 1;
 }
@@ -475,7 +475,7 @@ template <typename ConstBuffer>
 inline const const_buffer* buffer_sequence_end(const ConstBuffer& b,
     typename enable_if<
       is_convertible<const ConstBuffer*, const const_buffer*>::value
-    >::type* = 0) ASIO_NOEXCEPT
+    >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
 {
   return static_cast<const const_buffer*>(detail::addressof(b)) + 1;
 }
@@ -488,7 +488,7 @@ inline auto buffer_sequence_end(C& c,
     typename enable_if<
       !is_convertible<const C*, const mutable_buffer*>::value
         && !is_convertible<const C*, const const_buffer*>::value
-    >::type* = 0) ASIO_NOEXCEPT -> decltype(c.end())
+    >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT -> decltype(c.end())
 {
   return c.end();
 }
@@ -499,7 +499,7 @@ inline auto buffer_sequence_end(const C& c,
     typename enable_if<
       !is_convertible<const C*, const mutable_buffer*>::value
         && !is_convertible<const C*, const const_buffer*>::value
-    >::type* = 0) ASIO_NOEXCEPT -> decltype(c.end())
+    >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT -> decltype(c.end())
 {
   return c.end();
 }
@@ -511,7 +511,7 @@ inline typename C::iterator buffer_sequence_end(C& c,
     typename enable_if<
       !is_convertible<const C*, const mutable_buffer*>::value
         && !is_convertible<const C*, const const_buffer*>::value
-    >::type* = 0) ASIO_NOEXCEPT
+    >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
 {
   return c.end();
 }
@@ -521,7 +521,7 @@ inline typename C::const_iterator buffer_sequence_end(const C& c,
     typename enable_if<
       !is_convertible<const C*, const mutable_buffer*>::value
         && !is_convertible<const C*, const const_buffer*>::value
-    >::type* = 0) ASIO_NOEXCEPT
+    >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
 {
   return c.end();
 }

--- a/asio/include/asio/co_spawn.hpp
+++ b/asio/include/asio/co_spawn.hpp
@@ -108,7 +108,7 @@ co_spawn(const Executor& ex, awaitable<T, AwaitableExecutor> a,
     typename enable_if<
       (is_executor<Executor>::value || execution::is_executor<Executor>::value)
         && is_convertible<Executor, AwaitableExecutor>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Spawn a new coroutined-based thread of execution.
 /**
@@ -164,7 +164,7 @@ co_spawn(const Executor& ex, awaitable<void, AwaitableExecutor> a,
     typename enable_if<
       (is_executor<Executor>::value || execution::is_executor<Executor>::value)
         && is_convertible<Executor, AwaitableExecutor>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Spawn a new coroutined-based thread of execution.
 /**
@@ -231,7 +231,7 @@ co_spawn(ExecutionContext& ctx, awaitable<T, AwaitableExecutor> a,
       is_convertible<ExecutionContext&, execution_context&>::value
         && is_convertible<typename ExecutionContext::executor_type,
           AwaitableExecutor>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Spawn a new coroutined-based thread of execution.
 /**
@@ -290,7 +290,7 @@ co_spawn(ExecutionContext& ctx, awaitable<void, AwaitableExecutor> a,
       is_convertible<ExecutionContext&, execution_context&>::value
         && is_convertible<typename ExecutionContext::executor_type,
           AwaitableExecutor>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Spawn a new coroutined-based thread of execution.
 /**
@@ -373,7 +373,7 @@ co_spawn(const Executor& ex, F&& f,
       ASIO_DEFAULT_COMPLETION_TOKEN(Executor),
     typename enable_if<
       is_executor<Executor>::value || execution::is_executor<Executor>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Spawn a new coroutined-based thread of execution.
 /**
@@ -458,7 +458,7 @@ co_spawn(ExecutionContext& ctx, F&& f,
         typename ExecutionContext::executor_type),
     typename enable_if<
       is_convertible<ExecutionContext&, execution_context&>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 } // namespace asio
 

--- a/asio/include/asio/connect.hpp
+++ b/asio/include/asio/connect.hpp
@@ -30,7 +30,7 @@ namespace detail
   char (&has_iterator_helper(...))[2];
 
   template <typename T>
-  char has_iterator_helper(T*, typename T::iterator* = 0);
+  char has_iterator_helper(T*, typename T::iterator* = ASIO_NULLPTR);
 
   template <typename T>
   struct has_iterator_typedef
@@ -91,7 +91,7 @@ template <typename Protocol, typename Executor, typename EndpointSequence>
 typename Protocol::endpoint connect(basic_socket<Protocol, Executor>& s,
     const EndpointSequence& endpoints,
     typename enable_if<is_endpoint_sequence<
-        EndpointSequence>::value>::type* = 0);
+        EndpointSequence>::value>::type* = ASIO_NULLPTR);
 
 /// Establishes a socket connection by trying each endpoint in a sequence.
 /**
@@ -127,7 +127,7 @@ template <typename Protocol, typename Executor, typename EndpointSequence>
 typename Protocol::endpoint connect(basic_socket<Protocol, Executor>& s,
     const EndpointSequence& endpoints, asio::error_code& ec,
     typename enable_if<is_endpoint_sequence<
-        EndpointSequence>::value>::type* = 0);
+        EndpointSequence>::value>::type* = ASIO_NULLPTR);
 
 #if !defined(ASIO_NO_DEPRECATED)
 /// (Deprecated: Use range overload.) Establishes a socket connection by trying
@@ -156,7 +156,7 @@ typename Protocol::endpoint connect(basic_socket<Protocol, Executor>& s,
  */
 template <typename Protocol, typename Executor, typename Iterator>
 Iterator connect(basic_socket<Protocol, Executor>& s, Iterator begin,
-    typename enable_if<!is_endpoint_sequence<Iterator>::value>::type* = 0);
+    typename enable_if<!is_endpoint_sequence<Iterator>::value>::type* = ASIO_NULLPTR);
 
 /// (Deprecated: Use range overload.) Establishes a socket connection by trying
 /// each endpoint in a sequence.
@@ -185,7 +185,7 @@ Iterator connect(basic_socket<Protocol, Executor>& s, Iterator begin,
 template <typename Protocol, typename Executor, typename Iterator>
 Iterator connect(basic_socket<Protocol, Executor>& s,
     Iterator begin, asio::error_code& ec,
-    typename enable_if<!is_endpoint_sequence<Iterator>::value>::type* = 0);
+    typename enable_if<!is_endpoint_sequence<Iterator>::value>::type* = ASIO_NULLPTR);
 #endif // !defined(ASIO_NO_DEPRECATED)
 
 /// Establishes a socket connection by trying each endpoint in a sequence.
@@ -312,7 +312,7 @@ template <typename Protocol, typename Executor,
 typename Protocol::endpoint connect(basic_socket<Protocol, Executor>& s,
     const EndpointSequence& endpoints, ConnectCondition connect_condition,
     typename enable_if<is_endpoint_sequence<
-        EndpointSequence>::value>::type* = 0);
+        EndpointSequence>::value>::type* = ASIO_NULLPTR);
 
 /// Establishes a socket connection by trying each endpoint in a sequence.
 /**
@@ -380,7 +380,7 @@ typename Protocol::endpoint connect(basic_socket<Protocol, Executor>& s,
     const EndpointSequence& endpoints, ConnectCondition connect_condition,
     asio::error_code& ec,
     typename enable_if<is_endpoint_sequence<
-        EndpointSequence>::value>::type* = 0);
+        EndpointSequence>::value>::type* = ASIO_NULLPTR);
 
 #if !defined(ASIO_NO_DEPRECATED)
 /// (Deprecated: Use range overload.) Establishes a socket connection by trying
@@ -422,7 +422,7 @@ template <typename Protocol, typename Executor,
     typename Iterator, typename ConnectCondition>
 Iterator connect(basic_socket<Protocol, Executor>& s,
     Iterator begin, ConnectCondition connect_condition,
-    typename enable_if<!is_endpoint_sequence<Iterator>::value>::type* = 0);
+    typename enable_if<!is_endpoint_sequence<Iterator>::value>::type* = ASIO_NULLPTR);
 
 /// (Deprecated: Use range overload.) Establishes a socket connection by trying
 /// each endpoint in a sequence.
@@ -463,7 +463,7 @@ template <typename Protocol, typename Executor,
     typename Iterator, typename ConnectCondition>
 Iterator connect(basic_socket<Protocol, Executor>& s, Iterator begin,
     ConnectCondition connect_condition, asio::error_code& ec,
-    typename enable_if<!is_endpoint_sequence<Iterator>::value>::type* = 0);
+    typename enable_if<!is_endpoint_sequence<Iterator>::value>::type* = ASIO_NULLPTR);
 #endif // !defined(ASIO_NO_DEPRECATED)
 
 /// Establishes a socket connection by trying each endpoint in a sequence.
@@ -676,7 +676,7 @@ async_connect(basic_socket<Protocol, Executor>& s,
     ASIO_MOVE_ARG(RangeConnectHandler) handler
       ASIO_DEFAULT_COMPLETION_TOKEN(Executor),
     typename enable_if<is_endpoint_sequence<
-        EndpointSequence>::value>::type* = 0);
+        EndpointSequence>::value>::type* = ASIO_NULLPTR);
 
 #if !defined(ASIO_NO_DEPRECATED)
 /// (Deprecated: Use range overload.) Asynchronously establishes a socket
@@ -723,7 +723,7 @@ ASIO_INITFN_AUTO_RESULT_TYPE(IteratorConnectHandler,
 async_connect(basic_socket<Protocol, Executor>& s, Iterator begin,
     ASIO_MOVE_ARG(IteratorConnectHandler) handler
       ASIO_DEFAULT_COMPLETION_TOKEN(Executor),
-    typename enable_if<!is_endpoint_sequence<Iterator>::value>::type* = 0);
+    typename enable_if<!is_endpoint_sequence<Iterator>::value>::type* = ASIO_NULLPTR);
 #endif // !defined(ASIO_NO_DEPRECATED)
 
 /// Asynchronously establishes a socket connection by trying each endpoint in a
@@ -892,7 +892,7 @@ async_connect(basic_socket<Protocol, Executor>& s,
     ASIO_MOVE_ARG(RangeConnectHandler) handler
       ASIO_DEFAULT_COMPLETION_TOKEN(Executor),
     typename enable_if<is_endpoint_sequence<
-        EndpointSequence>::value>::type* = 0);
+        EndpointSequence>::value>::type* = ASIO_NULLPTR);
 
 #if !defined(ASIO_NO_DEPRECATED)
 /// (Deprecated: Use range overload.) Asynchronously establishes a socket
@@ -952,7 +952,7 @@ async_connect(basic_socket<Protocol, Executor>& s, Iterator begin,
     ConnectCondition connect_condition,
     ASIO_MOVE_ARG(IteratorConnectHandler) handler
       ASIO_DEFAULT_COMPLETION_TOKEN(Executor),
-    typename enable_if<!is_endpoint_sequence<Iterator>::value>::type* = 0);
+    typename enable_if<!is_endpoint_sequence<Iterator>::value>::type* = ASIO_NULLPTR);
 #endif // !defined(ASIO_NO_DEPRECATED)
 
 /// Asynchronously establishes a socket connection by trying each endpoint in a

--- a/asio/include/asio/defer.hpp
+++ b/asio/include/asio/defer.hpp
@@ -103,7 +103,7 @@ ASIO_INITFN_AUTO_RESULT_TYPE(CompletionToken, void()) defer(
       ASIO_DEFAULT_COMPLETION_TOKEN(Executor),
     typename enable_if<
       execution::is_executor<Executor>::value || is_executor<Executor>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Submits a completion token or function object for execution.
 /**
@@ -119,7 +119,7 @@ ASIO_INITFN_AUTO_RESULT_TYPE(CompletionToken, void()) defer(
       ASIO_DEFAULT_COMPLETION_TOKEN(
         typename ExecutionContext::executor_type),
     typename enable_if<is_convertible<
-      ExecutionContext&, execution_context&>::value>::type* = 0);
+      ExecutionContext&, execution_context&>::value>::type* = ASIO_NULLPTR);
 
 } // namespace asio
 

--- a/asio/include/asio/detached.hpp
+++ b/asio/include/asio/detached.hpp
@@ -63,7 +63,7 @@ public:
     executor_with_default(const OtherExecutor& ex,
         typename enable_if<
           is_convertible<OtherExecutor, InnerExecutor>::value
-        >::type* = 0) ASIO_NOEXCEPT
+        >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
       : InnerExecutor(ex)
     {
     }

--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -871,6 +871,13 @@
 #  endif // defined(ASIO_MSVC)
 # endif // !defined(ASIO_DISABLE_NULLPTR)
 #endif // !defined(ASIO_HAS_NULLPTR)
+#if !defined(ASIO_NULLPTR)
+# if defined(ASIO_HAS_NULLPTR)
+#  define ASIO_NULLPTR nullptr
+# else // defined(ASIO_HAS_NULLPTR)
+#  define ASIO_NULLPTR 0
+# endif // defined(ASIO_HAS_NULLPTR)
+#endif // !defined(ASIO_NULLPTR)
 
 // Standard library support for the C++11 allocator additions.
 #if !defined(ASIO_HAS_CXX11_ALLOCATORS)

--- a/asio/include/asio/detail/io_object_impl.hpp
+++ b/asio/include/asio/detail/io_object_impl.hpp
@@ -55,7 +55,7 @@ public:
   template <typename ExecutionContext>
   explicit io_object_impl(ExecutionContext& context,
       typename enable_if<is_convertible<
-        ExecutionContext&, execution_context&>::value>::type* = 0)
+        ExecutionContext&, execution_context&>::value>::type* = ASIO_NULLPTR)
     : service_(&asio::use_service<IoObjectService>(context)),
       executor_(context.get_executor())
   {
@@ -140,7 +140,7 @@ private:
   // Helper function to get an executor's context.
   template <typename T>
   static execution_context& get_context(const T& t,
-      typename enable_if<execution::is_executor<T>::value>::type* = 0)
+      typename enable_if<execution::is_executor<T>::value>::type* = ASIO_NULLPTR)
   {
     return asio::query(t, execution::context);
   }
@@ -148,7 +148,7 @@ private:
   // Helper function to get an executor's context.
   template <typename T>
   static execution_context& get_context(const T& t,
-      typename enable_if<!execution::is_executor<T>::value>::type* = 0)
+      typename enable_if<!execution::is_executor<T>::value>::type* = ASIO_NULLPTR)
   {
     return t.context();
   }

--- a/asio/include/asio/detail/strand_executor_service.hpp
+++ b/asio/include/asio/detail/strand_executor_service.hpp
@@ -93,7 +93,7 @@ public:
       ASIO_MOVE_ARG(Function) function,
       typename enable_if<
         can_query<Executor, execution::allocator_t<void> >::value
-      >::type* = 0);
+      >::type* = ASIO_NULLPTR);
 
   // Request invocation of the given function.
   template <typename Executor, typename Function>
@@ -101,7 +101,7 @@ public:
       ASIO_MOVE_ARG(Function) function,
       typename enable_if<
         !can_query<Executor, execution::allocator_t<void> >::value
-      >::type* = 0);
+      >::type* = ASIO_NULLPTR);
 
   // Request invocation of the given function.
   template <typename Executor, typename Function, typename Allocator>

--- a/asio/include/asio/detail/win_iocp_overlapped_ptr.hpp
+++ b/asio/include/asio/detail/win_iocp_overlapped_ptr.hpp
@@ -136,7 +136,7 @@ private:
   static win_iocp_io_context* get_iocp_service(const Executor& ex,
       typename enable_if<
         can_query<const Executor&, execution::context_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     return &use_service<win_iocp_io_context>(
         asio::query(ex, execution::context));
@@ -146,7 +146,7 @@ private:
   static win_iocp_io_context* get_iocp_service(const Executor& ex,
       typename enable_if<
         !can_query<const Executor&, execution::context_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     return &use_service<win_iocp_io_context>(ex.context());
   }

--- a/asio/include/asio/dispatch.hpp
+++ b/asio/include/asio/dispatch.hpp
@@ -93,7 +93,7 @@ ASIO_INITFN_AUTO_RESULT_TYPE(CompletionToken, void()) dispatch(
       ASIO_DEFAULT_COMPLETION_TOKEN(Executor),
     typename enable_if<
       execution::is_executor<Executor>::value || is_executor<Executor>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Submits a completion token or function object for execution.
 /**
@@ -110,7 +110,7 @@ ASIO_INITFN_AUTO_RESULT_TYPE(CompletionToken, void()) dispatch(
       ASIO_DEFAULT_COMPLETION_TOKEN(
         typename ExecutionContext::executor_type),
     typename enable_if<is_convertible<
-      ExecutionContext&, execution_context&>::value>::type* = 0);
+      ExecutionContext&, execution_context&>::value>::type* = ASIO_NULLPTR);
 
 } // namespace asio
 

--- a/asio/include/asio/execution/any_executor.hpp
+++ b/asio/include/asio/execution/any_executor.hpp
@@ -699,7 +699,7 @@ protected:
   static const object_fns* object_fns_table(
       typename enable_if<
         is_same<Obj, void>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     static const object_fns fns =
     {
@@ -742,7 +742,7 @@ protected:
   static const object_fns* object_fns_table(
       typename enable_if<
         is_same<Obj, asio::detail::shared_ptr<void> >::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     static const object_fns fns =
     {
@@ -786,7 +786,7 @@ protected:
       typename enable_if<
         !is_same<Obj, void>::value
           && !is_same<Obj, asio::detail::shared_ptr<void> >::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     static const object_fns fns =
     {
@@ -847,7 +847,7 @@ protected:
   static const target_fns* target_fns_table(
       typename enable_if<
         is_same<Ex, void>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     static const target_fns fns =
     {
@@ -898,7 +898,7 @@ protected:
   static const target_fns* target_fns_table(bool is_always_blocking,
       typename enable_if<
         !is_same<Ex, void>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     static const target_fns fns_with_execute =
     {
@@ -1216,7 +1216,7 @@ public:
           is_executor<Executor>,
           false_type
         >::type::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : detail::any_executor_base(
         ASIO_MOVE_CAST(Executor)(ex), false_type())
   {
@@ -1401,7 +1401,7 @@ public:
             Executor, void(SupportableProperties...)>,
           false_type
         >::type::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : detail::any_executor_base(
         ASIO_MOVE_CAST(Executor)(ex), false_type()),
       prop_fns_(prop_fns_table<Executor>())
@@ -1421,7 +1421,7 @@ public:
               any_executor<OtherSupportableProperties...> >,
           false_type
         >::type::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : detail::any_executor_base(ASIO_MOVE_CAST(
           any_executor<OtherSupportableProperties...>)(other), true_type()),
       prop_fns_(prop_fns_table<any_executor<OtherSupportableProperties...> >())
@@ -1572,7 +1572,7 @@ public:
           typename find_convertible_property<Property>::query_result_type,
           void
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef find_convertible_property<Property> found;
     prop_fns_[found::index].query(0, object_fns_->target(*this),
@@ -1591,7 +1591,7 @@ public:
         is_reference<
           typename find_convertible_property<Property>::query_result_type
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef find_convertible_property<Property> found;
     typename remove_reference<
@@ -1613,7 +1613,7 @@ public:
         is_scalar<
           typename find_convertible_property<Property>::query_result_type
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef find_convertible_property<Property> found;
     typename found::query_result_type result;
@@ -1638,7 +1638,7 @@ public:
         !is_scalar<
           typename find_convertible_property<Property>::query_result_type
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef find_convertible_property<Property> found;
     typename found::query_result_type* result;
@@ -1658,7 +1658,7 @@ public:
   any_executor require(const Property& p,
       typename enable_if<
         find_convertible_requirable_property<Property>::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef find_convertible_requirable_property<Property> found;
     return prop_fns_[found::index].require(object_fns_->target(*this),
@@ -1675,7 +1675,7 @@ public:
   any_executor prefer(const Property& p,
       typename enable_if<
         find_convertible_preferable_property<Property>::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef find_convertible_preferable_property<Property> found;
     return prop_fns_[found::index].prefer(object_fns_->target(*this),
@@ -1833,7 +1833,7 @@ inline void swap(any_executor<SupportableProperties...>& a,
               Executor, void(ASIO_VARIADIC_TARGS(n))>, \
             false_type \
           >::type::value \
-        >::type* = 0) \
+        >::type* = ASIO_NULLPTR) \
       : detail::any_executor_base(ASIO_MOVE_CAST( \
             Executor)(ex), false_type()), \
         prop_fns_(prop_fns_table<Executor>()) \
@@ -1866,7 +1866,7 @@ inline void swap(any_executor<SupportableProperties...>& a,
                 is_valid_target<OtherAnyExecutor>, \
             false_type \
           >::type::value \
-        >::type* = 0) \
+        >::type* = ASIO_NULLPTR) \
       : detail::any_executor_base(ASIO_MOVE_CAST( \
             OtherAnyExecutor)(other), true_type()), \
         prop_fns_(prop_fns_table<OtherAnyExecutor>()) \
@@ -1987,7 +1987,7 @@ inline void swap(any_executor<SupportableProperties...>& a,
             typename find_convertible_property<Property>::query_result_type, \
             void \
           >::value \
-        >::type* = 0) const \
+        >::type* = ASIO_NULLPTR) const \
     { \
       typedef find_convertible_property<Property> found; \
       prop_fns_[found::index].query(0, object_fns_->target(*this), \
@@ -2006,7 +2006,7 @@ inline void swap(any_executor<SupportableProperties...>& a,
           is_reference< \
             typename find_convertible_property<Property>::query_result_type \
           >::value \
-        >::type* = 0) const \
+        >::type* = ASIO_NULLPTR) const \
     { \
       typedef find_convertible_property<Property> found; \
       typename remove_reference< \
@@ -2028,7 +2028,7 @@ inline void swap(any_executor<SupportableProperties...>& a,
           is_scalar< \
             typename find_convertible_property<Property>::query_result_type \
           >::value \
-        >::type* = 0) const \
+        >::type* = ASIO_NULLPTR) const \
     { \
       typedef find_convertible_property<Property> found; \
       typename found::query_result_type result; \
@@ -2053,7 +2053,7 @@ inline void swap(any_executor<SupportableProperties...>& a,
           !is_scalar< \
             typename find_convertible_property<Property>::query_result_type \
           >::value \
-        >::type* = 0) const \
+        >::type* = ASIO_NULLPTR) const \
     { \
       typedef find_convertible_property<Property> found; \
       typename found::query_result_type* result; \
@@ -2073,7 +2073,7 @@ inline void swap(any_executor<SupportableProperties...>& a,
     any_executor require(const Property& p, \
         typename enable_if< \
           find_convertible_requirable_property<Property>::value \
-        >::type* = 0) const \
+        >::type* = ASIO_NULLPTR) const \
     { \
       typedef find_convertible_requirable_property<Property> found; \
       return prop_fns_[found::index].require(object_fns_->target(*this), \
@@ -2090,7 +2090,7 @@ inline void swap(any_executor<SupportableProperties...>& a,
     any_executor prefer(const Property& p, \
         typename enable_if< \
           find_convertible_preferable_property<Property>::value \
-        >::type* = 0) const \
+        >::type* = ASIO_NULLPTR) const \
     { \
       typedef find_convertible_preferable_property<Property> found; \
       return prop_fns_[found::index].prefer(object_fns_->target(*this), \

--- a/asio/include/asio/execution/blocking.hpp
+++ b/asio/include/asio/execution/blocking.hpp
@@ -262,7 +262,7 @@ struct blocking_t
         !traits::query_static_constexpr_member<T, blocking_t>::is_valid
           && !traits::query_member<T, blocking_t>::is_valid
           && traits::static_query<T, possibly_t>::is_valid
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return traits::static_query<T, possibly_t>::value();
   }
@@ -276,7 +276,7 @@ struct blocking_t
           && !traits::query_member<T, blocking_t>::is_valid
           && !traits::static_query<T, possibly_t>::is_valid
           && traits::static_query<T, always_t>::is_valid
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return traits::static_query<T, always_t>::value();
   }
@@ -291,7 +291,7 @@ struct blocking_t
           && !traits::static_query<T, possibly_t>::is_valid
           && !traits::static_query<T, always_t>::is_valid
           && traits::static_query<T, never_t>::is_valid
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return traits::static_query<T, never_t>::value();
   }
@@ -324,7 +324,7 @@ struct blocking_t
       const Executor& ex, convertible_from_blocking_t,
       typename enable_if<
         can_query<const Executor&, possibly_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
 #if !defined(__clang__) // Clang crashes if noexcept is used here.
 #if defined(ASIO_MSVC) // Visual C++ wants the type to be qualified.
     ASIO_NOEXCEPT_IF((
@@ -344,7 +344,7 @@ struct blocking_t
       typename enable_if<
         !can_query<const Executor&, possibly_t>::value
           && can_query<const Executor&, always_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
 #if !defined(__clang__) // Clang crashes if noexcept is used here.
 #if defined(ASIO_MSVC) // Visual C++ wants the type to be qualified.
     ASIO_NOEXCEPT_IF((
@@ -365,7 +365,7 @@ struct blocking_t
         !can_query<const Executor&, possibly_t>::value
           && !can_query<const Executor&, always_t>::value
           && can_query<const Executor&, never_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
 #if !defined(__clang__) // Clang crashes if noexcept is used here.
 #if defined(ASIO_MSVC) // Visual C++ wants the type to be qualified.
     ASIO_NOEXCEPT_IF((
@@ -452,7 +452,7 @@ struct possibly_t
           && !traits::query_free<T, possibly_t>::is_valid
           && !can_query<T, always_t<I> >::value
           && !can_query<T, never_t<I> >::value
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return possibly_t();
   }
@@ -729,7 +729,7 @@ struct always_t
           const Executor&,
           blocking_adaptation::allowed_t<0>
         >::is_valid
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     return adapter<Executor>(0, e);
   }

--- a/asio/include/asio/execution/blocking_adaptation.hpp
+++ b/asio/include/asio/execution/blocking_adaptation.hpp
@@ -217,7 +217,7 @@ struct blocking_adaptation_t
             T, blocking_adaptation_t>::is_valid
           && !traits::query_member<T, blocking_adaptation_t>::is_valid
           && traits::static_query<T, disallowed_t>::is_valid
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return traits::static_query<T, disallowed_t>::value();
   }
@@ -232,7 +232,7 @@ struct blocking_adaptation_t
           && !traits::query_member<T, blocking_adaptation_t>::is_valid
           && !traits::static_query<T, disallowed_t>::is_valid
           && traits::static_query<T, allowed_t>::is_valid
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return traits::static_query<T, allowed_t>::value();
   }
@@ -269,7 +269,7 @@ struct blocking_adaptation_t
       const Executor& ex, convertible_from_blocking_adaptation_t,
       typename enable_if<
         can_query<const Executor&, disallowed_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
 #if !defined(__clang__) // Clang crashes if noexcept is used here.
 #if defined(ASIO_MSVC) // Visual C++ wants the type to be qualified.
     ASIO_NOEXCEPT_IF((
@@ -290,7 +290,7 @@ struct blocking_adaptation_t
       typename enable_if<
         !can_query<const Executor&, disallowed_t>::value
           && can_query<const Executor&, allowed_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
 #if !defined(__clang__) // Clang crashes if noexcept is used here.
 #if defined(ASIO_MSVC) // Visual C++ wants the type to be qualified.
     ASIO_NOEXCEPT_IF((
@@ -375,7 +375,7 @@ struct disallowed_t
           && !traits::query_member<T, disallowed_t>::is_valid
           && !traits::query_free<T, disallowed_t>::is_valid
           && !can_query<T, allowed_t<I> >::value
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return disallowed_t();
   }
@@ -580,7 +580,7 @@ struct allowed_t
       const Executor& e, const allowed_t&,
       typename enable_if<
         is_executor<Executor>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     return adapter<Executor>(0, e);
   }

--- a/asio/include/asio/execution/bulk_guarantee.hpp
+++ b/asio/include/asio/execution/bulk_guarantee.hpp
@@ -251,7 +251,7 @@ struct bulk_guarantee_t
         !traits::query_static_constexpr_member<T, bulk_guarantee_t>::is_valid
           && !traits::query_member<T, bulk_guarantee_t>::is_valid
           && traits::static_query<T, unsequenced_t>::is_valid
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return traits::static_query<T, unsequenced_t>::value();
   }
@@ -265,7 +265,7 @@ struct bulk_guarantee_t
           && !traits::query_member<T, bulk_guarantee_t>::is_valid
           && !traits::static_query<T, unsequenced_t>::is_valid
           && traits::static_query<T, sequenced_t>::is_valid
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return traits::static_query<T, sequenced_t>::value();
   }
@@ -280,7 +280,7 @@ struct bulk_guarantee_t
           && !traits::static_query<T, unsequenced_t>::is_valid
           && !traits::static_query<T, sequenced_t>::is_valid
           && traits::static_query<T, parallel_t>::is_valid
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return traits::static_query<T, parallel_t>::value();
   }
@@ -314,7 +314,7 @@ struct bulk_guarantee_t
       const Executor& ex, convertible_from_bulk_guarantee_t,
       typename enable_if<
         can_query<const Executor&, unsequenced_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
 #if !defined(__clang__) // Clang crashes if noexcept is used here.
 #if defined(ASIO_MSVC) // Visual C++ wants the type to be qualified.
     ASIO_NOEXCEPT_IF((
@@ -335,7 +335,7 @@ struct bulk_guarantee_t
       typename enable_if<
         !can_query<const Executor&, unsequenced_t>::value
           && can_query<const Executor&, sequenced_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
 #if !defined(__clang__) // Clang crashes if noexcept is used here.
 #if defined(ASIO_MSVC) // Visual C++ wants the type to be qualified.
     ASIO_NOEXCEPT_IF((
@@ -357,7 +357,7 @@ struct bulk_guarantee_t
         !can_query<const Executor&, unsequenced_t>::value
           && !can_query<const Executor&, sequenced_t>::value
           && can_query<const Executor&, parallel_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
 #if !defined(__clang__) // Clang crashes if noexcept is used here.
 #if defined(ASIO_MSVC) // Visual C++ wants the type to be qualified.
     ASIO_NOEXCEPT_IF((
@@ -447,7 +447,7 @@ struct unsequenced_t
           && !traits::query_free<T, unsequenced_t>::is_valid
           && !can_query<T, sequenced_t<I> >::value
           && !can_query<T, parallel_t<I> >::value
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return unsequenced_t();
   }

--- a/asio/include/asio/execution/context_as.hpp
+++ b/asio/include/asio/execution/context_as.hpp
@@ -111,7 +111,7 @@ struct context_as_t
       typename enable_if<
         is_same<T, U>::value
           && can_query<const Executor&, const context_t&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
 #if !defined(__clang__) // Clang crashes if noexcept is used here.
 #if defined(ASIO_MSVC) // Visual C++ wants the type to be qualified.
     ASIO_NOEXCEPT_IF((

--- a/asio/include/asio/execution/detail/bulk_sender.hpp
+++ b/asio/include/asio/execution/detail/bulk_sender.hpp
@@ -123,7 +123,7 @@ struct bulk_sender : sender_base
             Sender, Receiver, Function, Number
           >::arg_type
         >::value
-      >::type* = 0) ASIO_RVALUE_REF_QUAL ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_RVALUE_REF_QUAL ASIO_NOEXCEPT
   {
     return execution::connect(
         ASIO_MOVE_OR_LVALUE(typename remove_cvref<Sender>::type)(sender_),
@@ -147,7 +147,7 @@ struct bulk_sender : sender_base
             Sender, Receiver, Function, Number
           >::arg_type
         >::value
-      >::type* = 0) const ASIO_LVALUE_REF_QUAL ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) const ASIO_LVALUE_REF_QUAL ASIO_NOEXCEPT
   {
     return execution::connect(sender_,
         typename bulk_receiver_traits<Sender, Receiver, Function, Number>::type(

--- a/asio/include/asio/execution/mapping.hpp
+++ b/asio/include/asio/execution/mapping.hpp
@@ -246,7 +246,7 @@ struct mapping_t
         !traits::query_static_constexpr_member<T, mapping_t>::is_valid
           && !traits::query_member<T, mapping_t>::is_valid
           && traits::static_query<T, thread_t>::is_valid
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return traits::static_query<T, thread_t>::value();
   }
@@ -260,7 +260,7 @@ struct mapping_t
           && !traits::query_member<T, mapping_t>::is_valid
           && !traits::static_query<T, thread_t>::is_valid
           && traits::static_query<T, new_thread_t>::is_valid
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return traits::static_query<T, new_thread_t>::value();
   }
@@ -275,7 +275,7 @@ struct mapping_t
           && !traits::static_query<T, thread_t>::is_valid
           && !traits::static_query<T, new_thread_t>::is_valid
           && traits::static_query<T, other_t>::is_valid
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return traits::static_query<T, other_t>::value();
   }
@@ -308,7 +308,7 @@ struct mapping_t
       const Executor& ex, convertible_from_mapping_t,
       typename enable_if<
         can_query<const Executor&, thread_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
 #if !defined(__clang__) // Clang crashes if noexcept is used here.
 #if defined(ASIO_MSVC) // Visual C++ wants the type to be qualified.
     ASIO_NOEXCEPT_IF((
@@ -328,7 +328,7 @@ struct mapping_t
       typename enable_if<
         !can_query<const Executor&, thread_t>::value
           && can_query<const Executor&, new_thread_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
 #if !defined(__clang__) // Clang crashes if noexcept is used here.
 #if defined(ASIO_MSVC) // Visual C++ wants the type to be qualified.
     ASIO_NOEXCEPT_IF((
@@ -349,7 +349,7 @@ struct mapping_t
         !can_query<const Executor&, thread_t>::value
           && !can_query<const Executor&, new_thread_t>::value
           && can_query<const Executor&, other_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
 #if !defined(__clang__) // Clang crashes if noexcept is used here.
 #if defined(ASIO_MSVC) // Visual C++ wants the type to be qualified.
     ASIO_NOEXCEPT_IF((
@@ -436,7 +436,7 @@ struct thread_t
           && !traits::query_free<T, thread_t>::is_valid
           && !can_query<T, new_thread_t<I> >::value
           && !can_query<T, other_t<I> >::value
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return thread_t();
   }

--- a/asio/include/asio/execution/outstanding_work.hpp
+++ b/asio/include/asio/execution/outstanding_work.hpp
@@ -211,7 +211,7 @@ struct outstanding_work_t
             T, outstanding_work_t>::is_valid
           && !traits::query_member<T, outstanding_work_t>::is_valid
           && traits::static_query<T, untracked_t>::is_valid
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return traits::static_query<T, untracked_t>::value();
   }
@@ -226,7 +226,7 @@ struct outstanding_work_t
           && !traits::query_member<T, outstanding_work_t>::is_valid
           && !traits::static_query<T, untracked_t>::is_valid
           && traits::static_query<T, tracked_t>::is_valid
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return traits::static_query<T, tracked_t>::value();
   }
@@ -262,7 +262,7 @@ struct outstanding_work_t
       const Executor& ex, convertible_from_outstanding_work_t,
       typename enable_if<
         can_query<const Executor&, untracked_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
 #if !defined(__clang__) // Clang crashes if noexcept is used here.
 #if defined(ASIO_MSVC) // Visual C++ wants the type to be qualified.
     ASIO_NOEXCEPT_IF((
@@ -283,7 +283,7 @@ struct outstanding_work_t
       typename enable_if<
         !can_query<const Executor&, untracked_t>::value
           && can_query<const Executor&, tracked_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
 #if !defined(__clang__) // Clang crashes if noexcept is used here.
 #if defined(ASIO_MSVC) // Visual C++ wants the type to be qualified.
     ASIO_NOEXCEPT_IF((
@@ -368,7 +368,7 @@ struct untracked_t
           && !traits::query_member<T, untracked_t>::is_valid
           && !traits::query_free<T, untracked_t>::is_valid
           && !can_query<T, tracked_t<I> >::value
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return untracked_t();
   }

--- a/asio/include/asio/execution/prefer_only.hpp
+++ b/asio/include/asio/execution/prefer_only.hpp
@@ -221,7 +221,7 @@ struct prefer_only :
       typename enable_if<
         is_same<Property, InnerProperty>::value
           && can_prefer<const Executor&, const InnerProperty&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
 #if !defined(ASIO_MSVC) \
   && !defined(__clang__) // Clang crashes if noexcept is used here.
     ASIO_NOEXCEPT_IF((
@@ -239,7 +239,7 @@ struct prefer_only :
       typename enable_if<
         is_same<Property, InnerProperty>::value
           && can_query<const Executor&, const InnerProperty&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
 #if !defined(ASIO_MSVC) \
   && !defined(__clang__) // Clang crashes if noexcept is used here.
     ASIO_NOEXCEPT_IF((

--- a/asio/include/asio/execution/relationship.hpp
+++ b/asio/include/asio/execution/relationship.hpp
@@ -210,7 +210,7 @@ struct relationship_t
             T, relationship_t>::is_valid
           && !traits::query_member<T, relationship_t>::is_valid
           && traits::static_query<T, fork_t>::is_valid
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return traits::static_query<T, fork_t>::value();
   }
@@ -225,7 +225,7 @@ struct relationship_t
           && !traits::query_member<T, relationship_t>::is_valid
           && !traits::static_query<T, fork_t>::is_valid
           && traits::static_query<T, continuation_t>::is_valid
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return traits::static_query<T, continuation_t>::value();
   }
@@ -261,7 +261,7 @@ struct relationship_t
       const Executor& ex, convertible_from_relationship_t,
       typename enable_if<
         can_query<const Executor&, fork_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
 #if !defined(__clang__) // Clang crashes if noexcept is used here.
 #if defined(ASIO_MSVC) // Visual C++ wants the type to be qualified.
     ASIO_NOEXCEPT_IF((
@@ -281,7 +281,7 @@ struct relationship_t
       typename enable_if<
         !can_query<const Executor&, fork_t>::value
           && can_query<const Executor&, continuation_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
 #if !defined(__clang__) // Clang crashes if noexcept is used here.
 #if defined(ASIO_MSVC) // Visual C++ wants the type to be qualified.
     ASIO_NOEXCEPT_IF((
@@ -366,7 +366,7 @@ struct fork_t
           && !traits::query_member<T, fork_t>::is_valid
           && !traits::query_free<T, fork_t>::is_valid
           && !can_query<T, continuation_t<I> >::value
-      >::type* = 0) ASIO_NOEXCEPT
+      >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
   {
     return fork_t();
   }

--- a/asio/include/asio/executor_work_guard.hpp
+++ b/asio/include/asio/executor_work_guard.hpp
@@ -219,7 +219,7 @@ template <typename Executor>
 inline executor_work_guard<Executor> make_work_guard(const Executor& ex,
     typename enable_if<
       is_executor<Executor>::value || execution::is_executor<Executor>::value
-    >::type* = 0)
+    >::type* = ASIO_NULLPTR)
 {
   return executor_work_guard<Executor>(ex);
 }
@@ -230,7 +230,7 @@ inline executor_work_guard<typename ExecutionContext::executor_type>
 make_work_guard(ExecutionContext& ctx,
     typename enable_if<
       is_convertible<ExecutionContext&, execution_context&>::value
-    >::type* = 0)
+    >::type* = ASIO_NULLPTR)
 {
   return executor_work_guard<typename ExecutionContext::executor_type>(
       ctx.get_executor());
@@ -243,7 +243,7 @@ make_work_guard(const T& t,
     typename enable_if<
       !is_executor<T>::value && !execution::is_executor<T>::value
         && !is_convertible<T&, execution_context&
-    >::value>::type* = 0)
+    >::value>::type* = ASIO_NULLPTR)
 {
   return executor_work_guard<typename associated_executor<T>::type>(
       associated_executor<T>::get(t));
@@ -255,7 +255,7 @@ inline executor_work_guard<typename associated_executor<T, Executor>::type>
 make_work_guard(const T& t, const Executor& ex,
     typename enable_if<
       is_executor<Executor>::value || execution::is_executor<Executor>::value
-    >::type* = 0)
+    >::type* = ASIO_NULLPTR)
 {
   return executor_work_guard<typename associated_executor<T, Executor>::type>(
       associated_executor<T, Executor>::get(t, ex));
@@ -270,7 +270,7 @@ make_work_guard(const T& t, ExecutionContext& ctx,
       !is_executor<T>::value && !execution::is_executor<T>::value
         && !is_convertible<T&, execution_context&>::value
         && is_convertible<ExecutionContext&, execution_context&>::value
-    >::type* = 0)
+    >::type* = ASIO_NULLPTR)
 {
   return executor_work_guard<typename associated_executor<T,
     typename ExecutionContext::executor_type>::type>(

--- a/asio/include/asio/experimental/as_single.hpp
+++ b/asio/include/asio/experimental/as_single.hpp
@@ -82,7 +82,7 @@ public:
     executor_with_default(const OtherExecutor& ex,
         typename enable_if<
           is_convertible<OtherExecutor, InnerExecutor>::value
-        >::type* = 0) ASIO_NOEXCEPT
+        >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
       : InnerExecutor(ex)
     {
     }

--- a/asio/include/asio/impl/awaitable.hpp
+++ b/asio/include/asio/impl/awaitable.hpp
@@ -189,7 +189,7 @@ public:
           typename result_of<Function(awaitable_frame_base*)>::type,
           awaitable_thread<Executor>*
         >::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     struct result
     {

--- a/asio/include/asio/impl/compose.hpp
+++ b/asio/include/asio/impl/compose.hpp
@@ -501,7 +501,7 @@ namespace detail
       typename enable_if<
         !is_executor<IoObject>::value
           && !execution::is_executor<IoObject>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     return io_object.get_executor();
   }
@@ -511,7 +511,7 @@ namespace detail
       typename enable_if<
         is_executor<Executor>::value
           || execution::is_executor<Executor>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     return ex;
   }

--- a/asio/include/asio/impl/connect.hpp
+++ b/asio/include/asio/impl/connect.hpp
@@ -82,7 +82,7 @@ namespace detail
   inline Iterator call_connect_condition(ConnectCondition& connect_condition,
       const asio::error_code& ec, Iterator next, Iterator end,
       typename enable_if<is_legacy_connect_condition<
-        ConnectCondition, Iterator>::value>::type* = 0)
+        ConnectCondition, Iterator>::value>::type* = ASIO_NULLPTR)
   {
     if (next != end)
       return connect_condition(ec, next);
@@ -93,7 +93,7 @@ namespace detail
   inline Iterator call_connect_condition(ConnectCondition& connect_condition,
       const asio::error_code& ec, Iterator next, Iterator end,
       typename enable_if<!is_legacy_connect_condition<
-        ConnectCondition, Iterator>::value>::type* = 0)
+        ConnectCondition, Iterator>::value>::type* = ASIO_NULLPTR)
   {
     for (;next != end; ++next)
       if (connect_condition(ec, *next))

--- a/asio/include/asio/impl/defer.hpp
+++ b/asio/include/asio/impl/defer.hpp
@@ -41,7 +41,7 @@ public:
             typename decay<CompletionHandler>::type
           >::type
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef typename decay<CompletionHandler>::type handler_t;
 
@@ -67,7 +67,7 @@ public:
             typename decay<CompletionHandler>::type
           >::type
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef typename decay<CompletionHandler>::type handler_t;
 
@@ -108,7 +108,7 @@ public:
           typename decay<CompletionHandler>::type,
           Executor
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef typename decay<CompletionHandler>::type handler_t;
 
@@ -134,7 +134,7 @@ public:
           typename decay<CompletionHandler>::type,
           Executor
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef typename decay<CompletionHandler>::type handler_t;
 
@@ -165,7 +165,7 @@ public:
           typename decay<CompletionHandler>::type,
           Executor
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef typename decay<CompletionHandler>::type handler_t;
 
@@ -186,7 +186,7 @@ public:
           typename decay<CompletionHandler>::type,
           Executor
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef typename decay<CompletionHandler>::type handler_t;
 

--- a/asio/include/asio/impl/dispatch.hpp
+++ b/asio/include/asio/impl/dispatch.hpp
@@ -39,7 +39,7 @@ public:
             typename decay<CompletionHandler>::type
           >::type
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef typename decay<CompletionHandler>::type handler_t;
 
@@ -64,7 +64,7 @@ public:
             typename decay<CompletionHandler>::type
           >::type
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef typename decay<CompletionHandler>::type handler_t;
 
@@ -105,7 +105,7 @@ public:
           typename decay<CompletionHandler>::type,
           Executor
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef typename decay<CompletionHandler>::type handler_t;
 
@@ -130,7 +130,7 @@ public:
           typename decay<CompletionHandler>::type,
           Executor
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef typename decay<CompletionHandler>::type handler_t;
 
@@ -160,7 +160,7 @@ public:
           typename decay<CompletionHandler>::type,
           Executor
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef typename decay<CompletionHandler>::type handler_t;
 
@@ -181,7 +181,7 @@ public:
           typename decay<CompletionHandler>::type,
           Executor
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef typename decay<CompletionHandler>::type handler_t;
 

--- a/asio/include/asio/impl/post.hpp
+++ b/asio/include/asio/impl/post.hpp
@@ -41,7 +41,7 @@ public:
             typename decay<CompletionHandler>::type
           >::type
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef typename decay<CompletionHandler>::type handler_t;
 
@@ -67,7 +67,7 @@ public:
             typename decay<CompletionHandler>::type
           >::type
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef typename decay<CompletionHandler>::type handler_t;
 
@@ -108,7 +108,7 @@ public:
           typename decay<CompletionHandler>::type,
           Executor
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef typename decay<CompletionHandler>::type handler_t;
 
@@ -134,7 +134,7 @@ public:
           typename decay<CompletionHandler>::type,
           Executor
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef typename decay<CompletionHandler>::type handler_t;
 
@@ -165,7 +165,7 @@ public:
           typename decay<CompletionHandler>::type,
           Executor
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef typename decay<CompletionHandler>::type handler_t;
 
@@ -186,7 +186,7 @@ public:
           typename decay<CompletionHandler>::type,
           Executor
         >::value
-      >::type* = 0) const
+      >::type* = ASIO_NULLPTR) const
   {
     typedef typename decay<CompletionHandler>::type handler_t;
 

--- a/asio/include/asio/ip/basic_resolver.hpp
+++ b/asio/include/asio/ip/basic_resolver.hpp
@@ -121,7 +121,7 @@ public:
   explicit basic_resolver(ExecutionContext& context,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
   }
@@ -160,7 +160,7 @@ public:
   basic_resolver(basic_resolver<InternetProtocol, Executor1>&& other,
       typename enable_if<
           is_convertible<Executor1, Executor>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(std::move(other.impl_))
   {
   }

--- a/asio/include/asio/posix/basic_descriptor.hpp
+++ b/asio/include/asio/posix/basic_descriptor.hpp
@@ -101,7 +101,7 @@ public:
   explicit basic_descriptor(ExecutionContext& context,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
   }
@@ -147,7 +147,7 @@ public:
       const native_handle_type& native_descriptor,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;

--- a/asio/include/asio/posix/basic_stream_descriptor.hpp
+++ b/asio/include/asio/posix/basic_stream_descriptor.hpp
@@ -87,7 +87,7 @@ public:
   explicit basic_stream_descriptor(ExecutionContext& context,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_descriptor<Executor>(context)
   {
   }
@@ -129,7 +129,7 @@ public:
       const native_handle_type& native_descriptor,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_descriptor<Executor>(context, native_descriptor)
   {
   }

--- a/asio/include/asio/post.hpp
+++ b/asio/include/asio/post.hpp
@@ -99,7 +99,7 @@ ASIO_INITFN_AUTO_RESULT_TYPE(CompletionToken, void()) post(
       ASIO_DEFAULT_COMPLETION_TOKEN(Executor),
     typename enable_if<
       execution::is_executor<Executor>::value || is_executor<Executor>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Submits a completion token or function object for execution.
 /**
@@ -115,7 +115,7 @@ ASIO_INITFN_AUTO_RESULT_TYPE(CompletionToken, void()) post(
       ASIO_DEFAULT_COMPLETION_TOKEN(
         typename ExecutionContext::executor_type),
     typename enable_if<is_convertible<
-      ExecutionContext&, execution_context&>::value>::type* = 0);
+      ExecutionContext&, execution_context&>::value>::type* = ASIO_NULLPTR);
 
 } // namespace asio
 

--- a/asio/include/asio/read.hpp
+++ b/asio/include/asio/read.hpp
@@ -77,7 +77,7 @@ template <typename SyncReadStream, typename MutableBufferSequence>
 std::size_t read(SyncReadStream& s, const MutableBufferSequence& buffers,
     typename enable_if<
       is_mutable_buffer_sequence<MutableBufferSequence>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Attempt to read a certain amount of data from a stream before returning.
 /**
@@ -120,7 +120,7 @@ std::size_t read(SyncReadStream& s, const MutableBufferSequence& buffers,
     asio::error_code& ec,
     typename enable_if<
       is_mutable_buffer_sequence<MutableBufferSequence>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Attempt to read a certain amount of data from a stream before returning.
 /**
@@ -174,7 +174,7 @@ std::size_t read(SyncReadStream& s, const MutableBufferSequence& buffers,
     CompletionCondition completion_condition,
     typename enable_if<
       is_mutable_buffer_sequence<MutableBufferSequence>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Attempt to read a certain amount of data from a stream before returning.
 /**
@@ -221,7 +221,7 @@ std::size_t read(SyncReadStream& s, const MutableBufferSequence& buffers,
     CompletionCondition completion_condition, asio::error_code& ec,
     typename enable_if<
       is_mutable_buffer_sequence<MutableBufferSequence>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #if !defined(ASIO_NO_DYNAMIC_BUFFER_V1)
 
@@ -258,7 +258,7 @@ std::size_t read(SyncReadStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Attempt to read a certain amount of data from a stream before returning.
 /**
@@ -293,7 +293,7 @@ std::size_t read(SyncReadStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Attempt to read a certain amount of data from a stream before returning.
 /**
@@ -339,7 +339,7 @@ std::size_t read(SyncReadStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Attempt to read a certain amount of data from a stream before returning.
 /**
@@ -386,7 +386,7 @@ std::size_t read(SyncReadStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #if !defined(ASIO_NO_EXTENSIONS)
 #if !defined(ASIO_NO_IOSTREAM)
@@ -566,7 +566,7 @@ template <typename SyncReadStream, typename DynamicBuffer_v2>
 std::size_t read(SyncReadStream& s, DynamicBuffer_v2 buffers,
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Attempt to read a certain amount of data from a stream before returning.
 /**
@@ -599,7 +599,7 @@ std::size_t read(SyncReadStream& s, DynamicBuffer_v2 buffers,
     asio::error_code& ec,
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Attempt to read a certain amount of data from a stream before returning.
 /**
@@ -643,7 +643,7 @@ std::size_t read(SyncReadStream& s, DynamicBuffer_v2 buffers,
     CompletionCondition completion_condition,
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Attempt to read a certain amount of data from a stream before returning.
 /**
@@ -688,7 +688,7 @@ std::size_t read(SyncReadStream& s, DynamicBuffer_v2 buffers,
     CompletionCondition completion_condition, asio::error_code& ec,
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /*@}*/
 /**
@@ -772,7 +772,7 @@ async_read(AsyncReadStream& s, const MutableBufferSequence& buffers,
         typename AsyncReadStream::executor_type),
     typename enable_if<
       is_mutable_buffer_sequence<MutableBufferSequence>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Start an asynchronous operation to read a certain amount of data from a
 /// stream.
@@ -852,7 +852,7 @@ async_read(AsyncReadStream& s, const MutableBufferSequence& buffers,
         typename AsyncReadStream::executor_type),
     typename enable_if<
       is_mutable_buffer_sequence<MutableBufferSequence>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #if !defined(ASIO_NO_DYNAMIC_BUFFER_V1)
 
@@ -921,7 +921,7 @@ async_read(AsyncReadStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Start an asynchronous operation to read a certain amount of data from a
 /// stream.
@@ -998,7 +998,7 @@ async_read(AsyncReadStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #if !defined(ASIO_NO_EXTENSIONS)
 #if !defined(ASIO_NO_IOSTREAM)
@@ -1200,7 +1200,7 @@ async_read(AsyncReadStream& s, DynamicBuffer_v2 buffers,
         typename AsyncReadStream::executor_type),
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Start an asynchronous operation to read a certain amount of data from a
 /// stream.
@@ -1275,7 +1275,7 @@ async_read(AsyncReadStream& s, DynamicBuffer_v2 buffers,
         typename AsyncReadStream::executor_type),
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /*@}*/
 

--- a/asio/include/asio/read_until.hpp
+++ b/asio/include/asio/read_until.hpp
@@ -38,7 +38,7 @@ namespace detail
   char (&has_result_type_helper(...))[2];
 
   template <typename T>
-  char has_result_type_helper(T*, typename T::result_type* = 0);
+  char has_result_type_helper(T*, typename T::result_type* = ASIO_NULLPTR);
 
   template <typename T>
   struct has_result_type
@@ -136,7 +136,7 @@ std::size_t read_until(SyncReadStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Read data into a dynamic buffer sequence until it contains a specified
 /// delimiter.
@@ -179,7 +179,7 @@ std::size_t read_until(SyncReadStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Read data into a dynamic buffer sequence until it contains a specified
 /// delimiter.
@@ -239,7 +239,7 @@ std::size_t read_until(SyncReadStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Read data into a dynamic buffer sequence until it contains a specified
 /// delimiter.
@@ -283,7 +283,7 @@ std::size_t read_until(SyncReadStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #if !defined(ASIO_NO_EXTENSIONS)
 #if defined(ASIO_HAS_BOOST_REGEX) \
@@ -350,7 +350,7 @@ std::size_t read_until(SyncReadStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Read data into a dynamic buffer sequence until some part of the data it
 /// contains matches a regular expression.
@@ -395,7 +395,7 @@ std::size_t read_until(SyncReadStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #endif // defined(ASIO_HAS_BOOST_REGEX)
        // || defined(GENERATING_DOCUMENTATION)
@@ -511,7 +511,7 @@ std::size_t read_until(SyncReadStream& s,
       is_match_condition<MatchCondition>::value
         && is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Read data into a dynamic buffer sequence until a function object indicates a
 /// match.
@@ -575,7 +575,7 @@ std::size_t read_until(SyncReadStream& s,
       is_match_condition<MatchCondition>::value
         && is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #if !defined(ASIO_NO_IOSTREAM)
 
@@ -955,7 +955,7 @@ std::size_t read_until(SyncReadStream& s,
 template <typename SyncReadStream, typename Allocator, typename MatchCondition>
 std::size_t read_until(SyncReadStream& s,
     asio::basic_streambuf<Allocator>& b, MatchCondition match_condition,
-    typename enable_if<is_match_condition<MatchCondition>::value>::type* = 0);
+    typename enable_if<is_match_condition<MatchCondition>::value>::type* = ASIO_NULLPTR);
 
 /// Read data into a streambuf until a function object indicates a match.
 /**
@@ -1012,7 +1012,7 @@ template <typename SyncReadStream, typename Allocator, typename MatchCondition>
 std::size_t read_until(SyncReadStream& s,
     asio::basic_streambuf<Allocator>& b,
     MatchCondition match_condition, asio::error_code& ec,
-    typename enable_if<is_match_condition<MatchCondition>::value>::type* = 0);
+    typename enable_if<is_match_condition<MatchCondition>::value>::type* = ASIO_NULLPTR);
 
 #endif // !defined(ASIO_NO_IOSTREAM)
 #endif // !defined(ASIO_NO_EXTENSIONS)
@@ -1075,7 +1075,7 @@ template <typename SyncReadStream, typename DynamicBuffer_v2>
 std::size_t read_until(SyncReadStream& s, DynamicBuffer_v2 buffers, char delim,
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Read data into a dynamic buffer sequence until it contains a specified
 /// delimiter.
@@ -1116,7 +1116,7 @@ std::size_t read_until(SyncReadStream& s, DynamicBuffer_v2 buffers,
     char delim, asio::error_code& ec,
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Read data into a dynamic buffer sequence until it contains a specified
 /// delimiter.
@@ -1174,7 +1174,7 @@ std::size_t read_until(SyncReadStream& s, DynamicBuffer_v2 buffers,
     ASIO_STRING_VIEW_PARAM delim,
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Read data into a dynamic buffer sequence until it contains a specified
 /// delimiter.
@@ -1215,7 +1215,7 @@ std::size_t read_until(SyncReadStream& s, DynamicBuffer_v2 buffers,
     ASIO_STRING_VIEW_PARAM delim, asio::error_code& ec,
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #if !defined(ASIO_NO_EXTENSIONS)
 #if defined(ASIO_HAS_BOOST_REGEX) \
@@ -1280,7 +1280,7 @@ std::size_t read_until(SyncReadStream& s, DynamicBuffer_v2 buffers,
     const boost::regex& expr,
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Read data into a dynamic buffer sequence until some part of the data it
 /// contains matches a regular expression.
@@ -1323,7 +1323,7 @@ std::size_t read_until(SyncReadStream& s, DynamicBuffer_v2 buffers,
     const boost::regex& expr, asio::error_code& ec,
     typename enable_if<
         is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #endif // defined(ASIO_HAS_BOOST_REGEX)
        // || defined(GENERATING_DOCUMENTATION)
@@ -1437,7 +1437,7 @@ std::size_t read_until(SyncReadStream& s, DynamicBuffer_v2 buffers,
     typename enable_if<
       is_match_condition<MatchCondition>::value
         && is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Read data into a dynamic buffer sequence until a function object indicates a
 /// match.
@@ -1499,7 +1499,7 @@ std::size_t read_until(SyncReadStream& s, DynamicBuffer_v2 buffers,
     typename enable_if<
       is_match_condition<MatchCondition>::value
         && is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #endif // !defined(ASIO_NO_EXTENSIONS)
 
@@ -1613,7 +1613,7 @@ async_read_until(AsyncReadStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Start an asynchronous operation to read data into a dynamic buffer sequence
 /// until it contains a specified delimiter.
@@ -1713,7 +1713,7 @@ async_read_until(AsyncReadStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #if !defined(ASIO_NO_EXTENSIONS)
 #if defined(ASIO_HAS_BOOST_REGEX) \
@@ -1820,7 +1820,7 @@ async_read_until(AsyncReadStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #endif // defined(ASIO_HAS_BOOST_REGEX)
        // || defined(GENERATING_DOCUMENTATION)
@@ -1971,7 +1971,7 @@ async_read_until(AsyncReadStream& s,
       is_match_condition<MatchCondition>::value
         && is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #if !defined(ASIO_NO_IOSTREAM)
 
@@ -2395,7 +2395,7 @@ async_read_until(AsyncReadStream& s,
     ASIO_MOVE_ARG(ReadHandler) handler
       ASIO_DEFAULT_COMPLETION_TOKEN(
         typename AsyncReadStream::executor_type),
-    typename enable_if<is_match_condition<MatchCondition>::value>::type* = 0);
+    typename enable_if<is_match_condition<MatchCondition>::value>::type* = ASIO_NULLPTR);
 
 #endif // !defined(ASIO_NO_IOSTREAM)
 #endif // !defined(ASIO_NO_EXTENSIONS)
@@ -2496,7 +2496,7 @@ async_read_until(AsyncReadStream& s, DynamicBuffer_v2 buffers, char delim,
         typename AsyncReadStream::executor_type),
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Start an asynchronous operation to read data into a dynamic buffer sequence
 /// until it contains a specified delimiter.
@@ -2594,7 +2594,7 @@ async_read_until(AsyncReadStream& s, DynamicBuffer_v2 buffers,
         typename AsyncReadStream::executor_type),
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #if !defined(ASIO_NO_EXTENSIONS)
 #if defined(ASIO_HAS_BOOST_REGEX) \
@@ -2699,7 +2699,7 @@ async_read_until(AsyncReadStream& s, DynamicBuffer_v2 buffers,
         typename AsyncReadStream::executor_type),
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #endif // defined(ASIO_HAS_BOOST_REGEX)
        // || defined(GENERATING_DOCUMENTATION)
@@ -2848,7 +2848,7 @@ async_read_until(AsyncReadStream& s, DynamicBuffer_v2 buffers,
     typename enable_if<
       is_match_condition<MatchCondition>::value
         && is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #endif // !defined(ASIO_NO_EXTENSIONS)
 

--- a/asio/include/asio/spawn.hpp
+++ b/asio/include/asio/spawn.hpp
@@ -228,7 +228,7 @@ void spawn(ASIO_MOVE_ARG(Handler) handler,
     typename enable_if<
       !is_executor<typename decay<Handler>::type>::value &&
       !execution::is_executor<typename decay<Handler>::type>::value &&
-      !is_convertible<Handler&, execution_context&>::value>::type* = 0);
+      !is_convertible<Handler&, execution_context&>::value>::type* = ASIO_NULLPTR);
 
 /// Start a new stackful coroutine, inheriting the execution context of another.
 /**
@@ -270,7 +270,7 @@ void spawn(const Executor& ex,
       = boost::coroutines::attributes(),
     typename enable_if<
       is_executor<Executor>::value || execution::is_executor<Executor>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Start a new stackful coroutine that executes on a given strand.
 /**
@@ -331,7 +331,7 @@ void spawn(ExecutionContext& ctx,
     const boost::coroutines::attributes& attributes
       = boost::coroutines::attributes(),
     typename enable_if<is_convertible<
-      ExecutionContext&, execution_context&>::value>::type* = 0);
+      ExecutionContext&, execution_context&>::value>::type* = ASIO_NULLPTR);
 
 /*@}*/
 

--- a/asio/include/asio/strand.hpp
+++ b/asio/include/asio/strand.hpp
@@ -53,7 +53,7 @@ public:
           is_convertible<Executor1, Executor>,
           false_type
         >::type::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : executor_(e),
       impl_(strand::create_implementation(executor_))
   {
@@ -383,7 +383,7 @@ private:
   static implementation_type create_implementation(const InnerExecutor& ex,
       typename enable_if<
         can_query<InnerExecutor, execution::context_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     return use_service<detail::strand_executor_service>(
         asio::query(ex, execution::context)).create_implementation();
@@ -393,7 +393,7 @@ private:
   static implementation_type create_implementation(const InnerExecutor& ex,
       typename enable_if<
         !can_query<InnerExecutor, execution::context_t>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     return use_service<detail::strand_executor_service>(
         ex.context()).create_implementation();
@@ -421,7 +421,7 @@ template <typename Executor>
 inline strand<Executor> make_strand(const Executor& ex,
     typename enable_if<
       is_executor<Executor>::value || execution::is_executor<Executor>::value
-    >::type* = 0)
+    >::type* = ASIO_NULLPTR)
 {
   return strand<Executor>(ex);
 }
@@ -432,7 +432,7 @@ inline strand<typename ExecutionContext::executor_type>
 make_strand(ExecutionContext& ctx,
     typename enable_if<
       is_convertible<ExecutionContext&, execution_context&>::value
-    >::type* = 0)
+    >::type* = ASIO_NULLPTR)
 {
   return strand<typename ExecutionContext::executor_type>(ctx.get_executor());
 }

--- a/asio/include/asio/traits/static_require.hpp
+++ b/asio/include/asio/traits/static_require.hpp
@@ -78,7 +78,7 @@ template <typename T, typename Property>
 true_type static_require_test(T*, Property*,
     typename enable_if<
       Property::value() == traits::static_query<T, Property>::value()
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 template <typename T, typename Property>
 struct has_static_require

--- a/asio/include/asio/traits/static_require_concept.hpp
+++ b/asio/include/asio/traits/static_require_concept.hpp
@@ -78,7 +78,7 @@ template <typename T, typename Property>
 true_type static_require_concept_test(T*, Property*,
     typename enable_if<
       Property::value() == traits::static_query<T, Property>::value()
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 template <typename T, typename Property>
 struct has_static_require_concept

--- a/asio/include/asio/use_awaitable.hpp
+++ b/asio/include/asio/use_awaitable.hpp
@@ -110,7 +110,7 @@ struct use_awaitable_t
     executor_with_default(const OtherExecutor& ex,
         typename enable_if<
           is_convertible<OtherExecutor, InnerExecutor>::value
-        >::type* = 0) ASIO_NOEXCEPT
+        >::type* = ASIO_NULLPTR) ASIO_NOEXCEPT
       : InnerExecutor(ex)
     {
     }

--- a/asio/include/asio/windows/basic_object_handle.hpp
+++ b/asio/include/asio/windows/basic_object_handle.hpp
@@ -99,7 +99,7 @@ public:
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value,
         basic_object_handle
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
   }
@@ -144,7 +144,7 @@ public:
       const native_handle_type& native_handle,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;

--- a/asio/include/asio/windows/basic_overlapped_handle.hpp
+++ b/asio/include/asio/windows/basic_overlapped_handle.hpp
@@ -102,7 +102,7 @@ public:
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value,
         basic_overlapped_handle
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
   }
@@ -147,7 +147,7 @@ public:
       const native_handle_type& native_handle,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context)
   {
     asio::error_code ec;

--- a/asio/include/asio/windows/basic_random_access_handle.hpp
+++ b/asio/include/asio/windows/basic_random_access_handle.hpp
@@ -87,7 +87,7 @@ public:
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value,
         basic_random_access_handle
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_overlapped_handle<Executor>(context)
   {
   }
@@ -129,7 +129,7 @@ public:
       const native_handle_type& handle,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_overlapped_handle<Executor>(context, handle)
   {
   }

--- a/asio/include/asio/windows/basic_stream_handle.hpp
+++ b/asio/include/asio/windows/basic_stream_handle.hpp
@@ -89,7 +89,7 @@ public:
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value,
         basic_stream_handle
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_overlapped_handle<Executor>(context)
   {
   }
@@ -130,7 +130,7 @@ public:
       const native_handle_type& handle,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : basic_overlapped_handle<Executor>(context, handle)
   {
   }

--- a/asio/include/asio/windows/overlapped_ptr.hpp
+++ b/asio/include/asio/windows/overlapped_ptr.hpp
@@ -54,7 +54,7 @@ public:
       ASIO_MOVE_ARG(Handler) handler,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(context.get_executor(), ASIO_MOVE_CAST(Handler)(handler))
   {
   }
@@ -66,7 +66,7 @@ public:
       typename enable_if<
         execution::is_executor<Executor>::value
           || is_executor<Executor>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
     : impl_(ex, ASIO_MOVE_CAST(Handler)(handler))
   {
   }
@@ -88,7 +88,7 @@ public:
   void reset(ExecutionContext& context, ASIO_MOVE_ARG(Handler) handler,
       typename enable_if<
         is_convertible<ExecutionContext&, execution_context&>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     impl_.reset(context.get_executor(), ASIO_MOVE_CAST(Handler)(handler));
   }
@@ -100,7 +100,7 @@ public:
       typename enable_if<
         execution::is_executor<Executor>::value
           || is_executor<Executor>::value
-      >::type* = 0)
+      >::type* = ASIO_NULLPTR)
   {
     impl_.reset(ex, ASIO_MOVE_CAST(Handler)(handler));
   }

--- a/asio/include/asio/write.hpp
+++ b/asio/include/asio/write.hpp
@@ -77,7 +77,7 @@ template <typename SyncWriteStream, typename ConstBufferSequence>
 std::size_t write(SyncWriteStream& s, const ConstBufferSequence& buffers,
     typename enable_if<
       is_const_buffer_sequence<ConstBufferSequence>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Write all of the supplied data to a stream before returning.
 /**
@@ -120,7 +120,7 @@ std::size_t write(SyncWriteStream& s, const ConstBufferSequence& buffers,
     asio::error_code& ec,
     typename enable_if<
       is_const_buffer_sequence<ConstBufferSequence>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Write a certain amount of data to a stream before returning.
 /**
@@ -174,7 +174,7 @@ std::size_t write(SyncWriteStream& s, const ConstBufferSequence& buffers,
     CompletionCondition completion_condition,
     typename enable_if<
       is_const_buffer_sequence<ConstBufferSequence>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Write a certain amount of data to a stream before returning.
 /**
@@ -221,7 +221,7 @@ std::size_t write(SyncWriteStream& s, const ConstBufferSequence& buffers,
     CompletionCondition completion_condition, asio::error_code& ec,
     typename enable_if<
       is_const_buffer_sequence<ConstBufferSequence>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #if !defined(ASIO_NO_DYNAMIC_BUFFER_V1)
 
@@ -258,7 +258,7 @@ std::size_t write(SyncWriteStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Write all of the supplied data to a stream before returning.
 /**
@@ -294,7 +294,7 @@ std::size_t write(SyncWriteStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Write a certain amount of data to a stream before returning.
 /**
@@ -340,7 +340,7 @@ std::size_t write(SyncWriteStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Write a certain amount of data to a stream before returning.
 /**
@@ -387,7 +387,7 @@ std::size_t write(SyncWriteStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #if !defined(ASIO_NO_EXTENSIONS)
 #if !defined(ASIO_NO_IOSTREAM)
@@ -567,7 +567,7 @@ template <typename SyncWriteStream, typename DynamicBuffer_v2>
 std::size_t write(SyncWriteStream& s, DynamicBuffer_v2 buffers,
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Write all of the supplied data to a stream before returning.
 /**
@@ -601,7 +601,7 @@ std::size_t write(SyncWriteStream& s, DynamicBuffer_v2 buffers,
     asio::error_code& ec,
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Write a certain amount of data to a stream before returning.
 /**
@@ -645,7 +645,7 @@ std::size_t write(SyncWriteStream& s, DynamicBuffer_v2 buffers,
     CompletionCondition completion_condition,
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Write a certain amount of data to a stream before returning.
 /**
@@ -690,7 +690,7 @@ std::size_t write(SyncWriteStream& s, DynamicBuffer_v2 buffers,
     CompletionCondition completion_condition, asio::error_code& ec,
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /*@}*/
 /**
@@ -766,7 +766,7 @@ async_write(AsyncWriteStream& s, const ConstBufferSequence& buffers,
         typename AsyncWriteStream::executor_type),
     typename enable_if<
       is_const_buffer_sequence<ConstBufferSequence>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Start an asynchronous operation to write a certain amount of data to a
 /// stream.
@@ -846,7 +846,7 @@ async_write(AsyncWriteStream& s, const ConstBufferSequence& buffers,
     ASIO_MOVE_ARG(WriteHandler) handler,
     typename enable_if<
       is_const_buffer_sequence<ConstBufferSequence>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #if !defined(ASIO_NO_DYNAMIC_BUFFER_V1)
 
@@ -908,7 +908,7 @@ async_write(AsyncWriteStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Start an asynchronous operation to write a certain amount of data to a
 /// stream.
@@ -980,7 +980,7 @@ async_write(AsyncWriteStream& s,
     typename enable_if<
       is_dynamic_buffer_v1<typename decay<DynamicBuffer_v1>::type>::value
         && !is_dynamic_buffer_v2<typename decay<DynamicBuffer_v1>::type>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 #if !defined(ASIO_NO_EXTENSIONS)
 #if !defined(ASIO_NO_IOSTREAM)
@@ -1163,7 +1163,7 @@ async_write(AsyncWriteStream& s, DynamicBuffer_v2 buffers,
         typename AsyncWriteStream::executor_type),
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /// Start an asynchronous operation to write a certain amount of data to a
 /// stream.
@@ -1233,7 +1233,7 @@ async_write(AsyncWriteStream& s, DynamicBuffer_v2 buffers,
     ASIO_MOVE_ARG(WriteHandler) handler,
     typename enable_if<
       is_dynamic_buffer_v2<DynamicBuffer_v2>::value
-    >::type* = 0);
+    >::type* = ASIO_NULLPTR);
 
 /*@}*/
 

--- a/asio/src/doc/reference.qbk
+++ b/asio/src/doc/reference.qbk
@@ -931,7 +931,7 @@ Asynchronously establishes a socket connection by trying each endpoint in a sequ
       basic_socket< Protocol, Executor > & s,
       const EndpointSequence & endpoints,
       RangeConnectHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = 0);
+      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_connect.overload1 more...]]``
 
 (Deprecated: Use range overload.) Asynchronously establishes a socket connection by trying each endpoint in a sequence. 
@@ -945,7 +945,7 @@ Asynchronously establishes a socket connection by trying each endpoint in a sequ
       basic_socket< Protocol, Executor > & s,
       Iterator begin,
       IteratorConnectHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = 0);
+      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_connect.overload2 more...]]``
 
 Asynchronously establishes a socket connection by trying each endpoint in a sequence. 
@@ -973,7 +973,7 @@ Asynchronously establishes a socket connection by trying each endpoint in a sequ
       const EndpointSequence & endpoints,
       ConnectCondition connect_condition,
       RangeConnectHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = 0);
+      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_connect.overload4 more...]]``
 
 (Deprecated: Use range overload.) Asynchronously establishes a socket connection by trying each endpoint in a sequence. 
@@ -989,7 +989,7 @@ Asynchronously establishes a socket connection by trying each endpoint in a sequ
       Iterator begin,
       ConnectCondition connect_condition,
       IteratorConnectHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = 0);
+      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_connect.overload5 more...]]``
 
 Asynchronously establishes a socket connection by trying each endpoint in a sequence. 
@@ -1030,7 +1030,7 @@ Asynchronously establishes a socket connection by trying each endpoint in a sequ
       basic_socket< Protocol, Executor > & s,
       const EndpointSequence & endpoints,
       RangeConnectHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = 0);
+      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = ASIO_NULLPTR);
 
 
 This function attempts to connect a socket to one of a sequence of endpoints. It does this by repeated calls to the socket's `async_connect` member function, once for each endpoint in the sequence, until a connection is successfully established.
@@ -1121,7 +1121,7 @@ Regardless of whether the asynchronous operation completes immediately or not, t
       basic_socket< Protocol, Executor > & s,
       Iterator begin,
       IteratorConnectHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = 0);
+      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = ASIO_NULLPTR);
 
 
 This function attempts to connect a socket to one of a sequence of endpoints. It does this by repeated calls to the socket's `async_connect` member function, once for each endpoint in the sequence, until a connection is successfully established.
@@ -1261,7 +1261,7 @@ Asynchronously establishes a socket connection by trying each endpoint in a sequ
       const EndpointSequence & endpoints,
       ConnectCondition connect_condition,
       RangeConnectHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = 0);
+      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = ASIO_NULLPTR);
 
 
 This function attempts to connect a socket to one of a sequence of endpoints. It does this by repeated calls to the socket's `async_connect` member function, once for each endpoint in the sequence, until a connection is successfully established.
@@ -1386,7 +1386,7 @@ It would be used with the `asio::connect` function as follows:
       Iterator begin,
       ConnectCondition connect_condition,
       IteratorConnectHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = 0);
+      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = ASIO_NULLPTR);
 
 
 This function attempts to connect a socket to one of a sequence of endpoints. It does this by repeated calls to the socket's `async_connect` member function, once for each endpoint in the sequence, until a connection is successfully established.
@@ -1609,7 +1609,7 @@ Start an asynchronous operation to read a certain amount of data from a stream.
       AsyncReadStream & s,
       const MutableBufferSequence & buffers,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_read.overload1 more...]]``
 
   template<
@@ -1622,7 +1622,7 @@ Start an asynchronous operation to read a certain amount of data from a stream.
       const MutableBufferSequence & buffers,
       CompletionCondition completion_condition,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_read.overload2 more...]]``
 
   template<
@@ -1633,7 +1633,7 @@ Start an asynchronous operation to read a certain amount of data from a stream.
       AsyncReadStream & s,
       DynamicBuffer_v1 && buffers,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_read.overload3 more...]]``
 
   template<
@@ -1646,7 +1646,7 @@ Start an asynchronous operation to read a certain amount of data from a stream.
       DynamicBuffer_v1 && buffers,
       CompletionCondition completion_condition,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_read.overload4 more...]]``
 
   template<
@@ -1679,7 +1679,7 @@ Start an asynchronous operation to read a certain amount of data from a stream.
       AsyncReadStream & s,
       DynamicBuffer_v2 buffers,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_read.overload7 more...]]``
 
   template<
@@ -1692,7 +1692,7 @@ Start an asynchronous operation to read a certain amount of data from a stream.
       DynamicBuffer_v2 buffers,
       CompletionCondition completion_condition,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_read.overload8 more...]]``
 
 [heading Requirements]
@@ -1716,7 +1716,7 @@ Start an asynchronous operation to read a certain amount of data from a stream.
       AsyncReadStream & s,
       const MutableBufferSequence & buffers,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously read a certain number of bytes of data from a stream. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -1801,7 +1801,7 @@ Start an asynchronous operation to read a certain amount of data from a stream.
       const MutableBufferSequence & buffers,
       CompletionCondition completion_condition,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously read a certain number of bytes of data from a stream. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -1884,7 +1884,7 @@ Start an asynchronous operation to read a certain amount of data from a stream.
       AsyncReadStream & s,
       DynamicBuffer_v1 && buffers,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously read a certain number of bytes of data from a stream. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -1959,7 +1959,7 @@ Start an asynchronous operation to read a certain amount of data from a stream.
       DynamicBuffer_v1 && buffers,
       CompletionCondition completion_condition,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously read a certain number of bytes of data from a stream. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -2176,7 +2176,7 @@ Start an asynchronous operation to read a certain amount of data from a stream.
       AsyncReadStream & s,
       DynamicBuffer_v2 buffers,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously read a certain number of bytes of data from a stream. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -2251,7 +2251,7 @@ Start an asynchronous operation to read a certain amount of data from a stream.
       DynamicBuffer_v2 buffers,
       CompletionCondition completion_condition,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously read a certain number of bytes of data from a stream. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -2708,7 +2708,7 @@ Start an asynchronous operation to read data into a dynamic buffer sequence unti
       DynamicBuffer_v1 && buffers,
       char delim,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_read_until.overload1 more...]]``
 
   template<
@@ -2720,7 +2720,7 @@ Start an asynchronous operation to read data into a dynamic buffer sequence unti
       DynamicBuffer_v1 && buffers,
       string_view delim,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_read_until.overload2 more...]]``
 
 Start an asynchronous operation to read data into a dynamic buffer sequence until some part of its data matches a regular expression. 
@@ -2734,7 +2734,7 @@ Start an asynchronous operation to read data into a dynamic buffer sequence unti
       DynamicBuffer_v1 && buffers,
       const boost::regex & expr,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_read_until.overload3 more...]]``
 
 Start an asynchronous operation to read data into a dynamic buffer sequence until a function object indicates a match. 
@@ -2749,7 +2749,7 @@ Start an asynchronous operation to read data into a dynamic buffer sequence unti
       DynamicBuffer_v1 && buffers,
       MatchCondition match_condition,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_read_until.overload4 more...]]``
 
 Start an asynchronous operation to read data into a streambuf until it contains a specified delimiter. 
@@ -2801,7 +2801,7 @@ Start an asynchronous operation to read data into a streambuf until a function o
       asio::basic_streambuf< Allocator > & b,
       MatchCondition match_condition,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_match_condition< MatchCondition >::value >::type *  = 0);
+      typename enable_if< is_match_condition< MatchCondition >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_read_until.overload8 more...]]``
 
 Start an asynchronous operation to read data into a dynamic buffer sequence until it contains a specified delimiter. 
@@ -2815,7 +2815,7 @@ Start an asynchronous operation to read data into a dynamic buffer sequence unti
       DynamicBuffer_v2 buffers,
       char delim,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_read_until.overload9 more...]]``
 
   template<
@@ -2827,7 +2827,7 @@ Start an asynchronous operation to read data into a dynamic buffer sequence unti
       DynamicBuffer_v2 buffers,
       string_view delim,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_read_until.overload10 more...]]``
 
 Start an asynchronous operation to read data into a dynamic buffer sequence until some part of its data matches a regular expression. 
@@ -2841,7 +2841,7 @@ Start an asynchronous operation to read data into a dynamic buffer sequence unti
       DynamicBuffer_v2 buffers,
       const boost::regex & expr,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_read_until.overload11 more...]]``
 
 Start an asynchronous operation to read data into a dynamic buffer sequence until a function object indicates a match. 
@@ -2856,7 +2856,7 @@ Start an asynchronous operation to read data into a dynamic buffer sequence unti
       DynamicBuffer_v2 buffers,
       MatchCondition match_condition,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_read_until.overload12 more...]]``
 
 [heading Requirements]
@@ -2881,7 +2881,7 @@ Start an asynchronous operation to read data into a dynamic buffer sequence unti
       DynamicBuffer_v1 && buffers,
       char delim,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously read data into the specified dynamic buffer sequence until the dynamic buffer sequence's get area contains the specified delimiter. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -2986,7 +2986,7 @@ Start an asynchronous operation to read data into a dynamic buffer sequence unti
       DynamicBuffer_v1 && buffers,
       string_view delim,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously read data into the specified dynamic buffer sequence until the dynamic buffer sequence's get area contains the specified delimiter. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -3091,7 +3091,7 @@ Start an asynchronous operation to read data into a dynamic buffer sequence unti
       DynamicBuffer_v1 && buffers,
       const boost::regex & expr,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously read data into the specified dynamic buffer sequence until the dynamic buffer sequence's get area contains some data that matches a regular expression. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -3199,7 +3199,7 @@ Start an asynchronous operation to read data into a dynamic buffer sequence unti
       DynamicBuffer_v1 && buffers,
       MatchCondition match_condition,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously read data into the specified dynamic buffer sequence until a user-defined match condition function object, when applied to the data contained in the dynamic buffer sequence, indicates a successful match. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -3653,7 +3653,7 @@ Start an asynchronous operation to read data into a streambuf until a function o
       asio::basic_streambuf< Allocator > & b,
       MatchCondition match_condition,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_match_condition< MatchCondition >::value >::type *  = 0);
+      typename enable_if< is_match_condition< MatchCondition >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously read data into the specified streambuf until a user-defined match condition function object, when applied to the data contained in the streambuf, indicates a successful match. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -3790,7 +3790,7 @@ Start an asynchronous operation to read data into a dynamic buffer sequence unti
       DynamicBuffer_v2 buffers,
       char delim,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously read data into the specified dynamic buffer sequence until the dynamic buffer sequence's get area contains the specified delimiter. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -3895,7 +3895,7 @@ Start an asynchronous operation to read data into a dynamic buffer sequence unti
       DynamicBuffer_v2 buffers,
       string_view delim,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously read data into the specified dynamic buffer sequence until the dynamic buffer sequence's get area contains the specified delimiter. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -4000,7 +4000,7 @@ Start an asynchronous operation to read data into a dynamic buffer sequence unti
       DynamicBuffer_v2 buffers,
       const boost::regex & expr,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously read data into the specified dynamic buffer sequence until the dynamic buffer sequence's get area contains some data that matches a regular expression. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -4108,7 +4108,7 @@ Start an asynchronous operation to read data into a dynamic buffer sequence unti
       DynamicBuffer_v2 buffers,
       MatchCondition match_condition,
       ReadHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously read data into the specified dynamic buffer sequence until a user-defined match condition function object, when applied to the data contained in the dynamic buffer sequence, indicates a successful match. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -4547,7 +4547,7 @@ Start an asynchronous operation to write all of the supplied data to a stream.
       AsyncWriteStream & s,
       const ConstBufferSequence & buffers,
       WriteHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_write.overload1 more...]]``
 
 Start an asynchronous operation to write a certain amount of data to a stream. 
@@ -4562,7 +4562,7 @@ Start an asynchronous operation to write a certain amount of data to a stream.
       const ConstBufferSequence & buffers,
       CompletionCondition completion_condition,
       WriteHandler && handler,
-      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_write.overload2 more...]]``
 
 Start an asynchronous operation to write all of the supplied data to a stream. 
@@ -4575,7 +4575,7 @@ Start an asynchronous operation to write all of the supplied data to a stream.
       AsyncWriteStream & s,
       DynamicBuffer_v1 && buffers,
       WriteHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_write.overload3 more...]]``
 
 Start an asynchronous operation to write a certain amount of data to a stream. 
@@ -4590,7 +4590,7 @@ Start an asynchronous operation to write a certain amount of data to a stream.
       DynamicBuffer_v1 && buffers,
       CompletionCondition completion_condition,
       WriteHandler && handler,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_write.overload4 more...]]``
 
 Start an asynchronous operation to write all of the supplied data to a stream. 
@@ -4629,7 +4629,7 @@ Start an asynchronous operation to write all of the supplied data to a stream.
       AsyncWriteStream & s,
       DynamicBuffer_v2 buffers,
       WriteHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_write.overload7 more...]]``
 
 Start an asynchronous operation to write a certain amount of data to a stream. 
@@ -4644,7 +4644,7 @@ Start an asynchronous operation to write a certain amount of data to a stream.
       DynamicBuffer_v2 buffers,
       CompletionCondition completion_condition,
       WriteHandler && handler,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.async_write.overload8 more...]]``
 
 [heading Requirements]
@@ -4668,7 +4668,7 @@ Start an asynchronous operation to write all of the supplied data to a stream.
       AsyncWriteStream & s,
       const ConstBufferSequence & buffers,
       WriteHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously write a certain number of bytes of data to a stream. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -4739,7 +4739,7 @@ Start an asynchronous operation to write a certain amount of data to a stream.
       const ConstBufferSequence & buffers,
       CompletionCondition completion_condition,
       WriteHandler && handler,
-      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously write a certain number of bytes of data to a stream. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -4823,7 +4823,7 @@ Start an asynchronous operation to write all of the supplied data to a stream.
       AsyncWriteStream & s,
       DynamicBuffer_v1 && buffers,
       WriteHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously write a certain number of bytes of data to a stream. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -4884,7 +4884,7 @@ Start an asynchronous operation to write a certain amount of data to a stream.
       DynamicBuffer_v1 && buffers,
       CompletionCondition completion_condition,
       WriteHandler && handler,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously write a certain number of bytes of data to a stream. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -5085,7 +5085,7 @@ Start an asynchronous operation to write all of the supplied data to a stream.
       AsyncWriteStream & s,
       DynamicBuffer_v2 buffers,
       WriteHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously write a certain number of bytes of data to a stream. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -5146,7 +5146,7 @@ Start an asynchronous operation to write a certain amount of data to a stream.
       DynamicBuffer_v2 buffers,
       CompletionCondition completion_condition,
       WriteHandler && handler,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously write a certain number of bytes of data to a stream. The function call always returns immediately. The asynchronous operation will continue until one of the following conditions is true:
@@ -7148,7 +7148,7 @@ Construct a [link asio.reference.basic_datagram_socket `basic_datagram_socket`] 
       typename ExecutionContext>
   explicit ``[link asio.reference.basic_datagram_socket.basic_datagram_socket.overload2 basic_datagram_socket]``(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_datagram_socket.basic_datagram_socket.overload2 more...]]``
 
 
@@ -7165,7 +7165,7 @@ Construct and open a [link asio.reference.basic_datagram_socket `basic_datagram_
   ``[link asio.reference.basic_datagram_socket.basic_datagram_socket.overload4 basic_datagram_socket]``(
       ExecutionContext & context,
       const protocol_type & protocol,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_datagram_socket.basic_datagram_socket.overload4 more...]]``
 
 
@@ -7182,7 +7182,7 @@ Construct a [link asio.reference.basic_datagram_socket `basic_datagram_socket`],
   ``[link asio.reference.basic_datagram_socket.basic_datagram_socket.overload6 basic_datagram_socket]``(
       ExecutionContext & context,
       const endpoint_type & endpoint,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_datagram_socket.basic_datagram_socket.overload6 more...]]``
 
 
@@ -7201,7 +7201,7 @@ Construct a [link asio.reference.basic_datagram_socket `basic_datagram_socket`] 
       ExecutionContext & context,
       const protocol_type & protocol,
       const native_handle_type & native_socket,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_datagram_socket.basic_datagram_socket.overload8 more...]]``
 
 
@@ -7221,7 +7221,7 @@ Move-construct a [link asio.reference.basic_datagram_socket `basic_datagram_sock
       typename ``[link asio.reference.Executor1 Executor1]``>
   ``[link asio.reference.basic_datagram_socket.basic_datagram_socket.overload10 basic_datagram_socket]``(
       basic_datagram_socket< Protocol1, Executor1 > && other,
-      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = 0);
+      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_datagram_socket.basic_datagram_socket.overload10 more...]]``
 
 
@@ -7264,7 +7264,7 @@ Construct a [link asio.reference.basic_datagram_socket `basic_datagram_socket`] 
       typename ExecutionContext>
   basic_datagram_socket(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a datagram socket without opening it. The `open()` function must be called before data can be sent or received on the socket.
@@ -7339,7 +7339,7 @@ Construct and open a [link asio.reference.basic_datagram_socket `basic_datagram_
   basic_datagram_socket(
       ExecutionContext & context,
       const protocol_type & protocol,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates and opens a datagram socket.
@@ -7426,7 +7426,7 @@ Construct a [link asio.reference.basic_datagram_socket `basic_datagram_socket`],
   basic_datagram_socket(
       ExecutionContext & context,
       const endpoint_type & endpoint,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a datagram socket and automatically opens it bound to the specified endpoint on the local machine. The protocol used is the protocol associated with the given endpoint.
@@ -7517,7 +7517,7 @@ Construct a [link asio.reference.basic_datagram_socket `basic_datagram_socket`] 
       ExecutionContext & context,
       const protocol_type & protocol,
       const native_handle_type & native_socket,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a datagram socket object to hold an existing native socket.
@@ -7598,7 +7598,7 @@ Move-construct a [link asio.reference.basic_datagram_socket `basic_datagram_sock
       typename ``[link asio.reference.Executor1 Executor1]``>
   basic_datagram_socket(
       basic_datagram_socket< Protocol1, Executor1 > && other,
-      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = 0);
+      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor moves a datagram socket from one object to another.
@@ -12791,7 +12791,7 @@ Constructor.
       typename ExecutionContext>
   explicit ``[link asio.reference.basic_deadline_timer.basic_deadline_timer.overload2 basic_deadline_timer]``(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_deadline_timer.basic_deadline_timer.overload2 more...]]``
 
 
@@ -12808,7 +12808,7 @@ Constructor to set a particular expiry time as an absolute time.
   ``[link asio.reference.basic_deadline_timer.basic_deadline_timer.overload4 basic_deadline_timer]``(
       ExecutionContext & context,
       const time_type & expiry_time,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_deadline_timer.basic_deadline_timer.overload4 more...]]``
 
 
@@ -12825,7 +12825,7 @@ Constructor to set a particular expiry time relative to now.
   ``[link asio.reference.basic_deadline_timer.basic_deadline_timer.overload6 basic_deadline_timer]``(
       ExecutionContext & context,
       const duration_type & expiry_time,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_deadline_timer.basic_deadline_timer.overload6 more...]]``
 
 
@@ -12876,7 +12876,7 @@ Constructor.
       typename ExecutionContext>
   basic_deadline_timer(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a timer without setting an expiry time. The `expires_at()` or `expires_from_now()` functions must be called to set an expiry time before the timer can be waited on.
@@ -12941,7 +12941,7 @@ Constructor to set a particular expiry time as an absolute time.
   basic_deadline_timer(
       ExecutionContext & context,
       const time_type & expiry_time,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a timer and sets the expiry time.
@@ -13008,7 +13008,7 @@ Constructor to set a particular expiry time relative to now.
   basic_deadline_timer(
       ExecutionContext & context,
       const duration_type & expiry_time,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a timer and sets the expiry time.
@@ -15850,7 +15850,7 @@ Construct a [link asio.reference.basic_raw_socket `basic_raw_socket`] without op
       typename ExecutionContext>
   explicit ``[link asio.reference.basic_raw_socket.basic_raw_socket.overload2 basic_raw_socket]``(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_raw_socket.basic_raw_socket.overload2 more...]]``
 
 
@@ -15867,7 +15867,7 @@ Construct and open a [link asio.reference.basic_raw_socket `basic_raw_socket`].
   ``[link asio.reference.basic_raw_socket.basic_raw_socket.overload4 basic_raw_socket]``(
       ExecutionContext & context,
       const protocol_type & protocol,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_raw_socket.basic_raw_socket.overload4 more...]]``
 
 
@@ -15884,7 +15884,7 @@ Construct a [link asio.reference.basic_raw_socket `basic_raw_socket`], opening i
   ``[link asio.reference.basic_raw_socket.basic_raw_socket.overload6 basic_raw_socket]``(
       ExecutionContext & context,
       const endpoint_type & endpoint,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_raw_socket.basic_raw_socket.overload6 more...]]``
 
 
@@ -15903,7 +15903,7 @@ Construct a [link asio.reference.basic_raw_socket `basic_raw_socket`] on an exis
       ExecutionContext & context,
       const protocol_type & protocol,
       const native_handle_type & native_socket,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_raw_socket.basic_raw_socket.overload8 more...]]``
 
 
@@ -15923,7 +15923,7 @@ Move-construct a [link asio.reference.basic_raw_socket `basic_raw_socket`] from 
       typename ``[link asio.reference.Executor1 Executor1]``>
   ``[link asio.reference.basic_raw_socket.basic_raw_socket.overload10 basic_raw_socket]``(
       basic_raw_socket< Protocol1, Executor1 > && other,
-      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = 0);
+      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_raw_socket.basic_raw_socket.overload10 more...]]``
 
 
@@ -15966,7 +15966,7 @@ Construct a [link asio.reference.basic_raw_socket `basic_raw_socket`] without op
       typename ExecutionContext>
   basic_raw_socket(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a raw socket without opening it. The `open()` function must be called before data can be sent or received on the socket.
@@ -16041,7 +16041,7 @@ Construct and open a [link asio.reference.basic_raw_socket `basic_raw_socket`].
   basic_raw_socket(
       ExecutionContext & context,
       const protocol_type & protocol,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates and opens a raw socket.
@@ -16128,7 +16128,7 @@ Construct a [link asio.reference.basic_raw_socket `basic_raw_socket`], opening i
   basic_raw_socket(
       ExecutionContext & context,
       const endpoint_type & endpoint,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a raw socket and automatically opens it bound to the specified endpoint on the local machine. The protocol used is the protocol associated with the given endpoint.
@@ -16219,7 +16219,7 @@ Construct a [link asio.reference.basic_raw_socket `basic_raw_socket`] on an exis
       ExecutionContext & context,
       const protocol_type & protocol,
       const native_handle_type & native_socket,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a raw socket object to hold an existing native socket.
@@ -16300,7 +16300,7 @@ Move-construct a [link asio.reference.basic_raw_socket `basic_raw_socket`] from 
       typename ``[link asio.reference.Executor1 Executor1]``>
   basic_raw_socket(
       basic_raw_socket< Protocol1, Executor1 > && other,
-      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = 0);
+      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor moves a raw socket from one object to another.
@@ -22199,7 +22199,7 @@ Construct a [link asio.reference.basic_seq_packet_socket `basic_seq_packet_socke
       typename ExecutionContext>
   explicit ``[link asio.reference.basic_seq_packet_socket.basic_seq_packet_socket.overload2 basic_seq_packet_socket]``(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_seq_packet_socket.basic_seq_packet_socket.overload2 more...]]``
 
 
@@ -22216,7 +22216,7 @@ Construct and open a [link asio.reference.basic_seq_packet_socket `basic_seq_pac
   ``[link asio.reference.basic_seq_packet_socket.basic_seq_packet_socket.overload4 basic_seq_packet_socket]``(
       ExecutionContext & context,
       const protocol_type & protocol,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_seq_packet_socket.basic_seq_packet_socket.overload4 more...]]``
 
 
@@ -22233,7 +22233,7 @@ Construct a [link asio.reference.basic_seq_packet_socket `basic_seq_packet_socke
   ``[link asio.reference.basic_seq_packet_socket.basic_seq_packet_socket.overload6 basic_seq_packet_socket]``(
       ExecutionContext & context,
       const endpoint_type & endpoint,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_seq_packet_socket.basic_seq_packet_socket.overload6 more...]]``
 
 
@@ -22252,7 +22252,7 @@ Construct a [link asio.reference.basic_seq_packet_socket `basic_seq_packet_socke
       ExecutionContext & context,
       const protocol_type & protocol,
       const native_handle_type & native_socket,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_seq_packet_socket.basic_seq_packet_socket.overload8 more...]]``
 
 
@@ -22272,7 +22272,7 @@ Move-construct a [link asio.reference.basic_seq_packet_socket `basic_seq_packet_
       typename ``[link asio.reference.Executor1 Executor1]``>
   ``[link asio.reference.basic_seq_packet_socket.basic_seq_packet_socket.overload10 basic_seq_packet_socket]``(
       basic_seq_packet_socket< Protocol1, Executor1 > && other,
-      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = 0);
+      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_seq_packet_socket.basic_seq_packet_socket.overload10 more...]]``
 
 
@@ -22315,7 +22315,7 @@ Construct a [link asio.reference.basic_seq_packet_socket `basic_seq_packet_socke
       typename ExecutionContext>
   basic_seq_packet_socket(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a sequenced packet socket without opening it. The socket needs to be opened and then connected or accepted before data can be sent or received on it.
@@ -22390,7 +22390,7 @@ Construct and open a [link asio.reference.basic_seq_packet_socket `basic_seq_pac
   basic_seq_packet_socket(
       ExecutionContext & context,
       const protocol_type & protocol,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates and opens a sequenced\_packet socket. The socket needs to be connected or accepted before data can be sent or received on it.
@@ -22477,7 +22477,7 @@ Construct a [link asio.reference.basic_seq_packet_socket `basic_seq_packet_socke
   basic_seq_packet_socket(
       ExecutionContext & context,
       const endpoint_type & endpoint,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a sequenced packet socket and automatically opens it bound to the specified endpoint on the local machine. The protocol used is the protocol associated with the given endpoint.
@@ -22568,7 +22568,7 @@ Construct a [link asio.reference.basic_seq_packet_socket `basic_seq_packet_socke
       ExecutionContext & context,
       const protocol_type & protocol,
       const native_handle_type & native_socket,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a sequenced packet socket object to hold an existing native socket.
@@ -22649,7 +22649,7 @@ Move-construct a [link asio.reference.basic_seq_packet_socket `basic_seq_packet_
       typename ``[link asio.reference.Executor1 Executor1]``>
   basic_seq_packet_socket(
       basic_seq_packet_socket< Protocol1, Executor1 > && other,
-      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = 0);
+      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor moves a sequenced packet socket from one object to another.
@@ -27469,7 +27469,7 @@ Construct a [link asio.reference.basic_serial_port `basic_serial_port`] without 
       typename ExecutionContext>
   explicit ``[link asio.reference.basic_serial_port.basic_serial_port.overload2 basic_serial_port]``(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_serial_port >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_serial_port >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_serial_port.basic_serial_port.overload2 more...]]``
 
 
@@ -27486,7 +27486,7 @@ Construct and open a [link asio.reference.basic_serial_port `basic_serial_port`]
   ``[link asio.reference.basic_serial_port.basic_serial_port.overload4 basic_serial_port]``(
       ExecutionContext & context,
       const char * device,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_serial_port.basic_serial_port.overload4 more...]]``
 
   ``[link asio.reference.basic_serial_port.basic_serial_port.overload5 basic_serial_port]``(
@@ -27499,7 +27499,7 @@ Construct and open a [link asio.reference.basic_serial_port `basic_serial_port`]
   ``[link asio.reference.basic_serial_port.basic_serial_port.overload6 basic_serial_port]``(
       ExecutionContext & context,
       const std::string & device,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_serial_port.basic_serial_port.overload6 more...]]``
 
 
@@ -27516,7 +27516,7 @@ Construct a [link asio.reference.basic_serial_port `basic_serial_port`] on an ex
   ``[link asio.reference.basic_serial_port.basic_serial_port.overload8 basic_serial_port]``(
       ExecutionContext & context,
       const native_handle_type & native_serial_port,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_serial_port.basic_serial_port.overload8 more...]]``
 
 
@@ -27567,7 +27567,7 @@ Construct a [link asio.reference.basic_serial_port `basic_serial_port`] without 
       typename ExecutionContext>
   basic_serial_port(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_serial_port >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_serial_port >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a serial port without opening it.
@@ -27632,7 +27632,7 @@ Construct and open a [link asio.reference.basic_serial_port `basic_serial_port`]
   basic_serial_port(
       ExecutionContext & context,
       const char * device,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates and opens a serial port for the specified device name.
@@ -27699,7 +27699,7 @@ Construct and open a [link asio.reference.basic_serial_port `basic_serial_port`]
   basic_serial_port(
       ExecutionContext & context,
       const std::string & device,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates and opens a serial port for the specified device name.
@@ -27776,7 +27776,7 @@ Construct a [link asio.reference.basic_serial_port `basic_serial_port`] on an ex
   basic_serial_port(
       ExecutionContext & context,
       const native_handle_type & native_serial_port,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a serial port object to hold an existing native serial port.
@@ -29470,7 +29470,7 @@ Construct a signal set without adding any signals.
       typename ExecutionContext>
   explicit ``[link asio.reference.basic_signal_set.basic_signal_set.overload2 basic_signal_set]``(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_signal_set.basic_signal_set.overload2 more...]]``
 
 
@@ -29487,7 +29487,7 @@ Construct a signal set and add one signal.
   ``[link asio.reference.basic_signal_set.basic_signal_set.overload4 basic_signal_set]``(
       ExecutionContext & context,
       int signal_number_1,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_signal_set.basic_signal_set.overload4 more...]]``
 
 
@@ -29506,7 +29506,7 @@ Construct a signal set and add two signals.
       ExecutionContext & context,
       int signal_number_1,
       int signal_number_2,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_signal_set.basic_signal_set.overload6 more...]]``
 
 
@@ -29527,7 +29527,7 @@ Construct a signal set and add three signals.
       int signal_number_1,
       int signal_number_2,
       int signal_number_3,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_signal_set.basic_signal_set.overload8 more...]]``
 
 
@@ -29570,7 +29570,7 @@ Construct a signal set without adding any signals.
       typename ExecutionContext>
   basic_signal_set(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a signal set without registering for any signals.
@@ -29646,7 +29646,7 @@ Construct a signal set and add one signal.
   basic_signal_set(
       ExecutionContext & context,
       int signal_number_1,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a signal set and registers for one signal.
@@ -29740,7 +29740,7 @@ Construct a signal set and add two signals.
       ExecutionContext & context,
       int signal_number_1,
       int signal_number_2,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a signal set and registers for two signals.
@@ -29842,7 +29842,7 @@ Construct a signal set and add three signals.
       int signal_number_1,
       int signal_number_2,
       int signal_number_3,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a signal set and registers for three signals.
@@ -31150,7 +31150,7 @@ Construct a [link asio.reference.basic_socket `basic_socket`] without opening it
       typename ExecutionContext>
   explicit ``[link asio.reference.basic_socket.basic_socket.overload2 basic_socket]``(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket.basic_socket.overload2 more...]]``
 
 
@@ -31167,7 +31167,7 @@ Construct and open a [link asio.reference.basic_socket `basic_socket`].
   ``[link asio.reference.basic_socket.basic_socket.overload4 basic_socket]``(
       ExecutionContext & context,
       const protocol_type & protocol,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket.basic_socket.overload4 more...]]``
 
 
@@ -31184,7 +31184,7 @@ Construct a [link asio.reference.basic_socket `basic_socket`], opening it and bi
   ``[link asio.reference.basic_socket.basic_socket.overload6 basic_socket]``(
       ExecutionContext & context,
       const endpoint_type & endpoint,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket.basic_socket.overload6 more...]]``
 
 
@@ -31203,7 +31203,7 @@ Construct a [link asio.reference.basic_socket `basic_socket`] on an existing nat
       ExecutionContext & context,
       const protocol_type & protocol,
       const native_handle_type & native_socket,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket.basic_socket.overload8 more...]]``
 
 
@@ -31223,7 +31223,7 @@ Move-construct a [link asio.reference.basic_socket `basic_socket`] from a socket
       typename ``[link asio.reference.Executor1 Executor1]``>
   ``[link asio.reference.basic_socket.basic_socket.overload10 basic_socket]``(
       basic_socket< Protocol1, Executor1 > && other,
-      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = 0);
+      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket.basic_socket.overload10 more...]]``
 
 
@@ -31266,7 +31266,7 @@ Construct a [link asio.reference.basic_socket `basic_socket`] without opening it
       typename ExecutionContext>
   basic_socket(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a socket without opening it.
@@ -31341,7 +31341,7 @@ Construct and open a [link asio.reference.basic_socket `basic_socket`].
   basic_socket(
       ExecutionContext & context,
       const protocol_type & protocol,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates and opens a socket.
@@ -31428,7 +31428,7 @@ Construct a [link asio.reference.basic_socket `basic_socket`], opening it and bi
   basic_socket(
       ExecutionContext & context,
       const endpoint_type & endpoint,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a socket and automatically opens it bound to the specified endpoint on the local machine. The protocol used is the protocol associated with the given endpoint.
@@ -31519,7 +31519,7 @@ Construct a [link asio.reference.basic_socket `basic_socket`] on an existing nat
       ExecutionContext & context,
       const protocol_type & protocol,
       const native_handle_type & native_socket,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a socket object to hold an existing native socket.
@@ -31600,7 +31600,7 @@ Move-construct a [link asio.reference.basic_socket `basic_socket`] from a socket
       typename ``[link asio.reference.Executor1 Executor1]``>
   basic_socket(
       basic_socket< Protocol1, Executor1 > && other,
-      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = 0);
+      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor moves a socket from one object to another.
@@ -35988,7 +35988,7 @@ Accept a new connection.
       typename ``[link asio.reference.Executor1 Executor1]``>
   void ``[link asio.reference.basic_socket_acceptor.accept.overload1 accept]``(
       basic_socket< Protocol1, Executor1 > & peer,
-      typename enable_if< is_convertible< Protocol, Protocol1 >::value >::type *  = 0);
+      typename enable_if< is_convertible< Protocol, Protocol1 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.accept.overload1 more...]]``
 
   template<
@@ -35997,7 +35997,7 @@ Accept a new connection.
   void ``[link asio.reference.basic_socket_acceptor.accept.overload2 accept]``(
       basic_socket< Protocol1, Executor1 > & peer,
       asio::error_code & ec,
-      typename enable_if< is_convertible< Protocol, Protocol1 >::value >::type *  = 0);
+      typename enable_if< is_convertible< Protocol, Protocol1 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.accept.overload2 more...]]``
 
 
@@ -36030,14 +36030,14 @@ Accept a new connection and obtain the endpoint of the peer.
       typename ``[link asio.reference.Executor1 Executor1]``>
   Protocol::socket::template rebind_executor< Executor1 >::other ``[link asio.reference.basic_socket_acceptor.accept.overload7 accept]``(
       const Executor1 & ex,
-      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.accept.overload7 more...]]``
 
   template<
       typename ExecutionContext>
   Protocol::socket::template rebind_executor< typename ExecutionContext::executor_type >::other ``[link asio.reference.basic_socket_acceptor.accept.overload8 accept]``(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.accept.overload8 more...]]``
 
   template<
@@ -36045,7 +36045,7 @@ Accept a new connection and obtain the endpoint of the peer.
   Protocol::socket::template rebind_executor< Executor1 >::other ``[link asio.reference.basic_socket_acceptor.accept.overload9 accept]``(
       const Executor1 & ex,
       asio::error_code & ec,
-      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.accept.overload9 more...]]``
 
   template<
@@ -36053,7 +36053,7 @@ Accept a new connection and obtain the endpoint of the peer.
   Protocol::socket::template rebind_executor< typename ExecutionContext::executor_type >::other ``[link asio.reference.basic_socket_acceptor.accept.overload10 accept]``(
       ExecutionContext & context,
       asio::error_code & ec,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.accept.overload10 more...]]``
 
   Protocol::socket::template rebind_executor< executor_type >::other ``[link asio.reference.basic_socket_acceptor.accept.overload11 accept]``(
@@ -36070,7 +36070,7 @@ Accept a new connection and obtain the endpoint of the peer.
   Protocol::socket::template rebind_executor< Executor1 >::other ``[link asio.reference.basic_socket_acceptor.accept.overload13 accept]``(
       const Executor1 & ex,
       endpoint_type & peer_endpoint,
-      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.accept.overload13 more...]]``
 
   template<
@@ -36078,7 +36078,7 @@ Accept a new connection and obtain the endpoint of the peer.
   Protocol::socket::template rebind_executor< typename ExecutionContext::executor_type >::other ``[link asio.reference.basic_socket_acceptor.accept.overload14 accept]``(
       ExecutionContext & context,
       endpoint_type & peer_endpoint,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.accept.overload14 more...]]``
 
   template<
@@ -36087,7 +36087,7 @@ Accept a new connection and obtain the endpoint of the peer.
       const executor_type & ex,
       endpoint_type & peer_endpoint,
       asio::error_code & ec,
-      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.accept.overload15 more...]]``
 
   template<
@@ -36096,7 +36096,7 @@ Accept a new connection and obtain the endpoint of the peer.
       ExecutionContext & context,
       endpoint_type & peer_endpoint,
       asio::error_code & ec,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.accept.overload16 more...]]``
 
 
@@ -36111,7 +36111,7 @@ Accept a new connection.
       typename ``[link asio.reference.Executor1 Executor1]``>
   void accept(
       basic_socket< Protocol1, Executor1 > & peer,
-      typename enable_if< is_convertible< Protocol, Protocol1 >::value >::type *  = 0);
+      typename enable_if< is_convertible< Protocol, Protocol1 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to accept a new connection from a peer into the given socket. The function call will block until a new connection has been accepted successfully or an error occurs.
@@ -36168,7 +36168,7 @@ Accept a new connection.
   void accept(
       basic_socket< Protocol1, Executor1 > & peer,
       asio::error_code & ec,
-      typename enable_if< is_convertible< Protocol, Protocol1 >::value >::type *  = 0);
+      typename enable_if< is_convertible< Protocol, Protocol1 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to accept a new connection from a peer into the given socket. The function call will block until a new connection has been accepted successfully or an error occurs.
@@ -36433,7 +36433,7 @@ Accept a new connection.
       typename ``[link asio.reference.Executor1 Executor1]``>
   Protocol::socket::template rebind_executor< Executor1 >::other accept(
       const Executor1 & ex,
-      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to accept a new connection from a peer. The function call will block until a new connection has been accepted successfully or an error occurs.
@@ -36494,7 +36494,7 @@ Accept a new connection.
       typename ExecutionContext>
   Protocol::socket::template rebind_executor< typename ExecutionContext::executor_type >::other accept(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to accept a new connection from a peer. The function call will block until a new connection has been accepted successfully or an error occurs.
@@ -36556,7 +36556,7 @@ Accept a new connection.
   Protocol::socket::template rebind_executor< Executor1 >::other accept(
       const Executor1 & ex,
       asio::error_code & ec,
-      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to accept a new connection from a peer. The function call will block until a new connection has been accepted successfully or an error occurs.
@@ -36614,7 +36614,7 @@ Accept a new connection.
   Protocol::socket::template rebind_executor< typename ExecutionContext::executor_type >::other accept(
       ExecutionContext & context,
       asio::error_code & ec,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to accept a new connection from a peer. The function call will block until a new connection has been accepted successfully or an error occurs.
@@ -36787,7 +36787,7 @@ Accept a new connection.
   Protocol::socket::template rebind_executor< Executor1 >::other accept(
       const Executor1 & ex,
       endpoint_type & peer_endpoint,
-      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to accept a new connection from a peer. The function call will block until a new connection has been accepted successfully or an error occurs.
@@ -36853,7 +36853,7 @@ Accept a new connection.
   Protocol::socket::template rebind_executor< typename ExecutionContext::executor_type >::other accept(
       ExecutionContext & context,
       endpoint_type & peer_endpoint,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to accept a new connection from a peer. The function call will block until a new connection has been accepted successfully or an error occurs.
@@ -36920,7 +36920,7 @@ Accept a new connection.
       const executor_type & ex,
       endpoint_type & peer_endpoint,
       asio::error_code & ec,
-      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to accept a new connection from a peer. The function call will block until a new connection has been accepted successfully or an error occurs.
@@ -36983,7 +36983,7 @@ Accept a new connection.
       ExecutionContext & context,
       endpoint_type & peer_endpoint,
       asio::error_code & ec,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to accept a new connection from a peer. The function call will block until a new connection has been accepted successfully or an error occurs.
@@ -37100,7 +37100,7 @@ Start an asynchronous accept.
   ``[link asio.reference.asynchronous_operations.automatic_deduction_of_initiating_function_return_type ['DEDUCED]]`` ``[link asio.reference.basic_socket_acceptor.async_accept.overload1 async_accept]``(
       basic_socket< Protocol1, Executor1 > & peer,
       AcceptHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_convertible< Protocol, Protocol1 >::value >::type *  = 0);
+      typename enable_if< is_convertible< Protocol, Protocol1 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.async_accept.overload1 more...]]``
 
   template<
@@ -37124,7 +37124,7 @@ Start an asynchronous accept.
   ``[link asio.reference.asynchronous_operations.automatic_deduction_of_initiating_function_return_type ['DEDUCED]]`` ``[link asio.reference.basic_socket_acceptor.async_accept.overload4 async_accept]``(
       const Executor1 & ex,
       MoveAcceptHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.async_accept.overload4 more...]]``
 
   template<
@@ -37133,7 +37133,7 @@ Start an asynchronous accept.
   ``[link asio.reference.asynchronous_operations.automatic_deduction_of_initiating_function_return_type ['DEDUCED]]`` ``[link asio.reference.basic_socket_acceptor.async_accept.overload5 async_accept]``(
       ExecutionContext & context,
       MoveAcceptHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.async_accept.overload5 more...]]``
 
   template<
@@ -37150,7 +37150,7 @@ Start an asynchronous accept.
       const Executor1 & ex,
       endpoint_type & peer_endpoint,
       MoveAcceptHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.async_accept.overload7 more...]]``
 
   template<
@@ -37160,7 +37160,7 @@ Start an asynchronous accept.
       ExecutionContext & context,
       endpoint_type & peer_endpoint,
       MoveAcceptHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.async_accept.overload8 more...]]``
 
 
@@ -37177,7 +37177,7 @@ Start an asynchronous accept.
   ``[link asio.reference.asynchronous_operations.automatic_deduction_of_initiating_function_return_type ['DEDUCED]]`` async_accept(
       basic_socket< Protocol1, Executor1 > & peer,
       AcceptHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_convertible< Protocol, Protocol1 >::value >::type *  = 0);
+      typename enable_if< is_convertible< Protocol, Protocol1 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously accept a new connection into a socket. The function call always returns immediately.
@@ -37352,7 +37352,7 @@ Start an asynchronous accept.
   ``[link asio.reference.asynchronous_operations.automatic_deduction_of_initiating_function_return_type ['DEDUCED]]`` async_accept(
       const Executor1 & ex,
       MoveAcceptHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously accept a new connection. The function call always returns immediately.
@@ -37421,7 +37421,7 @@ Start an asynchronous accept.
   ``[link asio.reference.asynchronous_operations.automatic_deduction_of_initiating_function_return_type ['DEDUCED]]`` async_accept(
       ExecutionContext & context,
       MoveAcceptHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously accept a new connection. The function call always returns immediately.
@@ -37562,7 +37562,7 @@ Start an asynchronous accept.
       const Executor1 & ex,
       endpoint_type & peer_endpoint,
       MoveAcceptHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor1 >::value||execution::is_executor< Executor1 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously accept a new connection. The function call always returns immediately.
@@ -37635,7 +37635,7 @@ Start an asynchronous accept.
       ExecutionContext & context,
       endpoint_type & peer_endpoint,
       MoveAcceptHandler && handler = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to asynchronously accept a new connection. The function call always returns immediately.
@@ -37775,7 +37775,7 @@ Construct an acceptor without opening it.
       typename ExecutionContext>
   explicit ``[link asio.reference.basic_socket_acceptor.basic_socket_acceptor.overload2 basic_socket_acceptor]``(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.basic_socket_acceptor.overload2 more...]]``
 
 
@@ -37792,7 +37792,7 @@ Construct an open acceptor.
   ``[link asio.reference.basic_socket_acceptor.basic_socket_acceptor.overload4 basic_socket_acceptor]``(
       ExecutionContext & context,
       const protocol_type & protocol,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.basic_socket_acceptor.overload4 more...]]``
 
 
@@ -37811,7 +37811,7 @@ Construct an acceptor opened on the given endpoint.
       ExecutionContext & context,
       const endpoint_type & endpoint,
       bool reuse_addr = true,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.basic_socket_acceptor.overload6 more...]]``
 
 
@@ -37830,7 +37830,7 @@ Construct a [link asio.reference.basic_socket_acceptor `basic_socket_acceptor`] 
       ExecutionContext & context,
       const protocol_type & protocol,
       const native_handle_type & native_acceptor,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.basic_socket_acceptor.overload8 more...]]``
 
 
@@ -37850,7 +37850,7 @@ Move-construct a [link asio.reference.basic_socket_acceptor `basic_socket_accept
       typename ``[link asio.reference.Executor1 Executor1]``>
   ``[link asio.reference.basic_socket_acceptor.basic_socket_acceptor.overload10 basic_socket_acceptor]``(
       basic_socket_acceptor< Protocol1, Executor1 > && other,
-      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = 0);
+      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_socket_acceptor.basic_socket_acceptor.overload10 more...]]``
 
 
@@ -37893,7 +37893,7 @@ Construct an acceptor without opening it.
       typename ExecutionContext>
   basic_socket_acceptor(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates an acceptor without opening it to listen for new connections. The `open()` function must be called before the acceptor can accept new socket connections.
@@ -37968,7 +37968,7 @@ Construct an open acceptor.
   basic_socket_acceptor(
       ExecutionContext & context,
       const protocol_type & protocol,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates an acceptor and automatically opens it.
@@ -38074,7 +38074,7 @@ Construct an acceptor opened on the given endpoint.
       ExecutionContext & context,
       const endpoint_type & endpoint,
       bool reuse_addr = true,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates an acceptor and automatically opens it to listen for new connections on the specified endpoint.
@@ -38182,7 +38182,7 @@ Construct a [link asio.reference.basic_socket_acceptor `basic_socket_acceptor`] 
       ExecutionContext & context,
       const protocol_type & protocol,
       const native_handle_type & native_acceptor,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates an acceptor object to hold an existing native acceptor.
@@ -38263,7 +38263,7 @@ Move-construct a [link asio.reference.basic_socket_acceptor `basic_socket_accept
       typename ``[link asio.reference.Executor1 Executor1]``>
   basic_socket_acceptor(
       basic_socket_acceptor< Protocol1, Executor1 > && other,
-      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = 0);
+      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor moves an acceptor from one object to another.
@@ -44011,7 +44011,7 @@ Construct a [link asio.reference.basic_stream_socket `basic_stream_socket`] with
       typename ExecutionContext>
   explicit ``[link asio.reference.basic_stream_socket.basic_stream_socket.overload2 basic_stream_socket]``(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_stream_socket.basic_stream_socket.overload2 more...]]``
 
 
@@ -44028,7 +44028,7 @@ Construct and open a [link asio.reference.basic_stream_socket `basic_stream_sock
   ``[link asio.reference.basic_stream_socket.basic_stream_socket.overload4 basic_stream_socket]``(
       ExecutionContext & context,
       const protocol_type & protocol,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_stream_socket.basic_stream_socket.overload4 more...]]``
 
 
@@ -44045,7 +44045,7 @@ Construct a [link asio.reference.basic_stream_socket `basic_stream_socket`], ope
   ``[link asio.reference.basic_stream_socket.basic_stream_socket.overload6 basic_stream_socket]``(
       ExecutionContext & context,
       const endpoint_type & endpoint,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_stream_socket.basic_stream_socket.overload6 more...]]``
 
 
@@ -44064,7 +44064,7 @@ Construct a [link asio.reference.basic_stream_socket `basic_stream_socket`] on a
       ExecutionContext & context,
       const protocol_type & protocol,
       const native_handle_type & native_socket,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_stream_socket.basic_stream_socket.overload8 more...]]``
 
 
@@ -44084,7 +44084,7 @@ Move-construct a [link asio.reference.basic_stream_socket `basic_stream_socket`]
       typename ``[link asio.reference.Executor1 Executor1]``>
   ``[link asio.reference.basic_stream_socket.basic_stream_socket.overload10 basic_stream_socket]``(
       basic_stream_socket< Protocol1, Executor1 > && other,
-      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = 0);
+      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_stream_socket.basic_stream_socket.overload10 more...]]``
 
 
@@ -44127,7 +44127,7 @@ Construct a [link asio.reference.basic_stream_socket `basic_stream_socket`] with
       typename ExecutionContext>
   basic_stream_socket(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a stream socket without opening it. The socket needs to be opened and then connected or accepted before data can be sent or received on it.
@@ -44202,7 +44202,7 @@ Construct and open a [link asio.reference.basic_stream_socket `basic_stream_sock
   basic_stream_socket(
       ExecutionContext & context,
       const protocol_type & protocol,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates and opens a stream socket. The socket needs to be connected or accepted before data can be sent or received on it.
@@ -44289,7 +44289,7 @@ Construct a [link asio.reference.basic_stream_socket `basic_stream_socket`], ope
   basic_stream_socket(
       ExecutionContext & context,
       const endpoint_type & endpoint,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a stream socket and automatically opens it bound to the specified endpoint on the local machine. The protocol used is the protocol associated with the given endpoint.
@@ -44380,7 +44380,7 @@ Construct a [link asio.reference.basic_stream_socket `basic_stream_socket`] on a
       ExecutionContext & context,
       const protocol_type & protocol,
       const native_handle_type & native_socket,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a stream socket object to hold an existing native socket.
@@ -44461,7 +44461,7 @@ Move-construct a [link asio.reference.basic_stream_socket `basic_stream_socket`]
       typename ``[link asio.reference.Executor1 Executor1]``>
   basic_stream_socket(
       basic_stream_socket< Protocol1, Executor1 > && other,
-      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = 0);
+      typename enable_if< is_convertible< Protocol1, Protocol >::value &&is_convertible< Executor1, Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor moves a stream socket from one object to another.
@@ -51507,7 +51507,7 @@ Constructor.
       typename ExecutionContext>
   explicit ``[link asio.reference.basic_waitable_timer.basic_waitable_timer.overload2 basic_waitable_timer]``(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_waitable_timer.basic_waitable_timer.overload2 more...]]``
 
 
@@ -51524,7 +51524,7 @@ Constructor to set a particular expiry time as an absolute time.
   explicit ``[link asio.reference.basic_waitable_timer.basic_waitable_timer.overload4 basic_waitable_timer]``(
       ExecutionContext & context,
       const time_point & expiry_time,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_waitable_timer.basic_waitable_timer.overload4 more...]]``
 
 
@@ -51541,7 +51541,7 @@ Constructor to set a particular expiry time relative to now.
   explicit ``[link asio.reference.basic_waitable_timer.basic_waitable_timer.overload6 basic_waitable_timer]``(
       ExecutionContext & context,
       const duration & expiry_time,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_waitable_timer.basic_waitable_timer.overload6 more...]]``
 
 
@@ -51556,7 +51556,7 @@ Move-construct a [link asio.reference.basic_waitable_timer `basic_waitable_timer
       typename ``[link asio.reference.Executor1 Executor1]``>
   ``[link asio.reference.basic_waitable_timer.basic_waitable_timer.overload8 basic_waitable_timer]``(
       basic_waitable_timer< Clock, WaitTraits, Executor1 > && other,
-      typename enable_if< is_convertible< Executor1, Executor >::value >::type *  = 0);
+      typename enable_if< is_convertible< Executor1, Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.basic_waitable_timer.basic_waitable_timer.overload8 more...]]``
 
 
@@ -51599,7 +51599,7 @@ Constructor.
       typename ExecutionContext>
   basic_waitable_timer(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a timer without setting an expiry time. The `expires_at()` or `expires_after()` functions must be called to set an expiry time before the timer can be waited on.
@@ -51664,7 +51664,7 @@ Constructor to set a particular expiry time as an absolute time.
   basic_waitable_timer(
       ExecutionContext & context,
       const time_point & expiry_time,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a timer and sets the expiry time.
@@ -51731,7 +51731,7 @@ Constructor to set a particular expiry time relative to now.
   basic_waitable_timer(
       ExecutionContext & context,
       const duration & expiry_time,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a timer and sets the expiry time.
@@ -51799,7 +51799,7 @@ Move-construct a [link asio.reference.basic_waitable_timer `basic_waitable_timer
       typename ``[link asio.reference.Executor1 Executor1]``>
   basic_waitable_timer(
       basic_waitable_timer< Clock, WaitTraits, Executor1 > && other,
-      typename enable_if< is_convertible< Executor1, Executor >::value >::type *  = 0);
+      typename enable_if< is_convertible< Executor1, Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor moves a timer from one object to another.
@@ -53241,7 +53241,7 @@ Associate an object of type `T` with an executor of type `Executor`.
   executor_binder< typename decay< T >::type, Executor > ``[link asio.reference.bind_executor.overload1 bind_executor]``(
       const Executor & ex,
       T && t,
-      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.bind_executor.overload1 more...]]``
 
 Associate an object of type `T` with an execution context's executor. 
@@ -53252,7 +53252,7 @@ Associate an object of type `T` with an execution context's executor.
   executor_binder< typename decay< T >::type, typename ExecutionContext::executor_type > ``[link asio.reference.bind_executor.overload2 bind_executor]``(
       ExecutionContext & ctx,
       T && t,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.bind_executor.overload2 more...]]``
 
 [heading Requirements]
@@ -53274,7 +53274,7 @@ Associate an object of type `T` with an executor of type `Executor`.
   executor_binder< typename decay< T >::type, Executor > bind_executor(
       const Executor & ex,
       T && t,
-      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -53294,7 +53294,7 @@ Associate an object of type `T` with an execution context's executor.
   executor_binder< typename decay< T >::type, typename ExecutionContext::executor_type > bind_executor(
       ExecutionContext & ctx,
       T && t,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -55027,28 +55027,28 @@ Get an iterator to the first element in a buffer sequence.
       typename MutableBuffer>
   const mutable_buffer * ``[link asio.reference.buffer_sequence_begin.overload1 buffer_sequence_begin]``(
       const MutableBuffer & b,
-      typename enable_if< is_convertible< const MutableBuffer *, const mutable_buffer * >::value >::type *  = 0);
+      typename enable_if< is_convertible< const MutableBuffer *, const mutable_buffer * >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.buffer_sequence_begin.overload1 more...]]``
 
   template<
       typename ConstBuffer>
   const const_buffer * ``[link asio.reference.buffer_sequence_begin.overload2 buffer_sequence_begin]``(
       const ConstBuffer & b,
-      typename enable_if< is_convertible< const ConstBuffer *, const const_buffer * >::value >::type *  = 0);
+      typename enable_if< is_convertible< const ConstBuffer *, const const_buffer * >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.buffer_sequence_begin.overload2 more...]]``
 
   template<
       typename C>
   auto ``[link asio.reference.buffer_sequence_begin.overload3 buffer_sequence_begin]``(
       C & c,
-      typename enable_if< !is_convertible< const C *, const mutable_buffer * >::value &&!is_convertible< const C *, const const_buffer * >::value >::type *  = 0);
+      typename enable_if< !is_convertible< const C *, const mutable_buffer * >::value &&!is_convertible< const C *, const const_buffer * >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.buffer_sequence_begin.overload3 more...]]``
 
   template<
       typename C>
   auto ``[link asio.reference.buffer_sequence_begin.overload4 buffer_sequence_begin]``(
       const C & c,
-      typename enable_if< !is_convertible< const C *, const mutable_buffer * >::value &&!is_convertible< const C *, const const_buffer * >::value >::type *  = 0);
+      typename enable_if< !is_convertible< const C *, const mutable_buffer * >::value &&!is_convertible< const C *, const const_buffer * >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.buffer_sequence_begin.overload4 more...]]``
 
 [heading Requirements]
@@ -55068,7 +55068,7 @@ Get an iterator to the first element in a buffer sequence.
       typename MutableBuffer>
   const mutable_buffer * buffer_sequence_begin(
       const MutableBuffer & b,
-      typename enable_if< is_convertible< const MutableBuffer *, const mutable_buffer * >::value >::type *  = 0);
+      typename enable_if< is_convertible< const MutableBuffer *, const mutable_buffer * >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -55086,7 +55086,7 @@ Get an iterator to the first element in a buffer sequence.
       typename ConstBuffer>
   const const_buffer * buffer_sequence_begin(
       const ConstBuffer & b,
-      typename enable_if< is_convertible< const ConstBuffer *, const const_buffer * >::value >::type *  = 0);
+      typename enable_if< is_convertible< const ConstBuffer *, const const_buffer * >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -55104,7 +55104,7 @@ Get an iterator to the first element in a buffer sequence.
       typename C>
   auto buffer_sequence_begin(
       C & c,
-      typename enable_if< !is_convertible< const C *, const mutable_buffer * >::value &&!is_convertible< const C *, const const_buffer * >::value >::type *  = 0);
+      typename enable_if< !is_convertible< const C *, const mutable_buffer * >::value &&!is_convertible< const C *, const const_buffer * >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -55122,7 +55122,7 @@ Get an iterator to the first element in a buffer sequence.
       typename C>
   auto buffer_sequence_begin(
       const C & c,
-      typename enable_if< !is_convertible< const C *, const mutable_buffer * >::value &&!is_convertible< const C *, const const_buffer * >::value >::type *  = 0);
+      typename enable_if< !is_convertible< const C *, const mutable_buffer * >::value &&!is_convertible< const C *, const const_buffer * >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -55143,28 +55143,28 @@ Get an iterator to one past the end element in a buffer sequence.
       typename MutableBuffer>
   const mutable_buffer * ``[link asio.reference.buffer_sequence_end.overload1 buffer_sequence_end]``(
       const MutableBuffer & b,
-      typename enable_if< is_convertible< const MutableBuffer *, const mutable_buffer * >::value >::type *  = 0);
+      typename enable_if< is_convertible< const MutableBuffer *, const mutable_buffer * >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.buffer_sequence_end.overload1 more...]]``
 
   template<
       typename ConstBuffer>
   const const_buffer * ``[link asio.reference.buffer_sequence_end.overload2 buffer_sequence_end]``(
       const ConstBuffer & b,
-      typename enable_if< is_convertible< const ConstBuffer *, const const_buffer * >::value >::type *  = 0);
+      typename enable_if< is_convertible< const ConstBuffer *, const const_buffer * >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.buffer_sequence_end.overload2 more...]]``
 
   template<
       typename C>
   auto ``[link asio.reference.buffer_sequence_end.overload3 buffer_sequence_end]``(
       C & c,
-      typename enable_if< !is_convertible< const C *, const mutable_buffer * >::value &&!is_convertible< const C *, const const_buffer * >::value >::type *  = 0);
+      typename enable_if< !is_convertible< const C *, const mutable_buffer * >::value &&!is_convertible< const C *, const const_buffer * >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.buffer_sequence_end.overload3 more...]]``
 
   template<
       typename C>
   auto ``[link asio.reference.buffer_sequence_end.overload4 buffer_sequence_end]``(
       const C & c,
-      typename enable_if< !is_convertible< const C *, const mutable_buffer * >::value &&!is_convertible< const C *, const const_buffer * >::value >::type *  = 0);
+      typename enable_if< !is_convertible< const C *, const mutable_buffer * >::value &&!is_convertible< const C *, const const_buffer * >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.buffer_sequence_end.overload4 more...]]``
 
 [heading Requirements]
@@ -55184,7 +55184,7 @@ Get an iterator to one past the end element in a buffer sequence.
       typename MutableBuffer>
   const mutable_buffer * buffer_sequence_end(
       const MutableBuffer & b,
-      typename enable_if< is_convertible< const MutableBuffer *, const mutable_buffer * >::value >::type *  = 0);
+      typename enable_if< is_convertible< const MutableBuffer *, const mutable_buffer * >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -55202,7 +55202,7 @@ Get an iterator to one past the end element in a buffer sequence.
       typename ConstBuffer>
   const const_buffer * buffer_sequence_end(
       const ConstBuffer & b,
-      typename enable_if< is_convertible< const ConstBuffer *, const const_buffer * >::value >::type *  = 0);
+      typename enable_if< is_convertible< const ConstBuffer *, const const_buffer * >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -55220,7 +55220,7 @@ Get an iterator to one past the end element in a buffer sequence.
       typename C>
   auto buffer_sequence_end(
       C & c,
-      typename enable_if< !is_convertible< const C *, const mutable_buffer * >::value &&!is_convertible< const C *, const const_buffer * >::value >::type *  = 0);
+      typename enable_if< !is_convertible< const C *, const mutable_buffer * >::value &&!is_convertible< const C *, const const_buffer * >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -55238,7 +55238,7 @@ Get an iterator to one past the end element in a buffer sequence.
       typename C>
   auto buffer_sequence_end(
       const C & c,
-      typename enable_if< !is_convertible< const C *, const mutable_buffer * >::value &&!is_convertible< const C *, const const_buffer * >::value >::type *  = 0);
+      typename enable_if< !is_convertible< const C *, const mutable_buffer * >::value &&!is_convertible< const C *, const const_buffer * >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -58431,7 +58431,7 @@ Spawn a new coroutined-based thread of execution.
       const Executor & ex,
       awaitable< T, AwaitableExecutor > a,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< (is_executor< Executor >::value||execution::is_executor< Executor >::value)&&is_convertible< Executor, AwaitableExecutor >::value >::type *  = 0);
+      typename enable_if< (is_executor< Executor >::value||execution::is_executor< Executor >::value)&&is_convertible< Executor, AwaitableExecutor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.co_spawn.overload1 more...]]``
 
   template<
@@ -58442,7 +58442,7 @@ Spawn a new coroutined-based thread of execution.
       const Executor & ex,
       awaitable< void, AwaitableExecutor > a,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< (is_executor< Executor >::value||execution::is_executor< Executor >::value)&&is_convertible< Executor, AwaitableExecutor >::value >::type *  = 0);
+      typename enable_if< (is_executor< Executor >::value||execution::is_executor< Executor >::value)&&is_convertible< Executor, AwaitableExecutor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.co_spawn.overload2 more...]]``
 
   template<
@@ -58454,7 +58454,7 @@ Spawn a new coroutined-based thread of execution.
       ExecutionContext & ctx,
       awaitable< T, AwaitableExecutor > a,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value &&is_convertible< typename ExecutionContext::executor_type, AwaitableExecutor >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value &&is_convertible< typename ExecutionContext::executor_type, AwaitableExecutor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.co_spawn.overload3 more...]]``
 
   template<
@@ -58465,7 +58465,7 @@ Spawn a new coroutined-based thread of execution.
       ExecutionContext & ctx,
       awaitable< void, AwaitableExecutor > a,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value &&is_convertible< typename ExecutionContext::executor_type, AwaitableExecutor >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value &&is_convertible< typename ExecutionContext::executor_type, AwaitableExecutor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.co_spawn.overload4 more...]]``
 
   template<
@@ -58476,7 +58476,7 @@ Spawn a new coroutined-based thread of execution.
       const Executor & ex,
       F && f,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.co_spawn.overload5 more...]]``
 
   template<
@@ -58487,7 +58487,7 @@ Spawn a new coroutined-based thread of execution.
       ExecutionContext & ctx,
       F && f,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.co_spawn.overload6 more...]]``
 
 [heading Requirements]
@@ -58512,7 +58512,7 @@ Spawn a new coroutined-based thread of execution.
       const Executor & ex,
       awaitable< T, AwaitableExecutor > a,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< (is_executor< Executor >::value||execution::is_executor< Executor >::value)&&is_convertible< Executor, AwaitableExecutor >::value >::type *  = 0);
+      typename enable_if< (is_executor< Executor >::value||execution::is_executor< Executor >::value)&&is_convertible< Executor, AwaitableExecutor >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -58596,7 +58596,7 @@ Spawn a new coroutined-based thread of execution.
       const Executor & ex,
       awaitable< void, AwaitableExecutor > a,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< (is_executor< Executor >::value||execution::is_executor< Executor >::value)&&is_convertible< Executor, AwaitableExecutor >::value >::type *  = 0);
+      typename enable_if< (is_executor< Executor >::value||execution::is_executor< Executor >::value)&&is_convertible< Executor, AwaitableExecutor >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -58673,7 +58673,7 @@ Spawn a new coroutined-based thread of execution.
       ExecutionContext & ctx,
       awaitable< T, AwaitableExecutor > a,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value &&is_convertible< typename ExecutionContext::executor_type, AwaitableExecutor >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value &&is_convertible< typename ExecutionContext::executor_type, AwaitableExecutor >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -58757,7 +58757,7 @@ Spawn a new coroutined-based thread of execution.
       ExecutionContext & ctx,
       awaitable< void, AwaitableExecutor > a,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value &&is_convertible< typename ExecutionContext::executor_type, AwaitableExecutor >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value &&is_convertible< typename ExecutionContext::executor_type, AwaitableExecutor >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -58833,7 +58833,7 @@ Spawn a new coroutined-based thread of execution.
       const Executor & ex,
       F && f,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -58940,7 +58940,7 @@ Spawn a new coroutined-based thread of execution.
       ExecutionContext & ctx,
       F && f,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -59049,7 +59049,7 @@ Establishes a socket connection by trying each endpoint in a sequence.
   Protocol::endpoint ``[link asio.reference.connect.overload1 connect]``(
       basic_socket< Protocol, Executor > & s,
       const EndpointSequence & endpoints,
-      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = 0);
+      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.connect.overload1 more...]]``
 
   template<
@@ -59060,7 +59060,7 @@ Establishes a socket connection by trying each endpoint in a sequence.
       basic_socket< Protocol, Executor > & s,
       const EndpointSequence & endpoints,
       asio::error_code & ec,
-      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = 0);
+      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.connect.overload2 more...]]``
 
 (Deprecated: Use range overload.) Establishes a socket connection by trying each endpoint in a sequence. 
@@ -59072,7 +59072,7 @@ Establishes a socket connection by trying each endpoint in a sequence.
   Iterator ``[link asio.reference.connect.overload3 connect]``(
       basic_socket< Protocol, Executor > & s,
       Iterator begin,
-      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = 0);
+      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.connect.overload3 more...]]``
 
   template<
@@ -59083,7 +59083,7 @@ Establishes a socket connection by trying each endpoint in a sequence.
       basic_socket< Protocol, Executor > & s,
       Iterator begin,
       asio::error_code & ec,
-      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = 0);
+      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.connect.overload4 more...]]``
 
 Establishes a socket connection by trying each endpoint in a sequence. 
@@ -59118,7 +59118,7 @@ Establishes a socket connection by trying each endpoint in a sequence.
       basic_socket< Protocol, Executor > & s,
       const EndpointSequence & endpoints,
       ConnectCondition connect_condition,
-      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = 0);
+      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.connect.overload7 more...]]``
 
   template<
@@ -59131,7 +59131,7 @@ Establishes a socket connection by trying each endpoint in a sequence.
       const EndpointSequence & endpoints,
       ConnectCondition connect_condition,
       asio::error_code & ec,
-      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = 0);
+      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.connect.overload8 more...]]``
 
 (Deprecated: Use range overload.) Establishes a socket connection by trying each endpoint in a sequence. 
@@ -59145,7 +59145,7 @@ Establishes a socket connection by trying each endpoint in a sequence.
       basic_socket< Protocol, Executor > & s,
       Iterator begin,
       ConnectCondition connect_condition,
-      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = 0);
+      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.connect.overload9 more...]]``
 
   template<
@@ -59158,7 +59158,7 @@ Establishes a socket connection by trying each endpoint in a sequence.
       Iterator begin,
       ConnectCondition connect_condition,
       asio::error_code & ec,
-      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = 0);
+      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.connect.overload10 more...]]``
 
 Establishes a socket connection by trying each endpoint in a sequence. 
@@ -59208,7 +59208,7 @@ Establishes a socket connection by trying each endpoint in a sequence.
   Protocol::endpoint connect(
       basic_socket< Protocol, Executor > & s,
       const EndpointSequence & endpoints,
-      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = 0);
+      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = ASIO_NULLPTR);
 
 
 This function attempts to connect a socket to one of a sequence of endpoints. It does this by repeated calls to the socket's `connect` member function, once for each endpoint in the sequence, until a connection is successfully established.
@@ -59274,7 +59274,7 @@ Establishes a socket connection by trying each endpoint in a sequence.
       basic_socket< Protocol, Executor > & s,
       const EndpointSequence & endpoints,
       asio::error_code & ec,
-      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = 0);
+      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = ASIO_NULLPTR);
 
 
 This function attempts to connect a socket to one of a sequence of endpoints. It does this by repeated calls to the socket's `connect` member function, once for each endpoint in the sequence, until a connection is successfully established.
@@ -59336,7 +59336,7 @@ On success, the successfully connected endpoint. Otherwise, a default-constructe
   Iterator connect(
       basic_socket< Protocol, Executor > & s,
       Iterator begin,
-      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = 0);
+      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = ASIO_NULLPTR);
 
 
 This function attempts to connect a socket to one of a sequence of endpoints. It does this by repeated calls to the socket's `connect` member function, once for each endpoint in the sequence, until a connection is successfully established.
@@ -59394,7 +59394,7 @@ This overload assumes that a default constructed object of type `Iterator` repre
       basic_socket< Protocol, Executor > & s,
       Iterator begin,
       asio::error_code & ec,
-      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = 0);
+      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = ASIO_NULLPTR);
 
 
 This function attempts to connect a socket to one of a sequence of endpoints. It does this by repeated calls to the socket's `connect` member function, once for each endpoint in the sequence, until a connection is successfully established.
@@ -59579,7 +59579,7 @@ Establishes a socket connection by trying each endpoint in a sequence.
       basic_socket< Protocol, Executor > & s,
       const EndpointSequence & endpoints,
       ConnectCondition connect_condition,
-      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = 0);
+      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = ASIO_NULLPTR);
 
 
 This function attempts to connect a socket to one of a sequence of endpoints. It does this by repeated calls to the socket's `connect` member function, once for each endpoint in the sequence, until a connection is successfully established.
@@ -59672,7 +59672,7 @@ Establishes a socket connection by trying each endpoint in a sequence.
       const EndpointSequence & endpoints,
       ConnectCondition connect_condition,
       asio::error_code & ec,
-      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = 0);
+      typename enable_if< is_endpoint_sequence< EndpointSequence >::value >::type *  = ASIO_NULLPTR);
 
 
 This function attempts to connect a socket to one of a sequence of endpoints. It does this by repeated calls to the socket's `connect` member function, once for each endpoint in the sequence, until a connection is successfully established.
@@ -59764,7 +59764,7 @@ It would be used with the `asio::connect` function as follows:
       basic_socket< Protocol, Executor > & s,
       Iterator begin,
       ConnectCondition connect_condition,
-      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = 0);
+      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = ASIO_NULLPTR);
 
 
 This function attempts to connect a socket to one of a sequence of endpoints. It does this by repeated calls to the socket's `connect` member function, once for each endpoint in the sequence, until a connection is successfully established.
@@ -59832,7 +59832,7 @@ This overload assumes that a default constructed object of type `Iterator` repre
       Iterator begin,
       ConnectCondition connect_condition,
       asio::error_code & ec,
-      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = 0);
+      typename enable_if<!is_endpoint_sequence< Iterator >::value >::type *  = ASIO_NULLPTR);
 
 
 This function attempts to connect a socket to one of a sequence of endpoints. It does this by repeated calls to the socket's `connect` member function, once for each endpoint in the sequence, until a connection is successfully established.
@@ -61362,7 +61362,7 @@ Submits a completion token or function object for execution.
   ``[link asio.reference.asynchronous_operations.automatic_deduction_of_initiating_function_return_type ['DEDUCED]]`` ``[link asio.reference.defer.overload2 defer]``(
       const Executor & ex,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.defer.overload2 more...]]``
 
   template<
@@ -61371,7 +61371,7 @@ Submits a completion token or function object for execution.
   ``[link asio.reference.asynchronous_operations.automatic_deduction_of_initiating_function_return_type ['DEDUCED]]`` ``[link asio.reference.defer.overload3 defer]``(
       ExecutionContext & ctx,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.defer.overload3 more...]]``
 
 [heading Requirements]
@@ -61436,7 +61436,7 @@ Submits a completion token or function object for execution.
   ``[link asio.reference.asynchronous_operations.automatic_deduction_of_initiating_function_return_type ['DEDUCED]]`` defer(
       const Executor & ex,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 This function submits an object for execution using the specified executor. The function object is queued for execution, and is never called from the current thread prior to returning from `defer()`.
@@ -61488,7 +61488,7 @@ Submits a completion token or function object for execution.
   ``[link asio.reference.asynchronous_operations.automatic_deduction_of_initiating_function_return_type ['DEDUCED]]`` defer(
       ExecutionContext & ctx,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -61733,7 +61733,7 @@ Convert the specified executor to the inner executor type, then use that to cons
       typename ``[link asio.reference.Executor1 OtherExecutor]``>
   ``[link asio.reference.detached_t__executor_with_default.executor_with_default.overload2 executor_with_default]``(
       const OtherExecutor & ex,
-      typename enable_if< is_convertible< OtherExecutor, InnerExecutor >::value >::type *  = 0);
+      typename enable_if< is_convertible< OtherExecutor, InnerExecutor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.detached_t__executor_with_default.executor_with_default.overload2 more...]]``
 
 
@@ -61762,7 +61762,7 @@ Convert the specified executor to the inner executor type, then use that to cons
       typename ``[link asio.reference.Executor1 OtherExecutor]``>
   executor_with_default(
       const OtherExecutor & ex,
-      typename enable_if< is_convertible< OtherExecutor, InnerExecutor >::value >::type *  = 0);
+      typename enable_if< is_convertible< OtherExecutor, InnerExecutor >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -61791,7 +61791,7 @@ Submits a completion token or function object for execution.
   ``[link asio.reference.asynchronous_operations.automatic_deduction_of_initiating_function_return_type ['DEDUCED]]`` ``[link asio.reference.dispatch.overload2 dispatch]``(
       const Executor & ex,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.dispatch.overload2 more...]]``
 
   template<
@@ -61800,7 +61800,7 @@ Submits a completion token or function object for execution.
   ``[link asio.reference.asynchronous_operations.automatic_deduction_of_initiating_function_return_type ['DEDUCED]]`` ``[link asio.reference.dispatch.overload3 dispatch]``(
       ExecutionContext & ctx,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.dispatch.overload3 more...]]``
 
 [heading Requirements]
@@ -61863,7 +61863,7 @@ Submits a completion token or function object for execution.
   ``[link asio.reference.asynchronous_operations.automatic_deduction_of_initiating_function_return_type ['DEDUCED]]`` dispatch(
       const Executor & ex,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 This function submits an object for execution using the specified executor. The function object may be called from the current thread prior to returning from `dispatch()`. Otherwise, it is queued for execution.
@@ -61913,7 +61913,7 @@ Submits a completion token or function object for execution.
   ``[link asio.reference.asynchronous_operations.automatic_deduction_of_initiating_function_return_type ['DEDUCED]]`` dispatch(
       ExecutionContext & ctx,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -74700,7 +74700,7 @@ Convert the specified executor to the inner executor type, then use that to cons
       typename ``[link asio.reference.Executor1 OtherExecutor]``>
   ``[link asio.reference.experimental__as_single_t__executor_with_default.executor_with_default.overload2 executor_with_default]``(
       const OtherExecutor & ex,
-      typename enable_if< is_convertible< OtherExecutor, InnerExecutor >::value >::type *  = 0);
+      typename enable_if< is_convertible< OtherExecutor, InnerExecutor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.experimental__as_single_t__executor_with_default.executor_with_default.overload2 more...]]``
 
 
@@ -74729,7 +74729,7 @@ Convert the specified executor to the inner executor type, then use that to cons
       typename ``[link asio.reference.Executor1 OtherExecutor]``>
   executor_with_default(
       const OtherExecutor & ex,
-      typename enable_if< is_convertible< OtherExecutor, InnerExecutor >::value >::type *  = 0);
+      typename enable_if< is_convertible< OtherExecutor, InnerExecutor >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -78823,7 +78823,7 @@ Helper function to obtain an object's associated executor.
   associated_executor< T, Executor >::type ``[link asio.reference.get_associated_executor.overload2 get_associated_executor]``(
       const T & t,
       const Executor & ex,
-      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.get_associated_executor.overload2 more...]]``
 
   template<
@@ -78832,7 +78832,7 @@ Helper function to obtain an object's associated executor.
   associated_executor< T, typename ExecutionContext::executor_type >::type ``[link asio.reference.get_associated_executor.overload3 get_associated_executor]``(
       const T & t,
       ExecutionContext & ctx,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.get_associated_executor.overload3 more...]]``
 
 [heading Requirements]
@@ -78878,7 +78878,7 @@ Helper function to obtain an object's associated executor.
   associated_executor< T, Executor >::type get_associated_executor(
       const T & t,
       const Executor & ex,
-      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -78905,7 +78905,7 @@ Helper function to obtain an object's associated executor.
   associated_executor< T, typename ExecutionContext::executor_type >::type get_associated_executor(
       const T & t,
       ExecutionContext & ctx,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -90934,7 +90934,7 @@ Construct with execution context.
       typename ExecutionContext>
   explicit ``[link asio.reference.ip__basic_resolver.basic_resolver.overload2 basic_resolver]``(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.ip__basic_resolver.basic_resolver.overload2 more...]]``
 
 
@@ -90949,7 +90949,7 @@ Move-construct a [link asio.reference.ip__basic_resolver `ip::basic_resolver`] f
       typename ``[link asio.reference.Executor1 Executor1]``>
   ``[link asio.reference.ip__basic_resolver.basic_resolver.overload4 basic_resolver]``(
       basic_resolver< InternetProtocol, Executor1 > && other,
-      typename enable_if< is_convertible< Executor1, Executor >::value >::type *  = 0);
+      typename enable_if< is_convertible< Executor1, Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.ip__basic_resolver.basic_resolver.overload4 more...]]``
 
 
@@ -90992,7 +90992,7 @@ Construct with execution context.
       typename ExecutionContext>
   basic_resolver(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a [link asio.reference.ip__basic_resolver `ip::basic_resolver`].
@@ -91058,7 +91058,7 @@ Move-construct a [link asio.reference.ip__basic_resolver `ip::basic_resolver`] f
       typename ``[link asio.reference.Executor1 Executor1]``>
   basic_resolver(
       basic_resolver< InternetProtocol, Executor1 > && other,
-      typename enable_if< is_convertible< Executor1, Executor >::value >::type *  = 0);
+      typename enable_if< is_convertible< Executor1, Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor moves a resolver from one object to another.
@@ -104509,7 +104509,7 @@ Create a [link asio.reference.strand `strand`]  object for an executor.
       typename ``[link asio.reference.Executor1 Executor]``>
   strand< Executor > ``[link asio.reference.make_strand.overload1 make_strand]``(
       const Executor & ex,
-      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.make_strand.overload1 more...]]``
 
 Create a [link asio.reference.strand `strand`]  object for an execution context. 
@@ -104518,7 +104518,7 @@ Create a [link asio.reference.strand `strand`]  object for an execution context.
       typename ExecutionContext>
   strand< typename ExecutionContext::executor_type > ``[link asio.reference.make_strand.overload2 make_strand]``(
       ExecutionContext & ctx,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.make_strand.overload2 more...]]``
 
 [heading Requirements]
@@ -104538,7 +104538,7 @@ Create a [link asio.reference.strand `strand`]  object for an executor.
       typename ``[link asio.reference.Executor1 Executor]``>
   strand< Executor > make_strand(
       const Executor & ex,
-      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -104556,7 +104556,7 @@ Create a [link asio.reference.strand `strand`]  object for an execution context.
       typename ExecutionContext>
   strand< typename ExecutionContext::executor_type > make_strand(
       ExecutionContext & ctx,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -104574,21 +104574,21 @@ Create an [link asio.reference.executor_work_guard `executor_work_guard`]  objec
       typename ``[link asio.reference.Executor1 Executor]``>
   executor_work_guard< Executor > ``[link asio.reference.make_work_guard.overload1 make_work_guard]``(
       const Executor & ex,
-      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.make_work_guard.overload1 more...]]``
 
   template<
       typename ExecutionContext>
   executor_work_guard< typename ExecutionContext::executor_type > ``[link asio.reference.make_work_guard.overload2 make_work_guard]``(
       ExecutionContext & ctx,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.make_work_guard.overload2 more...]]``
 
   template<
       typename T>
   executor_work_guard< typename associated_executor< T >::type > ``[link asio.reference.make_work_guard.overload3 make_work_guard]``(
       const T & t,
-      typename enable_if< !is_executor< T >::value &&!execution::is_executor< T >::value &&!is_convertible< T &, execution_context & >::value >::type *  = 0);
+      typename enable_if< !is_executor< T >::value &&!execution::is_executor< T >::value &&!is_convertible< T &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.make_work_guard.overload3 more...]]``
 
   template<
@@ -104597,7 +104597,7 @@ Create an [link asio.reference.executor_work_guard `executor_work_guard`]  objec
   executor_work_guard< typename associated_executor< T, Executor >::type > ``[link asio.reference.make_work_guard.overload4 make_work_guard]``(
       const T & t,
       const Executor & ex,
-      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.make_work_guard.overload4 more...]]``
 
   template<
@@ -104606,7 +104606,7 @@ Create an [link asio.reference.executor_work_guard `executor_work_guard`]  objec
   executor_work_guard< typename associated_executor< T, typename ExecutionContext::executor_type >::type > ``[link asio.reference.make_work_guard.overload5 make_work_guard]``(
       const T & t,
       ExecutionContext & ctx,
-      typename enable_if< !is_executor< T >::value &&!execution::is_executor< T >::value &&!is_convertible< T &, execution_context & >::value &&is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< !is_executor< T >::value &&!execution::is_executor< T >::value &&!is_convertible< T &, execution_context & >::value &&is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.make_work_guard.overload5 more...]]``
 
 [heading Requirements]
@@ -104626,7 +104626,7 @@ Create an [link asio.reference.executor_work_guard `executor_work_guard`]  objec
       typename ``[link asio.reference.Executor1 Executor]``>
   executor_work_guard< Executor > make_work_guard(
       const Executor & ex,
-      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -104644,7 +104644,7 @@ Create an [link asio.reference.executor_work_guard `executor_work_guard`]  objec
       typename ExecutionContext>
   executor_work_guard< typename ExecutionContext::executor_type > make_work_guard(
       ExecutionContext & ctx,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -104662,7 +104662,7 @@ Create an [link asio.reference.executor_work_guard `executor_work_guard`]  objec
       typename T>
   executor_work_guard< typename associated_executor< T >::type > make_work_guard(
       const T & t,
-      typename enable_if< !is_executor< T >::value &&!execution::is_executor< T >::value &&!is_convertible< T &, execution_context & >::value >::type *  = 0);
+      typename enable_if< !is_executor< T >::value &&!execution::is_executor< T >::value &&!is_convertible< T &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -104682,7 +104682,7 @@ Create an [link asio.reference.executor_work_guard `executor_work_guard`]  objec
   executor_work_guard< typename associated_executor< T, Executor >::type > make_work_guard(
       const T & t,
       const Executor & ex,
-      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -104702,7 +104702,7 @@ Create an [link asio.reference.executor_work_guard `executor_work_guard`]  objec
   executor_work_guard< typename associated_executor< T, typename ExecutionContext::executor_type >::type > make_work_guard(
       const T & t,
       ExecutionContext & ctx,
-      typename enable_if< !is_executor< T >::value &&!execution::is_executor< T >::value &&!is_convertible< T &, execution_context & >::value &&is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< !is_executor< T >::value &&!execution::is_executor< T >::value &&!is_convertible< T &, execution_context & >::value &&is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -106024,7 +106024,7 @@ Construct a descriptor without opening it.
       typename ExecutionContext>
   explicit ``[link asio.reference.posix__basic_descriptor.basic_descriptor.overload2 basic_descriptor]``(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.posix__basic_descriptor.basic_descriptor.overload2 more...]]``
 
 
@@ -106041,7 +106041,7 @@ Construct a descriptor on an existing native descriptor.
   ``[link asio.reference.posix__basic_descriptor.basic_descriptor.overload4 basic_descriptor]``(
       ExecutionContext & context,
       const native_handle_type & native_descriptor,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.posix__basic_descriptor.basic_descriptor.overload4 more...]]``
 
 
@@ -106092,7 +106092,7 @@ Construct a descriptor without opening it.
       typename ExecutionContext>
   basic_descriptor(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a descriptor without opening it.
@@ -106167,7 +106167,7 @@ Construct a descriptor on an existing native descriptor.
   basic_descriptor(
       ExecutionContext & context,
       const native_handle_type & native_descriptor,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a descriptor object to hold an existing native descriptor.
@@ -108006,7 +108006,7 @@ Construct a stream descriptor without opening it.
       typename ExecutionContext>
   explicit ``[link asio.reference.posix__basic_stream_descriptor.basic_stream_descriptor.overload2 basic_stream_descriptor]``(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.posix__basic_stream_descriptor.basic_stream_descriptor.overload2 more...]]``
 
 
@@ -108023,7 +108023,7 @@ Construct a stream descriptor on an existing native descriptor.
   ``[link asio.reference.posix__basic_stream_descriptor.basic_stream_descriptor.overload4 basic_stream_descriptor]``(
       ExecutionContext & context,
       const native_handle_type & native_descriptor,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.posix__basic_stream_descriptor.basic_stream_descriptor.overload4 more...]]``
 
 
@@ -108074,7 +108074,7 @@ Construct a stream descriptor without opening it.
       typename ExecutionContext>
   basic_stream_descriptor(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a stream descriptor without opening it. The descriptor needs to be opened and then connected or accepted before data can be sent or received on it.
@@ -108149,7 +108149,7 @@ Construct a stream descriptor on an existing native descriptor.
   basic_stream_descriptor(
       ExecutionContext & context,
       const native_handle_type & native_descriptor,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a stream descriptor object to hold an existing native descriptor.
@@ -110554,7 +110554,7 @@ Submits a completion token or function object for execution.
   ``[link asio.reference.asynchronous_operations.automatic_deduction_of_initiating_function_return_type ['DEDUCED]]`` ``[link asio.reference.post.overload2 post]``(
       const Executor & ex,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.post.overload2 more...]]``
 
   template<
@@ -110563,7 +110563,7 @@ Submits a completion token or function object for execution.
   ``[link asio.reference.asynchronous_operations.automatic_deduction_of_initiating_function_return_type ['DEDUCED]]`` ``[link asio.reference.post.overload3 post]``(
       ExecutionContext & ctx,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.post.overload3 more...]]``
 
 [heading Requirements]
@@ -110628,7 +110628,7 @@ Submits a completion token or function object for execution.
   ``[link asio.reference.asynchronous_operations.automatic_deduction_of_initiating_function_return_type ['DEDUCED]]`` post(
       const Executor & ex,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 This function submits an object for execution using the specified executor. The function object is queued for execution, and is never called from the current thread prior to returning from `post()`.
@@ -110680,7 +110680,7 @@ Submits a completion token or function object for execution.
   ``[link asio.reference.asynchronous_operations.automatic_deduction_of_initiating_function_return_type ['DEDUCED]]`` post(
       ExecutionContext & ctx,
       CompletionToken && token = ``[link asio.reference.asynchronous_operations.default_completion_tokens ['DEFAULT]]``,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -110914,7 +110914,7 @@ Attempt to read a certain amount of data from a stream before returning.
   std::size_t ``[link asio.reference.read.overload1 read]``(
       SyncReadStream & s,
       const MutableBufferSequence & buffers,
-      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read.overload1 more...]]``
 
   template<
@@ -110924,7 +110924,7 @@ Attempt to read a certain amount of data from a stream before returning.
       SyncReadStream & s,
       const MutableBufferSequence & buffers,
       asio::error_code & ec,
-      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read.overload2 more...]]``
 
   template<
@@ -110935,7 +110935,7 @@ Attempt to read a certain amount of data from a stream before returning.
       SyncReadStream & s,
       const MutableBufferSequence & buffers,
       CompletionCondition completion_condition,
-      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read.overload3 more...]]``
 
   template<
@@ -110947,7 +110947,7 @@ Attempt to read a certain amount of data from a stream before returning.
       const MutableBufferSequence & buffers,
       CompletionCondition completion_condition,
       asio::error_code & ec,
-      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read.overload4 more...]]``
 
   template<
@@ -110956,7 +110956,7 @@ Attempt to read a certain amount of data from a stream before returning.
   std::size_t ``[link asio.reference.read.overload5 read]``(
       SyncReadStream & s,
       DynamicBuffer_v1 && buffers,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read.overload5 more...]]``
 
   template<
@@ -110966,7 +110966,7 @@ Attempt to read a certain amount of data from a stream before returning.
       SyncReadStream & s,
       DynamicBuffer_v1 && buffers,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read.overload6 more...]]``
 
   template<
@@ -110977,7 +110977,7 @@ Attempt to read a certain amount of data from a stream before returning.
       SyncReadStream & s,
       DynamicBuffer_v1 && buffers,
       CompletionCondition completion_condition,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read.overload7 more...]]``
 
   template<
@@ -110989,7 +110989,7 @@ Attempt to read a certain amount of data from a stream before returning.
       DynamicBuffer_v1 && buffers,
       CompletionCondition completion_condition,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read.overload8 more...]]``
 
   template<
@@ -111036,7 +111036,7 @@ Attempt to read a certain amount of data from a stream before returning.
   std::size_t ``[link asio.reference.read.overload13 read]``(
       SyncReadStream & s,
       DynamicBuffer_v2 buffers,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read.overload13 more...]]``
 
   template<
@@ -111046,7 +111046,7 @@ Attempt to read a certain amount of data from a stream before returning.
       SyncReadStream & s,
       DynamicBuffer_v2 buffers,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read.overload14 more...]]``
 
   template<
@@ -111057,7 +111057,7 @@ Attempt to read a certain amount of data from a stream before returning.
       SyncReadStream & s,
       DynamicBuffer_v2 buffers,
       CompletionCondition completion_condition,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read.overload15 more...]]``
 
   template<
@@ -111069,7 +111069,7 @@ Attempt to read a certain amount of data from a stream before returning.
       DynamicBuffer_v2 buffers,
       CompletionCondition completion_condition,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read.overload16 more...]]``
 
 [heading Requirements]
@@ -111091,7 +111091,7 @@ Attempt to read a certain amount of data from a stream before returning.
   std::size_t read(
       SyncReadStream & s,
       const MutableBufferSequence & buffers,
-      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read a certain number of bytes of data from a stream. The call will block until one of the following conditions is true:
@@ -111173,7 +111173,7 @@ Attempt to read a certain amount of data from a stream before returning.
       SyncReadStream & s,
       const MutableBufferSequence & buffers,
       asio::error_code & ec,
-      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read a certain number of bytes of data from a stream. The call will block until one of the following conditions is true:
@@ -111248,7 +111248,7 @@ Attempt to read a certain amount of data from a stream before returning.
       SyncReadStream & s,
       const MutableBufferSequence & buffers,
       CompletionCondition completion_condition,
-      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read a certain number of bytes of data from a stream. The call will block until one of the following conditions is true:
@@ -111333,7 +111333,7 @@ Attempt to read a certain amount of data from a stream before returning.
       const MutableBufferSequence & buffers,
       CompletionCondition completion_condition,
       asio::error_code & ec,
-      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_mutable_buffer_sequence< MutableBufferSequence >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read a certain number of bytes of data from a stream. The call will block until one of the following conditions is true:
@@ -111396,7 +111396,7 @@ Attempt to read a certain amount of data from a stream before returning.
   std::size_t read(
       SyncReadStream & s,
       DynamicBuffer_v1 && buffers,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read a certain number of bytes of data from a stream. The call will block until one of the following conditions is true:
@@ -111468,7 +111468,7 @@ Attempt to read a certain amount of data from a stream before returning.
       SyncReadStream & s,
       DynamicBuffer_v1 && buffers,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read a certain number of bytes of data from a stream. The call will block until one of the following conditions is true:
@@ -111533,7 +111533,7 @@ Attempt to read a certain amount of data from a stream before returning.
       SyncReadStream & s,
       DynamicBuffer_v1 && buffers,
       CompletionCondition completion_condition,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read a certain number of bytes of data from a stream. The call will block until one of the following conditions is true:
@@ -111607,7 +111607,7 @@ Attempt to read a certain amount of data from a stream before returning.
       DynamicBuffer_v1 && buffers,
       CompletionCondition completion_condition,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read a certain number of bytes of data from a stream. The call will block until one of the following conditions is true:
@@ -111940,7 +111940,7 @@ Attempt to read a certain amount of data from a stream before returning.
   std::size_t read(
       SyncReadStream & s,
       DynamicBuffer_v2 buffers,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read a certain number of bytes of data from a stream. The call will block until one of the following conditions is true:
@@ -112012,7 +112012,7 @@ Attempt to read a certain amount of data from a stream before returning.
       SyncReadStream & s,
       DynamicBuffer_v2 buffers,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read a certain number of bytes of data from a stream. The call will block until one of the following conditions is true:
@@ -112077,7 +112077,7 @@ Attempt to read a certain amount of data from a stream before returning.
       SyncReadStream & s,
       DynamicBuffer_v2 buffers,
       CompletionCondition completion_condition,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read a certain number of bytes of data from a stream. The call will block until one of the following conditions is true:
@@ -112151,7 +112151,7 @@ Attempt to read a certain amount of data from a stream before returning.
       DynamicBuffer_v2 buffers,
       CompletionCondition completion_condition,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read a certain number of bytes of data from a stream. The call will block until one of the following conditions is true:
@@ -112902,7 +112902,7 @@ Read data into a dynamic buffer sequence until it contains a specified delimiter
       SyncReadStream & s,
       DynamicBuffer_v1 && buffers,
       char delim,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read_until.overload1 more...]]``
 
   template<
@@ -112913,7 +112913,7 @@ Read data into a dynamic buffer sequence until it contains a specified delimiter
       DynamicBuffer_v1 && buffers,
       char delim,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read_until.overload2 more...]]``
 
   template<
@@ -112923,7 +112923,7 @@ Read data into a dynamic buffer sequence until it contains a specified delimiter
       SyncReadStream & s,
       DynamicBuffer_v1 && buffers,
       string_view delim,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read_until.overload3 more...]]``
 
   template<
@@ -112934,7 +112934,7 @@ Read data into a dynamic buffer sequence until it contains a specified delimiter
       DynamicBuffer_v1 && buffers,
       string_view delim,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read_until.overload4 more...]]``
 
 Read data into a dynamic buffer sequence until some part of the data it contains matches a regular expression. 
@@ -112946,7 +112946,7 @@ Read data into a dynamic buffer sequence until some part of the data it contains
       SyncReadStream & s,
       DynamicBuffer_v1 && buffers,
       const boost::regex & expr,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read_until.overload5 more...]]``
 
   template<
@@ -112957,7 +112957,7 @@ Read data into a dynamic buffer sequence until some part of the data it contains
       DynamicBuffer_v1 && buffers,
       const boost::regex & expr,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read_until.overload6 more...]]``
 
 Read data into a dynamic buffer sequence until a function object indicates a match. 
@@ -112970,7 +112970,7 @@ Read data into a dynamic buffer sequence until a function object indicates a mat
       SyncReadStream & s,
       DynamicBuffer_v1 && buffers,
       MatchCondition match_condition,
-      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read_until.overload7 more...]]``
 
   template<
@@ -112982,7 +112982,7 @@ Read data into a dynamic buffer sequence until a function object indicates a mat
       DynamicBuffer_v1 && buffers,
       MatchCondition match_condition,
       asio::error_code & ec,
-      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read_until.overload8 more...]]``
 
 Read data into a streambuf until it contains a specified delimiter. 
@@ -113056,7 +113056,7 @@ Read data into a streambuf until a function object indicates a match.
       SyncReadStream & s,
       asio::basic_streambuf< Allocator > & b,
       MatchCondition match_condition,
-      typename enable_if< is_match_condition< MatchCondition >::value >::type *  = 0);
+      typename enable_if< is_match_condition< MatchCondition >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read_until.overload15 more...]]``
 
   template<
@@ -113068,7 +113068,7 @@ Read data into a streambuf until a function object indicates a match.
       asio::basic_streambuf< Allocator > & b,
       MatchCondition match_condition,
       asio::error_code & ec,
-      typename enable_if< is_match_condition< MatchCondition >::value >::type *  = 0);
+      typename enable_if< is_match_condition< MatchCondition >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read_until.overload16 more...]]``
 
 Read data into a dynamic buffer sequence until it contains a specified delimiter. 
@@ -113080,7 +113080,7 @@ Read data into a dynamic buffer sequence until it contains a specified delimiter
       SyncReadStream & s,
       DynamicBuffer_v2 buffers,
       char delim,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read_until.overload17 more...]]``
 
   template<
@@ -113091,7 +113091,7 @@ Read data into a dynamic buffer sequence until it contains a specified delimiter
       DynamicBuffer_v2 buffers,
       char delim,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read_until.overload18 more...]]``
 
   template<
@@ -113101,7 +113101,7 @@ Read data into a dynamic buffer sequence until it contains a specified delimiter
       SyncReadStream & s,
       DynamicBuffer_v2 buffers,
       string_view delim,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read_until.overload19 more...]]``
 
   template<
@@ -113112,7 +113112,7 @@ Read data into a dynamic buffer sequence until it contains a specified delimiter
       DynamicBuffer_v2 buffers,
       string_view delim,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read_until.overload20 more...]]``
 
 Read data into a dynamic buffer sequence until some part of the data it contains matches a regular expression. 
@@ -113124,7 +113124,7 @@ Read data into a dynamic buffer sequence until some part of the data it contains
       SyncReadStream & s,
       DynamicBuffer_v2 buffers,
       const boost::regex & expr,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read_until.overload21 more...]]``
 
   template<
@@ -113135,7 +113135,7 @@ Read data into a dynamic buffer sequence until some part of the data it contains
       DynamicBuffer_v2 buffers,
       const boost::regex & expr,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read_until.overload22 more...]]``
 
 Read data into a dynamic buffer sequence until a function object indicates a match. 
@@ -113148,7 +113148,7 @@ Read data into a dynamic buffer sequence until a function object indicates a mat
       SyncReadStream & s,
       DynamicBuffer_v2 buffers,
       MatchCondition match_condition,
-      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read_until.overload23 more...]]``
 
   template<
@@ -113160,7 +113160,7 @@ Read data into a dynamic buffer sequence until a function object indicates a mat
       DynamicBuffer_v2 buffers,
       MatchCondition match_condition,
       asio::error_code & ec,
-      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.read_until.overload24 more...]]``
 
 [heading Requirements]
@@ -113183,7 +113183,7 @@ Read data into a dynamic buffer sequence until it contains a specified delimiter
       SyncReadStream & s,
       DynamicBuffer_v1 && buffers,
       char delim,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read data into the specified dynamic buffer sequence until the dynamic buffer sequence's get area contains the specified delimiter. The call will block until one of the following conditions is true:
@@ -113280,7 +113280,7 @@ Read data into a dynamic buffer sequence until it contains a specified delimiter
       DynamicBuffer_v1 && buffers,
       char delim,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read data into the specified dynamic buffer sequence until the dynamic buffer sequence's get area contains the specified delimiter. The call will block until one of the following conditions is true:
@@ -113339,7 +113339,7 @@ Read data into a dynamic buffer sequence until it contains a specified delimiter
       SyncReadStream & s,
       DynamicBuffer_v1 && buffers,
       string_view delim,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read data into the specified dynamic buffer sequence until the dynamic buffer sequence's get area contains the specified delimiter. The call will block until one of the following conditions is true:
@@ -113426,7 +113426,7 @@ Read data into a dynamic buffer sequence until it contains a specified delimiter
       DynamicBuffer_v1 && buffers,
       string_view delim,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read data into the specified dynamic buffer sequence until the dynamic buffer sequence's get area contains the specified delimiter. The call will block until one of the following conditions is true:
@@ -113485,7 +113485,7 @@ Read data into a dynamic buffer sequence until some part of the data it contains
       SyncReadStream & s,
       DynamicBuffer_v1 && buffers,
       const boost::regex & expr,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read data into the specified dynamic buffer sequence until the dynamic buffer sequence's get area contains some data that matches a regular expression. The call will block until one of the following conditions is true:
@@ -113582,7 +113582,7 @@ Read data into a dynamic buffer sequence until some part of the data it contains
       DynamicBuffer_v1 && buffers,
       const boost::regex & expr,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read data into the specified dynamic buffer sequence until the dynamic buffer sequence's get area contains some data that matches a regular expression. The call will block until one of the following conditions is true:
@@ -113642,7 +113642,7 @@ Read data into a dynamic buffer sequence until a function object indicates a mat
       SyncReadStream & s,
       DynamicBuffer_v1 && buffers,
       MatchCondition match_condition,
-      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read data into the specified dynamic buffer sequence until a user-defined match condition function object, when applied to the data contained in the dynamic buffer sequence, indicates a successful match. The call will block until one of the following conditions is true:
@@ -113776,7 +113776,7 @@ Read data into a dynamic buffer sequence until a function object indicates a mat
       DynamicBuffer_v1 && buffers,
       MatchCondition match_condition,
       asio::error_code & ec,
-      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read data into the specified dynamic buffer sequence until a user-defined match condition function object, when applied to the data contained in the dynamic buffer sequence, indicates a successful match. The call will block until one of the following conditions is true:
@@ -114308,7 +114308,7 @@ Read data into a streambuf until a function object indicates a match.
       SyncReadStream & s,
       asio::basic_streambuf< Allocator > & b,
       MatchCondition match_condition,
-      typename enable_if< is_match_condition< MatchCondition >::value >::type *  = 0);
+      typename enable_if< is_match_condition< MatchCondition >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read data into the specified streambuf until a user-defined match condition function object, when applied to the data contained in the streambuf, indicates a successful match. The call will block until one of the following conditions is true:
@@ -114442,7 +114442,7 @@ Read data into a streambuf until a function object indicates a match.
       asio::basic_streambuf< Allocator > & b,
       MatchCondition match_condition,
       asio::error_code & ec,
-      typename enable_if< is_match_condition< MatchCondition >::value >::type *  = 0);
+      typename enable_if< is_match_condition< MatchCondition >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read data into the specified streambuf until a user-defined match condition function object, when applied to the data contained in the streambuf, indicates a successful match. The call will block until one of the following conditions is true:
@@ -114511,7 +114511,7 @@ Read data into a dynamic buffer sequence until it contains a specified delimiter
       SyncReadStream & s,
       DynamicBuffer_v2 buffers,
       char delim,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read data into the specified dynamic buffer sequence until the dynamic buffer sequence's get area contains the specified delimiter. The call will block until one of the following conditions is true:
@@ -114608,7 +114608,7 @@ Read data into a dynamic buffer sequence until it contains a specified delimiter
       DynamicBuffer_v2 buffers,
       char delim,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read data into the specified dynamic buffer sequence until the dynamic buffer sequence's get area contains the specified delimiter. The call will block until one of the following conditions is true:
@@ -114667,7 +114667,7 @@ Read data into a dynamic buffer sequence until it contains a specified delimiter
       SyncReadStream & s,
       DynamicBuffer_v2 buffers,
       string_view delim,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read data into the specified dynamic buffer sequence until the dynamic buffer sequence's get area contains the specified delimiter. The call will block until one of the following conditions is true:
@@ -114754,7 +114754,7 @@ Read data into a dynamic buffer sequence until it contains a specified delimiter
       DynamicBuffer_v2 buffers,
       string_view delim,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read data into the specified dynamic buffer sequence until the dynamic buffer sequence's get area contains the specified delimiter. The call will block until one of the following conditions is true:
@@ -114813,7 +114813,7 @@ Read data into a dynamic buffer sequence until some part of the data it contains
       SyncReadStream & s,
       DynamicBuffer_v2 buffers,
       const boost::regex & expr,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read data into the specified dynamic buffer sequence until the dynamic buffer sequence's get area contains some data that matches a regular expression. The call will block until one of the following conditions is true:
@@ -114910,7 +114910,7 @@ Read data into a dynamic buffer sequence until some part of the data it contains
       DynamicBuffer_v2 buffers,
       const boost::regex & expr,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read data into the specified dynamic buffer sequence until the dynamic buffer sequence's get area contains some data that matches a regular expression. The call will block until one of the following conditions is true:
@@ -114970,7 +114970,7 @@ Read data into a dynamic buffer sequence until a function object indicates a mat
       SyncReadStream & s,
       DynamicBuffer_v2 buffers,
       MatchCondition match_condition,
-      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read data into the specified dynamic buffer sequence until a user-defined match condition function object, when applied to the data contained in the dynamic buffer sequence, indicates a successful match. The call will block until one of the following conditions is true:
@@ -115104,7 +115104,7 @@ Read data into a dynamic buffer sequence until a function object indicates a mat
       DynamicBuffer_v2 buffers,
       MatchCondition match_condition,
       asio::error_code & ec,
-      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_match_condition< MatchCondition >::value &&is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to read data into the specified dynamic buffer sequence until a user-defined match condition function object, when applied to the data contained in the dynamic buffer sequence, indicates a successful match. The call will block until one of the following conditions is true:
@@ -117634,7 +117634,7 @@ Start a new stackful coroutine, calling the specified handler when it completes.
       Handler && handler,
       Function && function,
       const boost::coroutines::attributes & attributes = boost::coroutines::attributes(),
-      typename enable_if< !is_executor< typename decay< Handler >::type >::value &&!execution::is_executor< typename decay< Handler >::type >::value &&!is_convertible< Handler &, execution_context & >::value >::type *  = 0);
+      typename enable_if< !is_executor< typename decay< Handler >::type >::value &&!execution::is_executor< typename decay< Handler >::type >::value &&!is_convertible< Handler &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.spawn.overload2 more...]]``
 
 Start a new stackful coroutine, inheriting the execution context of another. 
@@ -117657,7 +117657,7 @@ Start a new stackful coroutine that executes on a given executor.
       const Executor & ex,
       Function && function,
       const boost::coroutines::attributes & attributes = boost::coroutines::attributes(),
-      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.spawn.overload4 more...]]``
 
 Start a new stackful coroutine that executes on a given strand. 
@@ -117690,7 +117690,7 @@ Start a new stackful coroutine that executes on a given execution context.
       ExecutionContext & ctx,
       Function && function,
       const boost::coroutines::attributes & attributes = boost::coroutines::attributes(),
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.spawn.overload7 more...]]``
 
 The `spawn()` function is a high-level wrapper over the Boost.Coroutine library. This function enables programs to implement asynchronous logic in a synchronous manner, as illustrated by the following example:
@@ -117783,7 +117783,7 @@ Start a new stackful coroutine, calling the specified handler when it completes.
       Handler && handler,
       Function && function,
       const boost::coroutines::attributes & attributes = boost::coroutines::attributes(),
-      typename enable_if< !is_executor< typename decay< Handler >::type >::value &&!execution::is_executor< typename decay< Handler >::type >::value &&!is_convertible< Handler &, execution_context & >::value >::type *  = 0);
+      typename enable_if< !is_executor< typename decay< Handler >::type >::value &&!execution::is_executor< typename decay< Handler >::type >::value &&!is_convertible< Handler &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to launch a new coroutine.
@@ -117872,7 +117872,7 @@ Start a new stackful coroutine that executes on a given executor.
       const Executor & ex,
       Function && function,
       const boost::coroutines::attributes & attributes = boost::coroutines::attributes(),
-      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< is_executor< Executor >::value||execution::is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to launch a new coroutine.
@@ -117998,7 +117998,7 @@ Start a new stackful coroutine that executes on a given execution context.
       ExecutionContext & ctx,
       Function && function,
       const boost::coroutines::attributes & attributes = boost::coroutines::attributes(),
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to launch a new coroutine.
@@ -124705,7 +124705,7 @@ Construct a strand for the specified executor.
       typename ``[link asio.reference.Executor1 Executor1]``>
   explicit ``[link asio.reference.strand.strand.overload2 strand]``(
       const Executor1 & e,
-      typename enable_if< conditional< !is_same< Executor1, strand >::value, is_convertible< Executor1, Executor >, false_type >::type::value >::type *  = 0);
+      typename enable_if< conditional< !is_same< Executor1, strand >::value, is_convertible< Executor1, Executor >, false_type >::type::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.strand.strand.overload2 more...]]``
 
 
@@ -124771,7 +124771,7 @@ Construct a strand for the specified executor.
       typename ``[link asio.reference.Executor1 Executor1]``>
   strand(
       const Executor1 & e,
-      typename enable_if< conditional< !is_same< Executor1, strand >::value, is_convertible< Executor1, Executor >, false_type >::type::value >::type *  = 0);
+      typename enable_if< conditional< !is_same< Executor1, strand >::value, is_convertible< Executor1, Executor >, false_type >::type::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -129822,7 +129822,7 @@ Convert the specified executor to the inner executor type, then use that to cons
       typename ``[link asio.reference.Executor1 OtherExecutor]``>
   ``[link asio.reference.use_awaitable_t__executor_with_default.executor_with_default.overload2 executor_with_default]``(
       const OtherExecutor & ex,
-      typename enable_if< is_convertible< OtherExecutor, InnerExecutor >::value >::type *  = 0);
+      typename enable_if< is_convertible< OtherExecutor, InnerExecutor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.use_awaitable_t__executor_with_default.executor_with_default.overload2 more...]]``
 
 
@@ -129851,7 +129851,7 @@ Convert the specified executor to the inner executor type, then use that to cons
       typename ``[link asio.reference.Executor1 OtherExecutor]``>
   executor_with_default(
       const OtherExecutor & ex,
-      typename enable_if< is_convertible< OtherExecutor, InnerExecutor >::value >::type *  = 0);
+      typename enable_if< is_convertible< OtherExecutor, InnerExecutor >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -130461,7 +130461,7 @@ Construct an object handle without opening it.
       typename ExecutionContext>
   explicit ``[link asio.reference.windows__basic_object_handle.basic_object_handle.overload2 basic_object_handle]``(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_object_handle >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_object_handle >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.windows__basic_object_handle.basic_object_handle.overload2 more...]]``
 
 
@@ -130478,7 +130478,7 @@ Construct an object handle on an existing native handle.
   ``[link asio.reference.windows__basic_object_handle.basic_object_handle.overload4 basic_object_handle]``(
       ExecutionContext & context,
       const native_handle_type & native_handle,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.windows__basic_object_handle.basic_object_handle.overload4 more...]]``
 
 
@@ -130529,7 +130529,7 @@ Construct an object handle without opening it.
       typename ExecutionContext>
   basic_object_handle(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_object_handle >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_object_handle >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates an object handle without opening it.
@@ -130604,7 +130604,7 @@ Construct an object handle on an existing native handle.
   basic_object_handle(
       ExecutionContext & context,
       const native_handle_type & native_handle,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates an object handle object to hold an existing native handle.
@@ -131567,7 +131567,7 @@ Construct an overlapped handle without opening it.
       typename ExecutionContext>
   explicit ``[link asio.reference.windows__basic_overlapped_handle.basic_overlapped_handle.overload2 basic_overlapped_handle]``(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_overlapped_handle >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_overlapped_handle >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.windows__basic_overlapped_handle.basic_overlapped_handle.overload2 more...]]``
 
 
@@ -131584,7 +131584,7 @@ Construct an overlapped handle on an existing native handle.
   ``[link asio.reference.windows__basic_overlapped_handle.basic_overlapped_handle.overload4 basic_overlapped_handle]``(
       ExecutionContext & context,
       const native_handle_type & native_handle,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.windows__basic_overlapped_handle.basic_overlapped_handle.overload4 more...]]``
 
 
@@ -131635,7 +131635,7 @@ Construct an overlapped handle without opening it.
       typename ExecutionContext>
   basic_overlapped_handle(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_overlapped_handle >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_overlapped_handle >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates an overlapped handle without opening it.
@@ -131710,7 +131710,7 @@ Construct an overlapped handle on an existing native handle.
   basic_overlapped_handle(
       ExecutionContext & context,
       const native_handle_type & native_handle,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates an overlapped handle object to hold an existing native handle.
@@ -132755,7 +132755,7 @@ Construct a random-access handle without opening it.
       typename ExecutionContext>
   explicit ``[link asio.reference.windows__basic_random_access_handle.basic_random_access_handle.overload2 basic_random_access_handle]``(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_random_access_handle >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_random_access_handle >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.windows__basic_random_access_handle.basic_random_access_handle.overload2 more...]]``
 
 
@@ -132772,7 +132772,7 @@ Construct a random-access handle on an existing native handle.
   ``[link asio.reference.windows__basic_random_access_handle.basic_random_access_handle.overload4 basic_random_access_handle]``(
       ExecutionContext & context,
       const native_handle_type & handle,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.windows__basic_random_access_handle.basic_random_access_handle.overload4 more...]]``
 
 
@@ -132823,7 +132823,7 @@ Construct a random-access handle without opening it.
       typename ExecutionContext>
   basic_random_access_handle(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_random_access_handle >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_random_access_handle >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a random-access handle without opening it. The handle needs to be opened or assigned before data can be sent or received on it.
@@ -132898,7 +132898,7 @@ Construct a random-access handle on an existing native handle.
   basic_random_access_handle(
       ExecutionContext & context,
       const native_handle_type & handle,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a random-access handle object to hold an existing native handle.
@@ -134229,7 +134229,7 @@ Construct a stream handle without opening it.
       typename ExecutionContext>
   explicit ``[link asio.reference.windows__basic_stream_handle.basic_stream_handle.overload2 basic_stream_handle]``(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_stream_handle >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_stream_handle >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.windows__basic_stream_handle.basic_stream_handle.overload2 more...]]``
 
 
@@ -134246,7 +134246,7 @@ Construct a stream handle on an existing native handle.
   ``[link asio.reference.windows__basic_stream_handle.basic_stream_handle.overload4 basic_stream_handle]``(
       ExecutionContext & context,
       const native_handle_type & handle,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.windows__basic_stream_handle.basic_stream_handle.overload4 more...]]``
 
 
@@ -134297,7 +134297,7 @@ Construct a stream handle without opening it.
       typename ExecutionContext>
   basic_stream_handle(
       ExecutionContext & context,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_stream_handle >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value, basic_stream_handle >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a stream handle without opening it. The handle needs to be opened or assigned before data can be sent or received on it.
@@ -134372,7 +134372,7 @@ Construct a stream handle on an existing native handle.
   basic_stream_handle(
       ExecutionContext & context,
       const native_handle_type & handle,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 This constructor creates a stream handle object to hold an existing native handle.
@@ -135776,7 +135776,7 @@ Construct an [link asio.reference.windows__overlapped_ptr `windows::overlapped_p
   explicit ``[link asio.reference.windows__overlapped_ptr.overlapped_ptr.overload2 overlapped_ptr]``(
       ExecutionContext & context,
       Handler && handler,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.windows__overlapped_ptr.overlapped_ptr.overload2 more...]]``
 
   template<
@@ -135785,7 +135785,7 @@ Construct an [link asio.reference.windows__overlapped_ptr `windows::overlapped_p
   explicit ``[link asio.reference.windows__overlapped_ptr.overlapped_ptr.overload3 overlapped_ptr]``(
       const Executor & ex,
       Handler && handler,
-      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.windows__overlapped_ptr.overlapped_ptr.overload3 more...]]``
 
 
@@ -135815,7 +135815,7 @@ Construct an [link asio.reference.windows__overlapped_ptr `windows::overlapped_p
   overlapped_ptr(
       ExecutionContext & context,
       Handler && handler,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -135835,7 +135835,7 @@ Construct an [link asio.reference.windows__overlapped_ptr `windows::overlapped_p
   overlapped_ptr(
       const Executor & ex,
       Handler && handler,
-      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -135877,7 +135877,7 @@ Reset to contain the specified handler, freeing any current OVERLAPPED object.
   void ``[link asio.reference.windows__overlapped_ptr.reset.overload2 reset]``(
       ExecutionContext & context,
       Handler && handler,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.windows__overlapped_ptr.reset.overload2 more...]]``
 
   template<
@@ -135886,7 +135886,7 @@ Reset to contain the specified handler, freeing any current OVERLAPPED object.
   void ``[link asio.reference.windows__overlapped_ptr.reset.overload3 reset]``(
       const Executor & ex,
       Handler && handler,
-      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.windows__overlapped_ptr.reset.overload3 more...]]``
 
 
@@ -135916,7 +135916,7 @@ Reset to contain the specified handler, freeing any current OVERLAPPED object.
   void reset(
       ExecutionContext & context,
       Handler && handler,
-      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = 0);
+      typename enable_if< is_convertible< ExecutionContext &, execution_context & >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -135936,7 +135936,7 @@ Reset to contain the specified handler, freeing any current OVERLAPPED object.
   void reset(
       const Executor & ex,
       Handler && handler,
-      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = 0);
+      typename enable_if< execution::is_executor< Executor >::value||is_executor< Executor >::value >::type *  = ASIO_NULLPTR);
 
 
 
@@ -136263,7 +136263,7 @@ Write all of the supplied data to a stream before returning.
   std::size_t ``[link asio.reference.write.overload1 write]``(
       SyncWriteStream & s,
       const ConstBufferSequence & buffers,
-      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.write.overload1 more...]]``
 
   template<
@@ -136273,7 +136273,7 @@ Write all of the supplied data to a stream before returning.
       SyncWriteStream & s,
       const ConstBufferSequence & buffers,
       asio::error_code & ec,
-      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.write.overload2 more...]]``
 
 Write a certain amount of data to a stream before returning. 
@@ -136286,7 +136286,7 @@ Write a certain amount of data to a stream before returning.
       SyncWriteStream & s,
       const ConstBufferSequence & buffers,
       CompletionCondition completion_condition,
-      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.write.overload3 more...]]``
 
   template<
@@ -136298,7 +136298,7 @@ Write a certain amount of data to a stream before returning.
       const ConstBufferSequence & buffers,
       CompletionCondition completion_condition,
       asio::error_code & ec,
-      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.write.overload4 more...]]``
 
 Write all of the supplied data to a stream before returning. 
@@ -136309,7 +136309,7 @@ Write all of the supplied data to a stream before returning.
   std::size_t ``[link asio.reference.write.overload5 write]``(
       SyncWriteStream & s,
       DynamicBuffer_v1 && buffers,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.write.overload5 more...]]``
 
   template<
@@ -136319,7 +136319,7 @@ Write all of the supplied data to a stream before returning.
       SyncWriteStream & s,
       DynamicBuffer_v1 && buffers,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.write.overload6 more...]]``
 
 Write a certain amount of data to a stream before returning. 
@@ -136332,7 +136332,7 @@ Write a certain amount of data to a stream before returning.
       SyncWriteStream & s,
       DynamicBuffer_v1 && buffers,
       CompletionCondition completion_condition,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.write.overload7 more...]]``
 
   template<
@@ -136344,7 +136344,7 @@ Write a certain amount of data to a stream before returning.
       DynamicBuffer_v1 && buffers,
       CompletionCondition completion_condition,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.write.overload8 more...]]``
 
 Write all of the supplied data to a stream before returning. 
@@ -136397,7 +136397,7 @@ Write all of the supplied data to a stream before returning.
   std::size_t ``[link asio.reference.write.overload13 write]``(
       SyncWriteStream & s,
       DynamicBuffer_v2 buffers,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.write.overload13 more...]]``
 
   template<
@@ -136407,7 +136407,7 @@ Write all of the supplied data to a stream before returning.
       SyncWriteStream & s,
       DynamicBuffer_v2 buffers,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.write.overload14 more...]]``
 
 Write a certain amount of data to a stream before returning. 
@@ -136420,7 +136420,7 @@ Write a certain amount of data to a stream before returning.
       SyncWriteStream & s,
       DynamicBuffer_v2 buffers,
       CompletionCondition completion_condition,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.write.overload15 more...]]``
 
   template<
@@ -136432,7 +136432,7 @@ Write a certain amount of data to a stream before returning.
       DynamicBuffer_v2 buffers,
       CompletionCondition completion_condition,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
   ``  [''''&raquo;''' [link asio.reference.write.overload16 more...]]``
 
 [heading Requirements]
@@ -136454,7 +136454,7 @@ Write all of the supplied data to a stream before returning.
   std::size_t write(
       SyncWriteStream & s,
       const ConstBufferSequence & buffers,
-      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to write a certain number of bytes of data to a stream. The call will block until one of the following conditions is true:
@@ -136536,7 +136536,7 @@ Write all of the supplied data to a stream before returning.
       SyncWriteStream & s,
       const ConstBufferSequence & buffers,
       asio::error_code & ec,
-      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to write a certain number of bytes of data to a stream. The call will block until one of the following conditions is true:
@@ -136611,7 +136611,7 @@ Write a certain amount of data to a stream before returning.
       SyncWriteStream & s,
       const ConstBufferSequence & buffers,
       CompletionCondition completion_condition,
-      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to write a certain number of bytes of data to a stream. The call will block until one of the following conditions is true:
@@ -136696,7 +136696,7 @@ Write a certain amount of data to a stream before returning.
       const ConstBufferSequence & buffers,
       CompletionCondition completion_condition,
       asio::error_code & ec,
-      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = 0);
+      typename enable_if< is_const_buffer_sequence< ConstBufferSequence >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to write a certain number of bytes of data to a stream. The call will block until one of the following conditions is true:
@@ -136759,7 +136759,7 @@ Write all of the supplied data to a stream before returning.
   std::size_t write(
       SyncWriteStream & s,
       DynamicBuffer_v1 && buffers,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to write a certain number of bytes of data to a stream. The call will block until one of the following conditions is true:
@@ -136831,7 +136831,7 @@ Write all of the supplied data to a stream before returning.
       SyncWriteStream & s,
       DynamicBuffer_v1 && buffers,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to write a certain number of bytes of data to a stream. The call will block until one of the following conditions is true:
@@ -136896,7 +136896,7 @@ Write a certain amount of data to a stream before returning.
       SyncWriteStream & s,
       DynamicBuffer_v1 && buffers,
       CompletionCondition completion_condition,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to write a certain number of bytes of data to a stream. The call will block until one of the following conditions is true:
@@ -136970,7 +136970,7 @@ Write a certain amount of data to a stream before returning.
       DynamicBuffer_v1 && buffers,
       CompletionCondition completion_condition,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v1< typename decay< DynamicBuffer_v1 >::type >::value &&!is_dynamic_buffer_v2< typename decay< DynamicBuffer_v1 >::type >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to write a certain number of bytes of data to a stream. The call will block until one of the following conditions is true:
@@ -137303,7 +137303,7 @@ Write all of the supplied data to a stream before returning.
   std::size_t write(
       SyncWriteStream & s,
       DynamicBuffer_v2 buffers,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to write a certain number of bytes of data to a stream. The call will block until one of the following conditions is true:
@@ -137375,7 +137375,7 @@ Write all of the supplied data to a stream before returning.
       SyncWriteStream & s,
       DynamicBuffer_v2 buffers,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to write a certain number of bytes of data to a stream. The call will block until one of the following conditions is true:
@@ -137440,7 +137440,7 @@ Write a certain amount of data to a stream before returning.
       SyncWriteStream & s,
       DynamicBuffer_v2 buffers,
       CompletionCondition completion_condition,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to write a certain number of bytes of data to a stream. The call will block until one of the following conditions is true:
@@ -137514,7 +137514,7 @@ Write a certain amount of data to a stream before returning.
       DynamicBuffer_v2 buffers,
       CompletionCondition completion_condition,
       asio::error_code & ec,
-      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = 0);
+      typename enable_if< is_dynamic_buffer_v2< DynamicBuffer_v2 >::value >::type *  = ASIO_NULLPTR);
 
 
 This function is used to write a certain number of bytes of data to a stream. The call will block until one of the following conditions is true:

--- a/asio/src/tests/unit/deadline_timer.cpp
+++ b/asio/src/tests/unit/deadline_timer.cpp
@@ -284,7 +284,7 @@ struct custom_allocation_timer_handler
     {
     }
 
-    pointer allocate(size_type n, const void* = 0)
+    pointer allocate(size_type n, const void* = ASIO_NULLPTR)
     {
       ++(*count_);
       return static_cast<T*>(::operator new(sizeof(T) * n));

--- a/asio/src/tests/unit/system_timer.cpp
+++ b/asio/src/tests/unit/system_timer.cpp
@@ -304,7 +304,7 @@ struct custom_allocation_timer_handler
     {
     }
 
-    pointer allocate(size_type n, const void* = 0)
+    pointer allocate(size_type n, const void* = ASIO_NULLPTR)
     {
       ++(*count_);
       return static_cast<T*>(::operator new(sizeof(T) * n));


### PR DESCRIPTION
This PR aims to fix #567.

In order not to break C++03, the macro `ASIO_NULLPTR` expands to `0` if `nullptr` is not available.