### PR TITLE
Fix promise.hpp: 'all_of': is not a member of 'std'

### DIFF
--- a/asio/include/asio/experimental/promise.hpp
+++ b/asio/include/asio/experimental/promise.hpp
@@ -26,6 +26,7 @@
 #include "asio/experimental/impl/promise.hpp"
 #include "asio/post.hpp"
 
+#include <algorithm>
 #include <variant>
 
 #include "asio/detail/push_options.hpp"


### PR DESCRIPTION
Fix missing including (on VS2019).