### PR TITLE
Different fix for strand "move after use" bug that should not make extra copies

### DIFF
--- a/asio/include/asio/detail/impl/strand_executor_service.hpp
+++ b/asio/include/asio/detail/impl/strand_executor_service.hpp
@@ -120,8 +120,8 @@ public:
               execution::blocking.never),
             execution::allocator(allocator));
 
-        execution::execute(BOOST_ASIO_MOVE_CAST(new_executor_type)(ex),
-            BOOST_ASIO_MOVE_CAST(invoker)(*this_));
+        execution::execute(ASIO_MOVE_CAST(new_executor_type)(ex),
+            ASIO_MOVE_CAST(invoker)(*this_));
       }
     }
   };

--- a/asio/include/asio/detail/impl/strand_executor_service.hpp
+++ b/asio/include/asio/detail/impl/strand_executor_service.hpp
@@ -107,18 +107,18 @@ public:
         recycling_allocator<void> allocator;
 	typedef typename decay<
             typename prefer_result<
-	      typename require_result<
-		executor_type,
-		execution::blocking_t::never_t
-	      >::type,
+              typename require_result<
+                executor_type,
+                execution::blocking_t::never_t
+              >::type,
               execution::allocator_t<recycling_allocator<void>>
             >::type
           >::type new_executor_type;
 
-	new_executor_type ex = boost::asio::prefer(
-	    boost::asio::require(this_->executor_,
+        new_executor_type ex = boost::asio::prefer(
+            boost::asio::require(this_->executor_,
               execution::blocking.never),
-	    execution::allocator(allocator));
+            execution::allocator(allocator));
 
         execution::execute(BOOST_ASIO_MOVE_CAST(new_executor_type)(ex),
             BOOST_ASIO_MOVE_CAST(invoker)(*this_));

--- a/asio/include/asio/detail/impl/strand_executor_service.hpp
+++ b/asio/include/asio/detail/impl/strand_executor_service.hpp
@@ -115,8 +115,8 @@ public:
             >::type
           >::type new_executor_type;
 
-        new_executor_type ex = boost::asio::prefer(
-            boost::asio::require(this_->executor_,
+        new_executor_type ex = asio::prefer(
+            asio::require(this_->executor_,
               execution::blocking.never),
             execution::allocator(allocator));
 

--- a/asio/include/asio/detail/impl/strand_executor_service.hpp
+++ b/asio/include/asio/detail/impl/strand_executor_service.hpp
@@ -105,13 +105,23 @@ public:
       if (push_waiting_to_ready(this_->impl_))
       {
         recycling_allocator<void> allocator;
-        executor_type ex = this_->executor_;
-        execution::execute(
-            asio::prefer(
-              asio::require(ex,
-                execution::blocking.never),
-            execution::allocator(allocator)),
-            ASIO_MOVE_CAST(invoker)(*this_));
+	typedef typename decay<
+            typename prefer_result<
+	      typename require_result<
+		executor_type,
+		execution::blocking_t::never_t
+	      >::type,
+              execution::allocator_t<recycling_allocator<void>>
+            >::type
+          >::type new_executor_type;
+
+	new_executor_type ex = boost::asio::prefer(
+	    boost::asio::require(this_->executor_,
+              execution::blocking.never),
+	    execution::allocator(allocator));
+
+        execution::execute(BOOST_ASIO_MOVE_CAST(new_executor_type)(ex),
+            BOOST_ASIO_MOVE_CAST(invoker)(*this_));
       }
     }
   };


### PR DESCRIPTION
Another way to fix https://github.com/chriskohlhoff/asio/issues/866