### PR TITLE
Reorder field members in basic_resolver_entry

### DIFF
--- a/asio/include/asio/ip/basic_resolver_entry.hpp
+++ b/asio/include/asio/ip/basic_resolver_entry.hpp
@@ -51,9 +51,9 @@ public:
   /// Construct with specified endpoint, host name and service name.
   basic_resolver_entry(const endpoint_type& ep,
       ASIO_STRING_VIEW_PARAM host, ASIO_STRING_VIEW_PARAM service)
-    : endpoint_(ep),
-      host_name_(static_cast<std::string>(host)),
-      service_name_(static_cast<std::string>(service))
+    : host_name_(static_cast<std::string>(host)),
+      service_name_(static_cast<std::string>(service)),
+      endpoint_(ep)
   {
   }
 
@@ -100,9 +100,9 @@ public:
   }
 
 private:
-  endpoint_type endpoint_;
   std::string host_name_;
   std::string service_name_;
+  endpoint_type endpoint_;
 };
 
 } // namespace ip


### PR DESCRIPTION
I've been working with a platform that defines the `sockaddr` struct using a flexible array member like so.

```C
struct sockaddr {
    sa_family_t sa_family;
    char        sa_data[];
};
```

This was causing problems for `basic_resolver_entry` because the `endpoint_` field isn't placed at the end of the class definition. Seeing as how this isn't necessarily a supported platform, I wasn't sure if you'd really want to accept this change. Having said that, the change is fairly benign, and I believe this may be a valid definition for the `sockaddr` struct in general so I also thought you might find this change to be worth considering.