### PR TITLE
Add reinterpret_cast to io_uring_prep_cancel

### DIFF
--- a/asio/include/asio/detail/impl/io_uring_service.ipp
+++ b/asio/include/asio/detail/impl/io_uring_service.ipp
@@ -78,7 +78,7 @@ void io_uring_service::shutdown()
       {
         ops.push(io_obj->queues_[i].op_queue_);
         if (::io_uring_sqe* sqe = get_sqe())
-          ::io_uring_prep_cancel(sqe, &io_obj->queues_[i], 0);
+          ::io_uring_prep_cancel(sqe, reinterpret_cast<std::size_t>(&io_obj->queues_[i]), 0);
       }
     }
     io_obj->shutdown_ = true;
@@ -87,7 +87,7 @@ void io_uring_service::shutdown()
 
   // Cancel the timeout operation.
   if (::io_uring_sqe* sqe = get_sqe())
-    ::io_uring_prep_cancel(sqe, &timeout_, IOSQE_IO_DRAIN);
+    ::io_uring_prep_cancel(sqe, reinterpret_cast<std::size_t>(&timeout_), IOSQE_IO_DRAIN);
   submit_sqes();
 
   // Wait for all completions to come back.
@@ -124,7 +124,7 @@ void io_uring_service::notify_fork(
           {
             mutex::scoped_lock lock(mutex_);
             if (::io_uring_sqe* sqe = get_sqe())
-              ::io_uring_prep_cancel(sqe, &io_obj->queues_[i], 0);
+              ::io_uring_prep_cancel(sqe, reinterpret_cast<std::size_t>(&io_obj->queues_[i]), 0);
           }
         }
       }
@@ -133,7 +133,7 @@ void io_uring_service::notify_fork(
       {
         mutex::scoped_lock lock(mutex_);
         if (::io_uring_sqe* sqe = get_sqe())
-          ::io_uring_prep_cancel(sqe, &timeout_, IOSQE_IO_DRAIN);
+          ::io_uring_prep_cancel(sqe, reinterpret_cast<std::size_t>(&timeout_), IOSQE_IO_DRAIN);
         submit_sqes();
       }
 
@@ -345,7 +345,7 @@ void io_uring_service::cancel_ops_by_key(
           mutex::scoped_lock lock(mutex_);
           if (::io_uring_sqe* sqe = get_sqe())
           {
-            ::io_uring_prep_cancel(sqe, &io_obj->queues_[op_type], 0);
+            ::io_uring_prep_cancel(sqe, reinterpret_cast<std::size_t>(&io_obj->queues_[op_type]), 0);
             submit_sqes();
           }
         }
@@ -641,7 +641,7 @@ void io_uring_service::do_cancel_ops(
       {
         io_obj->queues_[i].cancel_requested_ = true;
         if (::io_uring_sqe* sqe = get_sqe())
-          ::io_uring_prep_cancel(sqe, &io_obj->queues_[i], 0);
+          ::io_uring_prep_cancel(sqe, reinterpret_cast<std::size_t>(&io_obj->queues_[i]), 0);
       }
     }
     submit_sqes();


### PR DESCRIPTION
The function io_uring_prep_cancel, which second param's type is unsigned long long. So we should add reinterpret_cast to avoid compile error.