### PR TITLE
fix missing ref to send_endpoint in io_uring_socket_recvfrom_op

### DIFF
--- a/asio/include/asio/detail/io_uring_socket_recvfrom_op.hpp
+++ b/asio/include/asio/detail/io_uring_socket_recvfrom_op.hpp
@@ -121,7 +121,7 @@ private:
   socket_type socket_;
   socket_ops::state_type state_;
   MutableBufferSequence buffers_;
-  Endpoint sender_endpoint_;
+  Endpoint& sender_endpoint_;
   socket_base::message_flags flags_;
   buffer_sequence_adapter<asio::mutable_buffer,
       MutableBufferSequence> bufs_;


### PR DESCRIPTION
When using io_uring as backend(with BOOST_ASIO_HAS_IO_URING and BOOST_ASIO_DISABLE_EPOLL defined), the endpoint parameter in async_receive_from of udp_socket is not correctly set due to the missing ref in class io_uring_socket_recvfrom_op.