### PR TITLE
Fix any_io_executor with ASIO_USE_TS_EXECUTOR_AS_DEFAULT and ARATE_COMPILATION

### DIFF
--- a/asio/include/asio/impl/any_io_executor.ipp
+++ b/asio/include/asio/impl/any_io_executor.ipp
@@ -20,6 +20,8 @@
 
 #include "asio/detail/push_options.hpp"
 
+#if !defined(ASIO_USE_TS_EXECUTOR_AS_DEFAULT)
+
 namespace asio {
 
 any_io_executor::any_io_executor() ASIO_NOEXCEPT
@@ -118,6 +120,8 @@ any_io_executor any_io_executor::prefer(
 }
 
 } // namespace asio
+
+#endif // !defined(ASIO_USE_TS_EXECUTOR_AS_DEFAULT)
 
 #include "asio/detail/pop_options.hpp"
 


### PR DESCRIPTION
Previous commits didn't take account of the possibility to use the both defines above.
Hence, any_io_executor.ipp would be compiled anyway, but `any_io_executor` is just a typedef.