### PR TITLE
Fix any_io_executor with ASIO_USE_TS_EXECUTOR_AS_DEFAULT

### DIFF
--- a/asio/include/asio/any_io_executor.hpp
+++ b/asio/include/asio/any_io_executor.hpp
@@ -294,8 +294,8 @@ struct prefer_member<any_io_executor, Prop> :
 
 #include "asio/detail/pop_options.hpp"
 
-#if defined(ASIO_HEADER_ONLY)
+#if defined(ASIO_HEADER_ONLY) && !defined(ASIO_USE_TS_EXECUTOR_AS_DEFAULT)
 # include "asio/impl/any_io_executor.ipp"
-#endif // defined(ASIO_HEADER_ONLY)
+#endif // defined(ASIO_HEADER_ONLY) && !defined(ASIO_USE_TS_EXECUTOR_AS_DEFAULT)
 
 #endif // ASIO_ANY_IO_EXECUTOR_HPP


### PR DESCRIPTION
Commit bae9bcf has overlooked the case of `any_io_executor` being a typedef to `executor` (when `ASIO_USE_TS_EXECUTOR_AS_DEFAULT` is defined) instead of a proper class, resulting in compilation errors.