### PR TITLE
Fix check for aligned_alloc with libc++ in MSVCRT-like environment

### DIFF
--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -617,9 +617,9 @@
 #  if (__cplusplus >= 201703)
 #   if defined(__clang__)
 #    if defined(ASIO_HAS_CLANG_LIBCXX)
-#     if (_LIBCPP_STD_VER > 14) && defined(_LIBCPP_HAS_ALIGNED_ALLOC)
+#     if (_LIBCPP_STD_VER > 14) && defined(_LIBCPP_HAS_ALIGNED_ALLOC) && !defined(_LIBCPP_MSVCRT_LIKE)
 #      define ASIO_HAS_STD_ALIGNED_ALLOC 1
-#     endif // (_LIBCPP_STD_VER > 14) && defined(_LIBCPP_HAS_ALIGNED_ALLOC)
+#     endif // (_LIBCPP_STD_VER > 14) && defined(_LIBCPP_HAS_ALIGNED_ALLOC) && !defined(_LIBCPP_MSVCRT_LIKE)
 #    elif defined(_GLIBCXX_HAVE_ALIGNED_ALLOC)
 #     define ASIO_HAS_STD_ALIGNED_ALLOC 1
 #    endif // defined(_GLIBCXX_HAVE_ALIGNED_ALLOC)


### PR DESCRIPTION
Using MSYS2's clang64 environment, this error started to occur after updating to Boost 1.77.0:

```shell
 In file included from C:/_/mingw-w64-helics/src/src/helics/apps/helicsWebServer.cpp:33: 
 In file included from D:/a/_temp/msys64/clang64/include/boost/asio/dispatch.hpp:22: 
 In file included from D:/a/_temp/msys64/clang64/include/boost/asio/execution/executor.hpp:20: 
 In file included from D:/a/_temp/msys64/clang64/include/boost/asio/execution/execute.hpp:20: 
 In file included from D:/a/_temp/msys64/clang64/include/boost/asio/execution/detail/as_invocable.hpp:20: 
 D:/a/_temp/msys64/clang64/include/boost/asio/detail/memory.hpp:88:20: error: reference to unresolved using declaration 
  void* ptr = std::aligned_alloc(align, size); 
  ^ 
 D:/a/_temp/msys64/clang64/include/c++/v1/cstdlib:158:1: note: using declaration annotated with 'using_if_exists' here 
 using ::aligned_alloc _LIBCPP_USING_IF_EXISTS; 
 ^ 
 In file included from C:/_/mingw-w64-helics/src/src/helics/apps/helicsWebServer.cpp:33: 
 In file included from D:/a/_temp/msys64/clang64/include/boost/asio/dispatch.hpp:22: 
 In file included from D:/a/_temp/msys64/clang64/include/boost/asio/execution/executor.hpp:20: 
 In file included from D:/a/_temp/msys64/clang64/include/boost/asio/execution/execute.hpp:20: 
 In file included from D:/a/_temp/msys64/clang64/include/boost/asio/execution/detail/as_invocable.hpp:20: 
 D:/a/_temp/msys64/clang64/include/boost/asio/detail/memory.hpp:88:15: error: excess elements in scalar initializer 
  void* ptr = std::aligned_alloc(align, size);
```

As far as I can tell, the issue comes down to libc++ expecting an `aligned_alloc` function provided by libc, but msvcrt doesn't support that C11 function (Microsoft uses `_aligned_malloc` instead). The example code for `aligned_alloc` on [cppreference.com](https://en.cppreference.com/w/cpp/memory/c/aligned_alloc) fails with the same error.

The check for `_LIBCPP_HAS_ALIGNED_ALLOC` isn't sufficient, because in [libcxx/include/__config line 357](https://github.com/llvm/llvm-project/blob/main/libcxx/include/__config#L357) they always define it when the compiler has the attribute `using_if_exists`. Adding a check to see if `_LIBCPP_MSVCRT_LIKE` is not defined seems to be the most reliable macro I've found so far to detect that `std::aligned_alloc` isn't available with clang libc++.

---

I imagine this is also a problem with native clang and libc++ on Windows outside of an MSYS2 environment, but that's problem even rarer than this case (this issue came up in the default set of CI builds for submitting an updated MinGW package).

I'm also checking if there's a change in a future version of libc++ that could be made to help address this issue.