### PR TITLE
Fixes compiler error "error: 'asio::posix' has not been declared" on …

### DIFF
--- a/asio/src/examples/cpp14/parallel_group/wait_for_all.cpp
+++ b/asio/src/examples/cpp14/parallel_group/wait_for_all.cpp
@@ -12,6 +12,8 @@
 #include <asio/experimental/parallel_group.hpp>
 #include <iostream>
 
+#ifdef ASIO_HAS_POSIX_STREAM_DESCRIPTOR
+
 int main()
 {
   asio::io_context ctx;
@@ -56,3 +58,7 @@ int main()
 
   ctx.run();
 }
+
+#else // defined(ASIO_HAS_POSIX_STREAM_DESCRIPTOR)
+int main() {}
+#endif // defined(ASIO_HAS_POSIX_STREAM_DESCRIPTOR)

--- a/asio/src/examples/cpp14/parallel_group/wait_for_one.cpp
+++ b/asio/src/examples/cpp14/parallel_group/wait_for_one.cpp
@@ -12,6 +12,8 @@
 #include <asio/experimental/parallel_group.hpp>
 #include <iostream>
 
+#if defined(ASIO_HAS_POSIX_STREAM_DESCRIPTOR)
+
 int main()
 {
   asio::io_context ctx;
@@ -56,3 +58,7 @@ int main()
 
   ctx.run();
 }
+
+#else // defined(ASIO_HAS_POSIX_STREAM_DESCRIPTOR)
+int main() {}
+#endif // defined(ASIO_HAS_POSIX_STREAM_DESCRIPTOR)

--- a/asio/src/examples/cpp14/parallel_group/wait_for_one_error.cpp
+++ b/asio/src/examples/cpp14/parallel_group/wait_for_one_error.cpp
@@ -12,6 +12,8 @@
 #include <asio/experimental/parallel_group.hpp>
 #include <iostream>
 
+#if defined(ASIO_HAS_POSIX_STREAM_DESCRIPTOR)
+
 int main()
 {
   asio::io_context ctx;
@@ -56,3 +58,7 @@ int main()
 
   ctx.run();
 }
+
+#else // defined(ASIO_HAS_POSIX_STREAM_DESCRIPTOR)
+int main() {}
+#endif // defined(ASIO_HAS_POSIX_STREAM_DESCRIPTOR)

--- a/asio/src/examples/cpp14/parallel_group/wait_for_one_success.cpp
+++ b/asio/src/examples/cpp14/parallel_group/wait_for_one_success.cpp
@@ -12,6 +12,8 @@
 #include <asio/experimental/parallel_group.hpp>
 #include <iostream>
 
+#if defined(ASIO_HAS_POSIX_STREAM_DESCRIPTOR)
+
 int main()
 {
   asio::io_context ctx;
@@ -56,3 +58,7 @@ int main()
 
   ctx.run();
 }
+
+#else // defined(ASIO_HAS_POSIX_STREAM_DESCRIPTOR)
+int main() {}
+#endif // defined(ASIO_HAS_POSIX_STREAM_DESCRIPTOR)


### PR DESCRIPTION
…Windows 10 with MSYS Mingw64 10.3.0

Issue: #884

Signed-off-by: David Wedderwille <davidwe@posteo.de>