### PR TITLE
Mark template as inline to avoid duplicate symbol errors

### DIFF
--- a/asio/include/asio/impl/use_awaitable.hpp
+++ b/asio/include/asio/impl/use_awaitable.hpp
@@ -236,7 +236,7 @@ T dummy_return()
 }
 
 template <>
-void dummy_return()
+inline void dummy_return()
 {
 }
 #endif // defined(_MSC_VER)


### PR DESCRIPTION
```
LINK : bin\test_asyncly_d.exe not found or not built by the last incremental link; performing full link
ObservableTest.cpp.obj : error LNK2005: "void __cdecl boost::asio::dummy_return<void>(void)" (??$dummy_return@X@asio@boost@@YAXXZ) already defined in CoroutineTest.cpp.obj
bin\test_asyncly_d.exe : fatal error LNK1169: one or more multiply defined symbols found
```