### PR TITLE
Fix null dereference in awaitable_thread destructor.

### DIFF
--- a/asio/include/asio/impl/awaitable.hpp
+++ b/asio/include/asio/impl/awaitable.hpp
@@ -631,7 +631,8 @@ public:
     if (bottom_of_stack_.valid())
     {
       // Coroutine "stack unwinding" must be performed through the executor.
-      (post)(bottom_of_stack_.frame_->u_.executor_,
+      const executor_type& ex = bottom_of_stack_.frame_->u_.executor_;
+      (post)(ex,
           [a = std::move(bottom_of_stack_)]() mutable
           {
             (void)awaitable<awaitable_thread_entry_point, Executor>(


### PR DESCRIPTION
If the variable `bottom_of_stack_` is moved into the lambda capture before the expression `bottom_of_stack_.frame_->u_.executor_` is evaluated, a read access violation will occur.

I think this problem depends on the compiler, as the order in which function parameters are evaluated is unspecified. I observed this issue while compiling with MSVC.