### PR TITLE
promise copy executor from first item before moving range

### DIFF
--- a/asio/include/asio/experimental/promise.hpp
+++ b/asio/include/asio/experimental/promise.hpp
@@ -499,8 +499,11 @@ struct promise<void(Ts...), Executor>
     if (std::begin(range) == std::end(range))
       throw std::logic_error(
           "Can't use race on an empty range with deduced executor");
-    else
-      return race(std::begin(range)->get_executor(), std::move(range));
+    else 
+    {
+      auto ex = std::begin(range)->get_executor();
+      return race(ex, std::move(range));	
+    }
   }
 
   template <typename Range>
@@ -517,7 +520,10 @@ struct promise<void(Ts...), Executor>
       throw std::logic_error(
           "Can't use all on an empty range with deduced executor");
     else
-      return all(std::begin(range)->get_executor(), std::move(range));
+    {
+      auto ex = std::begin(range)->get_executor();
+      return all(ex, std::move(range));	
+    }
   }
 
 private:


### PR DESCRIPTION
This is undefined behavior and crashes on MSVC