### PR TITLE
Fix the initialisation order of members

### DIFF
--- a/asio/include/asio/detail/win_iocp_socket_accept_op.hpp
+++ b/asio/include/asio/detail/win_iocp_socket_accept_op.hpp
@@ -53,8 +53,8 @@ public:
       protocol_(protocol),
       peer_endpoint_(peer_endpoint),
       enable_connection_aborted_(enable_connection_aborted),
-      cancel_requested_(0),
       proxy_op_(0),
+      cancel_requested_(0),
       handler_(ASIO_MOVE_CAST(Handler)(handler)),
       work_(handler_, io_ex)
   {


### PR DESCRIPTION
Reorder the constructor list in `win_iocp_socket_accept_op`, so that `proxy_op` comes before `cancel_requested`, matching the order in which these members are declared (and the order in which they are initialised).

This addresses a warning that members are constructed in a different order to what the constructor implies. (I appreciate that you may not be able to guarantee that things build with all warnings in all compilers, but this is at least a simple one to resolve!)