### PR TITLE
Update async.qbk

### DIFF
--- a/asio/src/doc/overview/async.qbk
+++ b/asio/src/doc/overview/async.qbk
@@ -41,7 +41,7 @@ demultiplexer.]
 [mdash] Completion Handler
 
 [:Processes the result of an asynchronous operation. These are function
-objects, often created using `boost::bind`.]
+objects, often created using lambda expressions.]
 
 [mdash] Asynchronous Event Demultiplexer
 


### PR DESCRIPTION
Current common practice is using lambdas rather than boost::bind for completion handlers