### PR TITLE
#1028 decay<> ambiguity after using directives

### DIFF
--- a/asio/include/asio/execution/execute.hpp
+++ b/asio/include/asio/execution/execute.hpp
@@ -87,7 +87,6 @@ void submit_helper(ASIO_MOVE_ARG(S) s, ASIO_MOVE_ARG(R) r);
 namespace asio_execution_execute_fn {
 
 using asio::conditional;
-using asio::decay;
 using asio::declval;
 using asio::enable_if;
 using asio::execution::detail::as_receiver;
@@ -149,13 +148,13 @@ struct call_traits<Impl, T, void(F),
     !execute_free<T, F>::is_valid
   >::type,
   typename void_type<
-   typename result_of<typename decay<F>::type&()>::type
+   typename result_of<typename ::asio::decay<F>::type&()>::type
   >::type,
   typename enable_if<
-    !is_as_invocable<typename decay<F>::type>::value
+    !is_as_invocable<typename ::asio::decay<F>::type>::value
   >::type,
   typename enable_if<
-    is_sender_to<T, as_receiver<typename decay<F>::type, T> >::value
+    is_sender_to<T, as_receiver<typename ::asio::decay<F>::type, T> >::value
   >::type>
 {
   ASIO_STATIC_CONSTEXPR(overload_type, overload = adapter);
@@ -231,7 +230,7 @@ struct impl
   {
     return asio::execution::detail::submit_helper(
         ASIO_MOVE_CAST(T)(t),
-        as_receiver<typename decay<F>::type, T>(
+        as_receiver<typename ::asio::decay<F>::type, T>(
           ASIO_MOVE_CAST(F)(f), 0));
   }
 };

--- a/asio/include/asio/execution/schedule.hpp
+++ b/asio/include/asio/execution/schedule.hpp
@@ -69,7 +69,6 @@ struct can_schedule :
 
 namespace asio_execution_schedule_fn {
 
-using asio::decay;
 using asio::declval;
 using asio::enable_if;
 using asio::execution::is_executor;
@@ -126,7 +125,7 @@ struct call_traits<S,
     !schedule_free<S>::is_valid
   >::type,
   typename enable_if<
-    is_executor<typename decay<S>::type>::value
+    is_executor<typename ::asio::decay<S>::type>::value
   >::type>
 {
   ASIO_STATIC_CONSTEXPR(overload_type, overload = identity);
@@ -135,7 +134,7 @@ struct call_traits<S,
 #if defined(ASIO_HAS_MOVE)
   typedef ASIO_MOVE_ARG(S) result_type;
 #else // defined(ASIO_HAS_MOVE)
-  typedef ASIO_MOVE_ARG(typename decay<S>::type) result_type;
+  typedef ASIO_MOVE_ARG(typename ::asio::decay<S>::type) result_type;
 #endif // defined(ASIO_HAS_MOVE)
 };
 

--- a/asio/include/asio/execution/set_done.hpp
+++ b/asio/include/asio/execution/set_done.hpp
@@ -68,7 +68,6 @@ struct can_set_done :
 
 namespace asio_execution_set_done_fn {
 
-using asio::decay;
 using asio::declval;
 using asio::enable_if;
 using asio::traits::set_done_free;

--- a/asio/include/asio/execution/set_error.hpp
+++ b/asio/include/asio/execution/set_error.hpp
@@ -68,7 +68,6 @@ struct can_set_error :
 
 namespace asio_execution_set_error_fn {
 
-using asio::decay;
 using asio::declval;
 using asio::enable_if;
 using asio::traits::set_error_free;

--- a/asio/include/asio/execution/set_value.hpp
+++ b/asio/include/asio/execution/set_value.hpp
@@ -71,7 +71,6 @@ struct can_set_value :
 
 namespace asio_execution_set_value_fn {
 
-using asio::decay;
 using asio::declval;
 using asio::enable_if;
 using asio::traits::set_value_free;

--- a/asio/include/asio/execution/start.hpp
+++ b/asio/include/asio/execution/start.hpp
@@ -65,7 +65,6 @@ struct can_start :
 
 namespace asio_execution_start_fn {
 
-using asio::decay;
 using asio::declval;
 using asio::enable_if;
 using asio::traits::start_free;

--- a/asio/include/asio/prefer.hpp
+++ b/asio/include/asio/prefer.hpp
@@ -119,7 +119,6 @@ struct prefer_result
 namespace asio_prefer_fn {
 
 using asio::conditional;
-using asio::decay;
 using asio::declval;
 using asio::enable_if;
 using asio::is_applicable_property;
@@ -158,12 +157,12 @@ template <typename Impl, typename T, typename Property>
 struct call_traits<Impl, T, void(Property),
   typename enable_if<
     is_applicable_property<
-      typename decay<T>::type,
-      typename decay<Property>::type
+      typename ::asio::decay<T>::type,
+      typename ::asio::decay<Property>::type
     >::value
   >::type,
   typename enable_if<
-    decay<Property>::type::is_preferable
+    ::asio::decay<Property>::type::is_preferable
   >::type,
   typename enable_if<
     static_require<T, Property>::is_valid
@@ -175,7 +174,7 @@ struct call_traits<Impl, T, void(Property),
 #if defined(ASIO_HAS_MOVE)
   typedef ASIO_MOVE_ARG(T) result_type;
 #else // defined(ASIO_HAS_MOVE)
-  typedef ASIO_MOVE_ARG(typename decay<T>::type) result_type;
+  typedef ASIO_MOVE_ARG(typename ::asio::decay<T>::type) result_type;
 #endif // defined(ASIO_HAS_MOVE)
 };
 
@@ -183,12 +182,12 @@ template <typename Impl, typename T, typename Property>
 struct call_traits<Impl, T, void(Property),
   typename enable_if<
     is_applicable_property<
-      typename decay<T>::type,
-      typename decay<Property>::type
+      typename ::asio::decay<T>::type,
+      typename ::asio::decay<Property>::type
     >::value
   >::type,
   typename enable_if<
-    decay<Property>::type::is_preferable
+    ::asio::decay<Property>::type::is_preferable
   >::type,
   typename enable_if<
     !static_require<T, Property>::is_valid
@@ -205,12 +204,12 @@ template <typename Impl, typename T, typename Property>
 struct call_traits<Impl, T, void(Property),
   typename enable_if<
     is_applicable_property<
-      typename decay<T>::type,
-      typename decay<Property>::type
+      typename ::asio::decay<T>::type,
+      typename ::asio::decay<Property>::type
     >::value
   >::type,
   typename enable_if<
-    decay<Property>::type::is_preferable
+    ::asio::decay<Property>::type::is_preferable
   >::type,
   typename enable_if<
     !static_require<T, Property>::is_valid
@@ -230,12 +229,12 @@ template <typename Impl, typename T, typename Property>
 struct call_traits<Impl, T, void(Property),
   typename enable_if<
     is_applicable_property<
-      typename decay<T>::type,
-      typename decay<Property>::type
+      typename ::asio::decay<T>::type,
+      typename ::asio::decay<Property>::type
     >::value
   >::type,
   typename enable_if<
-    decay<Property>::type::is_preferable
+    ::asio::decay<Property>::type::is_preferable
   >::type,
   typename enable_if<
     !static_require<T, Property>::is_valid
@@ -258,12 +257,12 @@ template <typename Impl, typename T, typename Property>
 struct call_traits<Impl, T, void(Property),
   typename enable_if<
     is_applicable_property<
-      typename decay<T>::type,
-      typename decay<Property>::type
+      typename ::asio::decay<T>::type,
+      typename ::asio::decay<Property>::type
     >::value
   >::type,
   typename enable_if<
-    decay<Property>::type::is_preferable
+    ::asio::decay<Property>::type::is_preferable
   >::type,
   typename enable_if<
     !static_require<T, Property>::is_valid
@@ -289,8 +288,8 @@ template <typename Impl, typename T, typename Property>
 struct call_traits<Impl, T, void(Property),
   typename enable_if<
     is_applicable_property<
-      typename decay<T>::type,
-      typename decay<Property>::type
+      typename ::asio::decay<T>::type,
+      typename ::asio::decay<Property>::type
     >::value
   >::type,
   typename enable_if<

--- a/asio/include/asio/query.hpp
+++ b/asio/include/asio/query.hpp
@@ -101,7 +101,6 @@ struct query_result
 namespace asio_query_fn {
 
 using asio::conditional;
-using asio::decay;
 using asio::declval;
 using asio::enable_if;
 using asio::is_applicable_property;
@@ -132,8 +131,8 @@ template <typename Impl, typename T, typename Property>
 struct call_traits<Impl, T, void(Property),
   typename enable_if<
     is_applicable_property<
-      typename decay<T>::type,
-      typename decay<Property>::type
+      typename ::asio::decay<T>::type,
+      typename ::asio::decay<Property>::type
     >::value
   >::type,
   typename enable_if<
@@ -148,8 +147,8 @@ template <typename Impl, typename T, typename Property>
 struct call_traits<Impl, T, void(Property),
   typename enable_if<
     is_applicable_property<
-      typename decay<T>::type,
-      typename decay<Property>::type
+      typename ::asio::decay<T>::type,
+      typename ::asio::decay<Property>::type
     >::value
   >::type,
   typename enable_if<
@@ -167,8 +166,8 @@ template <typename Impl, typename T, typename Property>
 struct call_traits<Impl, T, void(Property),
   typename enable_if<
     is_applicable_property<
-      typename decay<T>::type,
-      typename decay<Property>::type
+      typename ::asio::decay<T>::type,
+      typename ::asio::decay<Property>::type
     >::value
   >::type,
   typename enable_if<
@@ -223,8 +222,8 @@ struct impl
       call_traits<impl, T, void(Property)>::is_noexcept))
   {
     return static_query<
-      typename decay<T>::type,
-      typename decay<Property>::type
+      typename ::asio::decay<T>::type,
+      typename ::asio::decay<Property>::type
     >::value();
   }
 

--- a/asio/include/asio/require.hpp
+++ b/asio/include/asio/require.hpp
@@ -108,7 +108,6 @@ struct require_result
 namespace asio_require_fn {
 
 using asio::conditional;
-using asio::decay;
 using asio::declval;
 using asio::enable_if;
 using asio::is_applicable_property;
@@ -141,12 +140,12 @@ template <typename Impl, typename T, typename Property>
 struct call_traits<Impl, T, void(Property),
   typename enable_if<
     is_applicable_property<
-      typename decay<T>::type,
-      typename decay<Property>::type
+      typename ::asio::decay<T>::type,
+      typename ::asio::decay<Property>::type
     >::value
   >::type,
   typename enable_if<
-    decay<Property>::type::is_requirable
+    ::asio::decay<Property>::type::is_requirable
   >::type,
   typename enable_if<
     static_require<T, Property>::is_valid
@@ -158,7 +157,7 @@ struct call_traits<Impl, T, void(Property),
 #if defined(ASIO_HAS_MOVE)
   typedef ASIO_MOVE_ARG(T) result_type;
 #else // defined(ASIO_HAS_MOVE)
-  typedef ASIO_MOVE_ARG(typename decay<T>::type) result_type;
+  typedef ASIO_MOVE_ARG(typename ::asio::decay<T>::type) result_type;
 #endif // defined(ASIO_HAS_MOVE)
 };
 
@@ -166,12 +165,12 @@ template <typename Impl, typename T, typename Property>
 struct call_traits<Impl, T, void(Property),
   typename enable_if<
     is_applicable_property<
-      typename decay<T>::type,
-      typename decay<Property>::type
+      typename ::asio::decay<T>::type,
+      typename ::asio::decay<Property>::type
     >::value
   >::type,
   typename enable_if<
-    decay<Property>::type::is_requirable
+    ::asio::decay<Property>::type::is_requirable
   >::type,
   typename enable_if<
     !static_require<T, Property>::is_valid
@@ -188,12 +187,12 @@ template <typename Impl, typename T, typename Property>
 struct call_traits<Impl, T, void(Property),
   typename enable_if<
     is_applicable_property<
-      typename decay<T>::type,
-      typename decay<Property>::type
+      typename ::asio::decay<T>::type,
+      typename ::asio::decay<Property>::type
     >::value
   >::type,
   typename enable_if<
-    decay<Property>::type::is_requirable
+    ::asio::decay<Property>::type::is_requirable
   >::type,
   typename enable_if<
     !static_require<T, Property>::is_valid
@@ -235,7 +234,7 @@ struct call_traits<Impl, T, void(P0, P1),
       >::is_noexcept
     ));
 
-  typedef typename decay<
+  typedef typename ::asio::decay<
     typename call_traits<
       Impl,
       typename call_traits<Impl, T, void(P0)>::result_type,
@@ -271,7 +270,7 @@ struct call_traits<Impl, T, void(P0, P1, PN ASIO_ELLIPSIS),
       >::is_noexcept
     ));
 
-  typedef typename decay<
+  typedef typename ::asio::decay<
     typename call_traits<
       Impl,
       typename call_traits<Impl, T, void(P0)>::result_type,

--- a/asio/include/asio/require_concept.hpp
+++ b/asio/include/asio/require_concept.hpp
@@ -108,7 +108,6 @@ struct require_concept_result
 namespace asio_require_concept_fn {
 
 using asio::conditional;
-using asio::decay;
 using asio::declval;
 using asio::enable_if;
 using asio::is_applicable_property;
@@ -139,12 +138,12 @@ template <typename Impl, typename T, typename Property>
 struct call_traits<Impl, T, void(Property),
   typename enable_if<
     is_applicable_property<
-      typename decay<T>::type,
-      typename decay<Property>::type
+      typename ::asio::decay<T>::type,
+      typename ::asio::decay<Property>::type
     >::value
   >::type,
   typename enable_if<
-    decay<Property>::type::is_requirable_concept
+    ::asio::decay<Property>::type::is_requirable_concept
   >::type,
   typename enable_if<
     static_require_concept<T, Property>::is_valid
@@ -159,12 +158,12 @@ template <typename Impl, typename T, typename Property>
 struct call_traits<Impl, T, void(Property),
   typename enable_if<
     is_applicable_property<
-      typename decay<T>::type,
-      typename decay<Property>::type
+      typename ::asio::decay<T>::type,
+      typename ::asio::decay<Property>::type
     >::value
   >::type,
   typename enable_if<
-    decay<Property>::type::is_requirable_concept
+    ::asio::decay<Property>::type::is_requirable_concept
   >::type,
   typename enable_if<
     !static_require_concept<T, Property>::is_valid
@@ -187,12 +186,12 @@ template <typename Impl, typename T, typename Property>
 struct call_traits<Impl, T, void(Property),
   typename enable_if<
     is_applicable_property<
-      typename decay<T>::type,
-      typename decay<Property>::type
+      typename ::asio::decay<T>::type,
+      typename ::asio::decay<Property>::type
     >::value
   >::type,
   typename enable_if<
-    decay<Property>::type::is_requirable_concept
+    ::asio::decay<Property>::type::is_requirable_concept
   >::type,
   typename enable_if<
     !static_require_concept<T, Property>::is_valid


### PR DESCRIPTION
#1028 decay<> ambiguity after using directives

Proposal for fixing the following fragment with MSVC by always referring
to the complete qualifier `::asio::decay`

```
#include <boost/optional.hpp>
#include <type_traits>
using namespace boost;
using namespace std;
#include <boost/asio.hpp>
```