### PR TITLE
Mark ~cancellation_handler_base() virtual

### DIFF
--- a/asio/include/asio/cancellation_signal.hpp
+++ b/asio/include/asio/cancellation_signal.hpp
@@ -38,7 +38,7 @@ public:
   virtual std::pair<void*, std::size_t> destroy() ASIO_NOEXCEPT = 0;
 
 protected:
-  ~cancellation_handler_base() {}
+  virtual ~cancellation_handler_base() {}
 };
 
 template <typename Handler>


### PR DESCRIPTION
This avoids C4265 on MSVC.