### PR TITLE
fixed -Wshadow Err/Warn - use 'a_'(as arg prefix)

### DIFF
--- a/asio/include/asio/this_coro.hpp
+++ b/asio/include/asio/this_coro.hpp
@@ -194,8 +194,8 @@ struct reset_cancellation_state_1_t
 {
   template <typename F>
   ASIO_CONSTEXPR reset_cancellation_state_1_t(
-      ASIO_MOVE_ARG(F) filter)
-    : filter(ASIO_MOVE_CAST(F)(filter))
+      ASIO_MOVE_ARG(F) a_filter)
+    : filter(ASIO_MOVE_CAST(F)(a_filter))
   {
   }
 
@@ -216,9 +216,9 @@ struct reset_cancellation_state_2_t
 {
   template <typename F1, typename F2>
   ASIO_CONSTEXPR reset_cancellation_state_2_t(
-      ASIO_MOVE_ARG(F1) in_filter, ASIO_MOVE_ARG(F2) out_filter)
-    : in_filter(ASIO_MOVE_CAST(F1)(in_filter)),
-      out_filter(ASIO_MOVE_CAST(F2)(out_filter))
+      ASIO_MOVE_ARG(F1) a_in_filter, ASIO_MOVE_ARG(F2) a_out_filter)
+    : in_filter(ASIO_MOVE_CAST(F1)(a_in_filter)),
+      out_filter(ASIO_MOVE_CAST(F2)(a_out_filter))
   {
   }
 
@@ -256,8 +256,8 @@ throw_if_cancelled()
 
 struct throw_if_cancelled_1_t
 {
-  ASIO_CONSTEXPR throw_if_cancelled_1_t(bool value)
-    : value(value)
+  ASIO_CONSTEXPR throw_if_cancelled_1_t(bool a_value)
+    : value(a_value)
   {
   }
 


### PR DESCRIPTION
Comply with -Wshadow flag (includes -Wshadow=compatible-local/local/global)  - gcc-9.3 able to the produce warnings
* Use prefix 'a_' as argument to variable 'name '

_The Warnings GCC-9.3 produces:_
```CPP
/root/builds/asio/asio-1.20.0/include/asio/this_coro.hpp: In constructor ‘constexpr asio::this_coro::reset_cancellation_state_1_t<Filter>::reset_cancellation_state_1_t(F&&)’:
/root/builds/asio/asio-1.20.0/include/asio/this_coro.hpp:198:5: error: declaration of ‘filter’ shadows a member of ‘asio::this_coro::reset_cancellation_state_1_t<Filter>’ [-Werror=shadow]
  198 |     : filter(ASIO_MOVE_CAST(F)(filter))
      |     ^
/root/builds/asio/asio-1.20.0/include/asio/this_coro.hpp:202:10: note: shadowed declaration is here
  202 |   Filter filter;
      |          ^~~~~~
/root/builds/asio/asio-1.20.0/include/asio/this_coro.hpp: In constructor ‘constexpr asio::this_coro::reset_cancellation_state_2_t<InFilter, OutFilter>::reset_cancellation_state_2_t(F1&&, F2&&)’:
/root/builds/asio/asio-1.20.0/include/asio/this_coro.hpp:220:5: error: declaration of ‘out_filter’ shadows a member of ‘asio::this_coro::reset_cancellation_state_2_t<InFilter, OutFilter>’ [-Werror=shadow]
  220 |     : in_filter(ASIO_MOVE_CAST(F1)(in_filter)),
      |     ^
/root/builds/asio/asio-1.20.0/include/asio/this_coro.hpp:226:13: note: shadowed declaration is here
  226 |   OutFilter out_filter;
      |             ^~~~~~~~~~
/root/builds/asio/asio-1.20.0/include/asio/this_coro.hpp:220:5: error: declaration of ‘in_filter’ shadows a member of ‘asio::this_coro::reset_cancellation_state_2_t<InFilter, OutFilter>’ [-Werror=shadow]
  220 |     : in_filter(ASIO_MOVE_CAST(F1)(in_filter)),
      |     ^
/root/builds/asio/asio-1.20.0/include/asio/this_coro.hpp:225:12: note: shadowed declaration is here
  225 |   InFilter in_filter;
      |            ^~~~~~~~~
/root/builds/asio/asio-1.20.0/include/asio/this_coro.hpp: In constructor ‘constexpr asio::this_coro::throw_if_cancelled_1_t::throw_if_cancelled_1_t(bool)’:
/root/builds/asio/asio-1.20.0/include/asio/this_coro.hpp:260:5: error: declaration of ‘value’ shadows a member of ‘asio::this_coro::throw_if_cancelled_1_t’ [-Werror=shadow]
  260 |     : value(value)
      |     ^
/root/builds/asio/asio-1.20.0/include/asio/this_coro.hpp:264:8: note: shadowed declaration is here
  264 |   bool value;
      |        ^~~~~
/root/builds/asio/asio-1.20.0/include/asio/this_coro.hpp: In constructor ‘constexpr asio::this_coro::throw_if_cancelled_1_t::throw_if_cancelled_1_t(bool)’:
/root/builds/asio/asio-1.20.0/include/asio/this_coro.hpp:262:3: error: declaration of ‘value’ shadows a member of ‘asio::this_coro::throw_if_cancelled_1_t’ [-Werror=shadow]
  262 |   }
      |   ^
/root/builds/asio/asio-1.20.0/include/asio/this_coro.hpp:264:8: note: shadowed declaration is here
  264 |   bool value;
      |        ^~~~~
/root/builds/asio/asio-1.20.0/include/asio/this_coro.hpp: In constructor ‘constexpr asio::this_coro::throw_if_cancelled_1_t::throw_if_cancelled_1_t(bool)’:
/root/builds/asio/asio-1.20.0/include/asio/this_coro.hpp:262:3: error: declaration of ‘value’ shadows a member of ‘asio::this_coro::throw_if_cancelled_1_t’ [-Werror=shadow]
  262 |   }
      |   ^
/root/builds/asio/asio-1.20.0/include/asio/this_coro.hpp:264:8: note: shadowed declaration is here
  264 |   bool value;
```
