### PR TITLE
use faster ctor for network_v4 in canonical()

### DIFF
--- a/asio/include/asio/ip/network_v4.hpp
+++ b/asio/include/asio/ip/network_v4.hpp
@@ -122,7 +122,7 @@ public:
   /// Obtain the true network address, omitting any host bits.
   network_v4 canonical() const ASIO_NOEXCEPT
   {
-    return network_v4(network(), netmask());
+    return network_v4(network(), prefix_length());
   }
 
   /// Test if network is a valid host address.


### PR DESCRIPTION
`network_v6::canonical()` already uses prefix_length().