### PR TITLE
Make allocators respect alignment requirements.

### DIFF
--- a/asio/asio.manifest
+++ b/asio/asio.manifest
@@ -4491,6 +4491,7 @@
 /include/asio/defer.hpp
 /include/asio/detached.hpp
 /include/asio/detail/
+/include/asio/detail/aligned_alloc.hpp
 /include/asio/detail/array_fwd.hpp
 /include/asio/detail/array.hpp
 /include/asio/detail/assert.hpp

--- a/asio/boost_asio.manifest
+++ b/asio/boost_asio.manifest
@@ -39,6 +39,7 @@
 /boost/asio/defer.hpp
 /boost/asio/detached.hpp
 /boost/asio/detail/
+/boost/asio/detail/aligned_alloc.hpp
 /boost/asio/detail/array_fwd.hpp
 /boost/asio/detail/array.hpp
 /boost/asio/detail/assert.hpp

--- a/asio/include/Makefile.am
+++ b/asio/include/Makefile.am
@@ -37,6 +37,7 @@ nobase_include_HEADERS = \
 	asio/deadline_timer.hpp \
 	asio/defer.hpp \
 	asio/detached.hpp \
+	asio/detail/aligned_alloc.hpp \
 	asio/detail/array_fwd.hpp \
 	asio/detail/array.hpp \
 	asio/detail/assert.hpp \

--- a/asio/include/asio/detail/aligned_alloc.hpp
+++ b/asio/include/asio/detail/aligned_alloc.hpp
@@ -1,0 +1,55 @@
+//
+// detail/aligned_alloc.hpp
+// ~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2021 Maarten de Vries (maarten at de-vri dot es)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef ASIO_DETAIL_ALIGNED_ALLOC_HPP
+#define ASIO_DETAIL_ALIGNED_ALLOC_HPP
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#include "asio/detail/config.hpp"
+
+#if !defined(ASIO_HAS_ALIGNED_NEW) \
+  && defined(ASIO_HAS_BOOST_ALIGN) \
+  && defined(ASIO_HAS_ALIGNOF)
+# include <boost/align/aligned_alloc.hpp>
+#else
+# include <new>
+#endif
+
+namespace asio {
+namespace detail {
+
+inline void* aligned_alloc(std::size_t align, std::size_t size) {
+#if defined(ASIO_HAS_ALIGNED_NEW) && defined(ASIO_HAS_ALIGNOF)
+  return ::operator new(size, std::align_val_t(align));
+#elif defined(ASIO_HAS_BOOST_ALIGN) && defined(ASIO_HAS_ALIGNOF)
+  return boost::alignment::aligned_alloc(align, size);
+#else
+  (void) align;
+  return ::operator new(size);
+#endif
+}
+
+inline void aligned_free(void* ptr) {
+#if !defined(ASIO_HAS_ALIGNED_NEW) \
+  && defined(ASIO_HAS_BOOST_ALIGN) \
+  && defined(ASIO_HAS_ALIGNOF)
+  boost::alignment::aligned_free(ptr);
+#else
+  ::operator delete(ptr);
+#endif
+}
+
+} // namespace detail
+} // namespace asio
+
+#endif // ASIO_DETAIL_ALIGNED_ALLOC_HPP

--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -26,6 +26,7 @@
 
 // boostify: non-boost code ends here
 #if defined(ASIO_STANDALONE)
+# define ASIO_DISABLE_BOOST_ALIGN 1
 # define ASIO_DISABLE_BOOST_ARRAY 1
 # define ASIO_DISABLE_BOOST_ASSERT 1
 # define ASIO_DISABLE_BOOST_BIND 1
@@ -558,6 +559,32 @@
 #  define ASIO_RVALUE_REF_QUAL
 # endif // !defined(ASIO_RVALUE_REF_QUAL)
 #endif // defined(ASIO_HAS_REF_QUALIFIED_FUNCTIONS)
