### PR TITLE
Fix variable reference in sockatmark()

### DIFF
--- a/asio/include/asio/detail/impl/socket_ops.ipp
+++ b/asio/include/asio/detail/impl/socket_ops.ipp
@@ -641,7 +641,7 @@ bool sockatmark(socket_type s, asio::error_code& ec)
 # endif // defined(ENOTTY)
 #else // defined(SIOCATMARK)
   int value = ::sockatmark(s);
-  get_last_error(ec, result < 0);
+  get_last_error(ec, value < 0);
 #endif // defined(SIOCATMARK)
 
   return ec ? false : value != 0;


### PR DESCRIPTION
This branch of the preprocessor logic is referencing a variable from the other branch, so it doesn't exist. I assume this was supposed to be checking for errors on `value` instead of `result`.