### PR TITLE
Properly null terminate local socket path names

### DIFF
--- a/asio/include/asio/local/detail/impl/endpoint.ipp
+++ b/asio/include/asio/local/detail/impl/endpoint.ipp
@@ -121,7 +121,7 @@ void endpoint::init(const char* path_name, std::size_t path_length)
 
   // NUL-terminate normal path names. Names that start with a NUL are in the
   // UNIX domain protocol's "abstract namespace" and are not NUL-terminated.
-  if (path_length > 0 && data_.local.sun_path[0] == 0)
+  if (path_length > 0 && data_.local.sun_path[0] != 0)
     data_.local.sun_path[path_length] = 0;
 }
 


### PR DESCRIPTION
The comment states that only names that don't start with NUL are null terminated but then the check for doing this is inverted.