+
+// Support for the alignof operator.
+#if !defined(ASIO_HAS_ALIGNOF)
+# if !defined(ASIO_DISABLE_ALIGNOF)
+#  if (__cplusplus >= 201103)
+#   define ASIO_HAS_ALIGNOF 1
+#  endif // (__cplusplus >= 201103)
+# endif // !defined(ASIO_DISABLE_ALIGNOF)
+#endif // !defined(ASIO_HAS_ALIGNOF)
+
+#if defined(ASIO_HAS_ALIGNOF)
+# define ASIO_ALIGNOF(T) alignof(T)
+# define ASIO_DEFAULT_ALIGN alignof(std::max_align_t)
+#else // defined(ASIO_HAS_ALIGNOF)
+# define ASIO_ALIGNOF(T) 1
+# define ASIO_DEFAULT_ALIGN 1
+#endif // defined(ASIO_HAS_ALIGNOF)
+
+// Support for operator new with alignment argument.
+#if !defined(ASIO_HAS_ALIGNED_NEW)
+# if !defined(ASIO_DISABLE_ALIGNED_NEW)
+#  if (__cplusplus >= 201703)
+#   define ASIO_HAS_ALIGNED_NEW 1
+#  endif // (__cplusplus >= 201703)
+# endif // !defined(ASIO_DISABLE_ALIGNED_NEW)
+#endif // !defined(ASIO_HAS_ALIGNED_NEW)
 
 // Standard library support for system errors.
 #if !defined(ASIO_HAS_STD_SYSTEM_ERROR)
@@ -1615,6 +1642,15 @@
     static const type assignment
 # endif // !defined(ASIO_DISABLE_BOOST_STATIC_CONSTANT)
 #endif // !defined(ASIO_STATIC_CONSTANT)
+
+// Boost align library.
+#if !defined(ASIO_HAS_BOOST_ALIGN)
+# if !defined(ASIO_DISABLE_BOOST_ALIGN)
+#  if defined(ASIO_HAS_BOOST_CONFIG) && (BOOST_VERSION >= 105600)
+#   define ASIO_HAS_BOOST_ALIGN 1
+#  endif // defined(ASIO_HAS_BOOST_CONFIG) && (BOOST_VERSION >= 105600)
+# endif // !defined(ASIO_DISABLE_BOOST_ALIGN)
+#endif // !defined(ASIO_HAS_BOOST_ALIGN)
 
 // Boost array library.
 #if !defined(ASIO_HAS_BOOST_ARRAY)

--- a/asio/include/asio/detail/recycling_allocator.hpp
+++ b/asio/include/asio/detail/recycling_allocator.hpp
@@ -49,7 +49,8 @@ public:
   T* allocate(std::size_t n)
   {
     void* p = thread_info_base::allocate(Purpose(),
-        thread_context::top_of_thread_call_stack(), sizeof(T) * n);
+        thread_context::top_of_thread_call_stack(), sizeof(T) * n,
+        ASIO_ALIGNOF(T));
     return static_cast<T*>(p);
   }
 

--- a/asio/include/asio/detail/thread_info_base.hpp
+++ b/asio/include/asio/detail/thread_info_base.hpp
@@ -18,6 +18,7 @@
 #include "asio/detail/config.hpp"
 #include <climits>
 #include <cstddef>
+#include "asio/detail/aligned_alloc.hpp"
 #include "asio/detail/noncopyable.hpp"
 
 #if defined(ASIO_HAS_STD_EXCEPTION_PTR) \
@@ -70,13 +71,14 @@ public:
       // it is significantly faster when using a tight io_context::poll() loop
       // in latency sensitive applications.
       if (reusable_memory_[i])
-        ::operator delete(reusable_memory_[i]);
+        aligned_free(reusable_memory_[i]);
     }
   }
 
-  static void* allocate(thread_info_base* this_thread, std::size_t size)
+  static void* allocate(thread_info_base* this_thread, std::size_t size,
+      std::size_t align = ASIO_DEFAULT_ALIGN)
   {
-    return allocate(default_tag(), this_thread, size);
+    return allocate(default_tag(), this_thread, size, align);
   }
 
   static void deallocate(thread_info_base* this_thread,
@@ -87,7 +89,7 @@ public:
 
   template <typename Purpose>
   static void* allocate(Purpose, thread_info_base* this_thread,
-      std::size_t size)
+      std::size_t size, std::size_t align = ASIO_DEFAULT_ALIGN)
   {
     std::size_t chunks = (size + chunk_size - 1) / chunk_size;
 
@@ -97,16 +99,16 @@ public:
       this_thread->reusable_memory_[Purpose::mem_index] = 0;
 
       unsigned char* const mem = static_cast<unsigned char*>(pointer);
-      if (static_cast<std::size_t>(mem[0]) >= chunks)
+      if (static_cast<std::size_t>(mem[0]) >= chunks && reinterpret_cast<std::size_t>(pointer) % align == 0)
       {
         mem[size] = mem[0];
         return pointer;
       }
 
-      ::operator delete(pointer);
+      aligned_free(pointer);
     }
 
