### PR TITLE
fix double errors on windows

### DIFF
--- a/asio/include/asio/detail/impl/throw_error.ipp
+++ b/asio/include/asio/detail/impl/throw_error.ipp
@@ -34,7 +34,7 @@ void do_throw_error(const asio::error_code& err)
 void do_throw_error(const asio::error_code& err, const char* location)
 {
   // boostify: non-boost code starts here
-#if defined(ASIO_MSVC) && defined(ASIO_HAS_STD_SYSTEM_ERROR)
+#if defined(ASIO_MSVC) && defined(ASIO_HAS_STD_SYSTEM_ERROR) && (_MSC_VER < 1928)
   // Microsoft's implementation of std::system_error is non-conformant in that
   // it ignores the error code's message when a "what" string is supplied. We'll
   // work around this by explicitly formatting the "what" string.


### PR DESCRIPTION
Error messages were getting doubled on Windows 10/ Visual Studio 2019. This fixed the issue for me.
https://github.com/diasurgical/devilutionX/issues/1978

works fine in _MSC_VER 1928 for me, no clue when they might've fixed that and I only got 1928
https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-160
_MSC_VER for different visual studio versions are near the bottom of that page