### PR TITLE
Fix outstanding_work.tracked executor move assignment.

### DIFF
--- a/asio/include/asio/impl/io_context.hpp
+++ b/asio/include/asio/impl/io_context.hpp
@@ -244,11 +244,16 @@ io_context::basic_executor_type<Allocator, Bits>::operator=(
 {
   if (this != &other)
   {
+    io_context* old_io_context = io_context_;
     io_context_ = other.io_context_;
     allocator_ = std::move(other.allocator_);
     bits_ = other.bits_;
     if (Bits & outstanding_work_tracked)
+    {
       other.io_context_ = 0;
+      if (old_io_context)
+        old_io_context->impl_.work_finished();
+    }
   }
   return *this;
 }

--- a/asio/include/asio/impl/thread_pool.hpp
+++ b/asio/include/asio/impl/thread_pool.hpp
@@ -76,11 +76,16 @@ thread_pool::basic_executor_type<Allocator, Bits>::operator=(
 {
   if (this != &other)
   {
+    thread_pool* old_thread_pool = pool_;
     pool_ = other.pool_;
     allocator_ = std::move(other.allocator_);
     bits_ = other.bits_;
     if (Bits & outstanding_work_tracked)
+    {
       other.pool_ = 0;
+      if (old_thread_pool)
+        old_thread_pool->scheduler_.work_finished();
+    }
   }
   return *this;
 }


### PR DESCRIPTION
Move assignments for io_context and thread pool executors are missing the logic present in copy assignments that finishes work on old contexts.
This causes the following example to hang:

```
#include <boost/asio/execution/outstanding_work.hpp>
#include <boost/asio/prefer.hpp>
#include <boost/asio/static_thread_pool.hpp>

int main()
{
    asio::static_thread_pool tp1{1},tp2{1};
    {
        auto work = asio::prefer(tp1.get_executor(),
            asio::execution::outstanding_work.tracked);
        work = asio::prefer(tp2.get_executor(),
            asio::execution::outstanding_work.tracked);
    }
    tp1.join();
    tp2.join();
}
```