-    void* const pointer = ::operator new(chunks * chunk_size + 1);
+    void* const pointer = aligned_alloc(align, chunks * chunk_size + 1);
     unsigned char* const mem = static_cast<unsigned char*>(pointer);
     mem[size] = (chunks <= UCHAR_MAX) ? static_cast<unsigned char>(chunks) : 0;
     return pointer;
@@ -127,7 +129,7 @@ public:
       }
     }
 
-    ::operator delete(pointer);
+    aligned_free(pointer);
   }
 
   void capture_current_exception()

--- a/asio/include/asio/impl/handler_alloc_hook.ipp
+++ b/asio/include/asio/impl/handler_alloc_hook.ipp
@@ -16,6 +16,7 @@
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
 
 #include "asio/detail/config.hpp"
+#include "asio/detail/aligned_alloc.hpp"
 #include "asio/detail/thread_context.hpp"
 #include "asio/detail/thread_info_base.hpp"
 #include "asio/handler_alloc_hook.hpp"
@@ -34,7 +35,7 @@ asio_handler_allocate(std::size_t size, ...)
   return detail::thread_info_base::allocate(
       detail::thread_context::top_of_thread_call_stack(), size);
 #else // !defined(ASIO_DISABLE_SMALL_BLOCK_RECYCLING)
-  return ::operator new(size);
+  return aligned_alloc(ASIO_DEFAULT_ALIGN, size);
 #endif // !defined(ASIO_DISABLE_SMALL_BLOCK_RECYCLING)
 }
 
@@ -50,7 +51,7 @@ asio_handler_deallocate(void* pointer, std::size_t size, ...)
       detail::thread_context::top_of_thread_call_stack(), pointer, size);
 #else // !defined(ASIO_DISABLE_SMALL_BLOCK_RECYCLING)
   (void)size;
-  ::operator delete(pointer);
+  aligned_free(pointer)
 #endif // !defined(ASIO_DISABLE_SMALL_BLOCK_RECYCLING)
 }
 


### PR DESCRIPTION
This PR makes `recycling_allocator` and `hook_allocator` respect alignment requirement. This is important when completion handlers contain over-aligned members, for example when captured in a lambda.

This is implemented with the C++17 `::operator new(size, align)` if available, and falls back to Boost Align. If Boost Align is also not available, the alignment is silently ignored as before.

I briefly considered implementing a fallback aligned allocation by allocating too much memory to put additional bookkeeping right before the returned pointer. However, I don't think that is worth the added complexity. I think it makes more sense for a user to enable C++17 or Boost if they require proper alignment.

I ran into this in practise when posting a lambda with over-aligned captured Eigen objects using this code:
```c++
#include <asio.hpp>
#include <Eigen/Geometry>
#include <iostream>

void __attribute__((noinline)) foo(
	Eigen::Isometry3d const & a
) {
	std::cout << "foo() a % 32: " << (std::size_t(&a) % 32) << "\n";
};

int main() {
	asio::io_context io_context;
	std::cout << "alignof(Eigen::Isometry3d): " << alignof(Eigen::Isometry3d) << "\n";

	auto b = Eigen::Isometry3d::Identity();
	asio::post(io_context, [b] () {
		foo(b);
	});

	io_context.run();
}
```

When compiled with `g++ -std=c++17 -pthread -mavx` without this patch, the code above produces the following output:
```
alignof(Eigen::Isometry3d): 32
a.out: /usr/include/eigen3/Eigen/src/Core/DenseStorage.h:128: Eigen::internal::plain_array<T, Size, MatrixOrArrayOptions, 32>::plain_array() [with T = double; int Size = 16; int MatrixOrArrayOptions = 0]: Assertion `(internal::UIntPtr(eigen_unaligned_array_assert_workaround_gcc47(array)) & (31)) == 0 && "this assertion is explained here: " "http://eigen.tuxfamily.org/dox-devel/group__TopicUnalignedArrayAssert.html" " **** READ THIS WEB PAGE !!! ****"' failed.
```

With the PR, the compiled binary works as expected if C++17 is available, or if C++11 and Boost Align are available.