### PR TITLE
Correct function signature of password callbacks in ssl examples

### DIFF
--- a/asio/src/examples/cpp03/ssl/server.cpp
+++ b/asio/src/examples/cpp03/ssl/server.cpp
@@ -98,11 +98,13 @@ public:
           asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port)),
       context_(asio::ssl::context::sslv23)
   {
+    using namespace boost::placeholders;
+
     context_.set_options(
         asio::ssl::context::default_workarounds
         | asio::ssl::context::no_sslv2
         | asio::ssl::context::single_dh_use);
-    context_.set_password_callback(boost::bind(&server::get_password, this));
+    context_.set_password_callback(boost::bind(&server::get_password, this, _1, _2));
     context_.use_certificate_chain_file("server.pem");
     context_.use_private_key_file("server.pem", asio::ssl::context::pem);
     context_.use_tmp_dh_file("dh2048.pem");
@@ -110,7 +112,7 @@ public:
     start_accept();
   }
 
-  std::string get_password() const
+  std::string get_password(std::size_t size, asio::ssl::context::password_purpose purpose) const
   {
     return "test";
   }

--- a/asio/src/examples/cpp11/ssl/server.cpp
+++ b/asio/src/examples/cpp11/ssl/server.cpp
@@ -81,11 +81,13 @@ public:
     : acceptor_(io_context, tcp::endpoint(tcp::v4(), port)),
       context_(asio::ssl::context::sslv23)
   {
+    using namespace std::placeholders;
+
     context_.set_options(
         asio::ssl::context::default_workarounds
         | asio::ssl::context::no_sslv2
         | asio::ssl::context::single_dh_use);
-    context_.set_password_callback(std::bind(&server::get_password, this));
+    context_.set_password_callback(std::bind(&server::get_password, this, _1, _2));
     context_.use_certificate_chain_file("server.pem");
     context_.use_private_key_file("server.pem", asio::ssl::context::pem);
     context_.use_tmp_dh_file("dh2048.pem");
@@ -94,7 +96,7 @@ public:
   }
 
 private:
-  std::string get_password() const
+  std::string get_password(std::size_t size, asio::ssl::context::password_purpose purpose) const
   {
     return "test";
   }


### PR DESCRIPTION
The function signature of the password callback is:
```cpp
std::string password_callback(
  std::size_t max_length,  // The maximum size for a password.
  password_purpose purpose // Whether password is for reading or writing.
);
```
But the function signature of some callbacks in ssl examples do not match that. This is because `bind` allows discarding arguments.

If users try to call `set_password_callback` with a no-argument lambda:
```cpp
context_.set_password_callback([]() { return "test"; });
```
they will get a compile error `term does not evaluate to a function taking 2 arguments`.

This is not friendly to new users learning `asio`. This PR fixed it.