### PR TITLE
Make gcc_x86_fenced_block compatible with -masm=intel

### DIFF
--- a/asio/include/asio/detail/gcc_x86_fenced_block.hpp
+++ b/asio/include/asio/detail/gcc_x86_fenced_block.hpp
@@ -55,7 +55,7 @@ private:
   {
     int r = 0, m = 1;
     __asm__ __volatile__ (
-        "xchgl %0, %1" :
+        "xchg{l} %0, %1" :
         "=r"(r), "=m"(m) :
         "0"(1), "m"(m) :
         "memory", "cc");


### PR DESCRIPTION
This small tweak allows `gcc -masm=intel` users to compile this header.