### PR TITLE
Fix compilation issues with OpenSSL 3.0 API

### DIFF
--- a/asio/include/asio/ssl/impl/context.ipp
+++ b/asio/include/asio/ssl/impl/context.ipp
@@ -53,11 +53,13 @@ struct context::rsa_cleanup
   ~rsa_cleanup() { if (p) ::RSA_free(p); }
 };
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
 struct context::dh_cleanup
 {
   DH* p;
   ~dh_cleanup() { if (p) ::DH_free(p); }
 };
+#endif
 
 context::context(context::method m)
   : handle_(0)
@@ -1118,6 +1120,19 @@ ASIO_SYNC_OP_VOID context::do_use_tmp_dh(
 {
   ::ERR_clear_error();
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+  EVP_PKEY* p = ::PEM_read_bio_Parameters(bio, 0);
+  if (p)
+  {
+    if (::SSL_CTX_set0_tmp_dh_pkey(handle_, p) == 1)
+    {
+      ec = asio::error_code();
+      ASIO_SYNC_OP_VOID_RETURN(ec);
+    }
+    else
+      EVP_PKEY_free(p);
+  }
+#else
   dh_cleanup dh = { ::PEM_read_bio_DHparams(bio, 0, 0, 0) };
   if (dh.p)
   {
@@ -1127,6 +1142,7 @@ ASIO_SYNC_OP_VOID context::do_use_tmp_dh(
       ASIO_SYNC_OP_VOID_RETURN(ec);
     }
   }
+#endif
 
   ec = asio::error_code(
       static_cast<int>(::ERR_get_error()),

--- a/asio/include/asio/ssl/impl/error.ipp
+++ b/asio/include/asio/ssl/impl/error.ipp
@@ -39,17 +39,11 @@ public:
     if (reason)
     {
       const char* lib = ::ERR_lib_error_string(value);
-      const char* func = ::ERR_func_error_string(value);
       std::string result(reason);
-      if (lib || func)
+      if (lib)
       {
         result += " (";
-        if (lib)
-          result += lib;
-        if (lib && func)
-          result += ", ";
-        if (func)
-          result += func;
+        result += lib;
         result += ")";
       }
       return result;


### PR DESCRIPTION
This fixes two out of three issues: usage of `ERR_func_error_string` and usage of the `DH` struct and the functions using it, which are only available if OpenSSL is built with OpenSSL 1.1.1 compatibility.
Unit tests are passing for me with OpenSSL 3.0 built with `--api=3.0` and without `no-deprecated`.

The third issue is usage of the `RSA` struct and the functions using it. ~~Maybe the easiest solution to that would be to remove/deprecate `use_rsa_private_key` and `use_rsa_private_key_file` or make them call `use_private_key` / `use_private_key_file` instead, but I've never used the RSA-specific functions and I'm not exactly sure how they differ from the generic ones.~~ (probably not an option, see comment below)