### PR TITLE
ssl/detail/io: Complete deferred write to SSL stream.

### DIFF
--- a/asio/include/asio/ssl/detail/io.hpp
+++ b/asio/include/asio/ssl/detail/io.hpp
@@ -245,8 +245,14 @@ public:
         }
 
         default:
-        if (bytes_transferred == ~std::size_t(0))
+        if (bytes_transferred == ~std::size_t(0)) {
           bytes_transferred = 0; // Timer cancellation, no data transferred.
+          // If a write has occurred and buffered additional data to the
+          // stream, cancel the timer and rerun the send which will flush it
+          // to the socket before calling the completion handler.
+          if (want_ == engine::want_output)
+             want_ = engine::want_output_and_retry;
+        }
         else if (!ec_)
           ec_ = ec;
 


### PR DESCRIPTION
Currently if a user write is deferred due to an existing lower-level write being in-progress, the user completion handler is called with apparent success, even though the data hasn't actually been flushed to the socket.  A subsequent user write flushes the previously buffered data and the newly written data.  This appears to violate the async_write contract which states that the completion handler is called once the data has been written to its ultimate destination.

It seems that the `pending_write_` timer is there to handle this case but its cancellation winds up only calling the user completion hook; the data is buffered, but not written to the socket.

The comment [here](https://github.com/abutcher-gh/asio/blob/a7d1b6d1b912c1a68dd8ce8e056ec04d89c9ad76/asio/include/asio/ssl/detail/io.hpp#L179) also implies that this is simply a deferral until the current write is complete.

I don't think that this issue can be solved by user code, as the user appears to get no feedback that the write was not actually flushed to the socket.

This patch causes the data buffered to the stream by a user write occurring before the completion of a in-progress lower-level write to be actually commited to the socket prior to notifying the user of write completion, rather than the data just being buffered until the next user write attempt (which may be a long time in the future or never).