### PR TITLE
Add this_thread null check for scheduler compensating_work_started routine

### DIFF
--- a/asio/include/asio/detail/impl/scheduler.ipp
+++ b/asio/include/asio/detail/impl/scheduler.ipp
@@ -320,8 +320,8 @@ void scheduler::restart()
 
 void scheduler::compensating_work_started()
 {
-  thread_info_base* this_thread = thread_call_stack::contains(this);
-  ++static_cast<thread_info*>(this_thread)->private_outstanding_work;
+  if (thread_info_base* this_thread = thread_call_stack::contains(this))
+    ++static_cast<thread_info*>(this_thread)->private_outstanding_work;
 }
 
 void scheduler::capture_current_exception()


### PR DESCRIPTION
Add this_thread null check for scheduler compensating_work_started routine to be aligned with other routines.