### PR TITLE
fixup! Defend against macros defined by Qt.

### DIFF
--- a/asio/include/asio/detail/pop_options.hpp
+++ b/asio/include/asio/detail/pop_options.hpp
@@ -146,4 +146,8 @@
 #  endif
 # endif
 
+# pragma pop_macro ("emit")
+# pragma pop_macro ("signal")
+# pragma pop_macro ("slot")
+
 #endif


### PR DESCRIPTION
The code path for `_MSC_VER` lacked the respective pop operations. See: #873 / 2d3a4c9.