### PR TITLE
Coropose Experiment (coroutine compose)

### DIFF
--- a/asio/include/asio/awaitable.hpp
+++ b/asio/include/asio/awaitable.hpp
@@ -99,9 +99,14 @@ public:
   }
 
   // Support for co_await keyword.
+
+  template<typename U>
+  static int inherits_awaitable_frame(const detail::awaitable_frame<U, Executor> & );
+
   template <class U>
   void await_suspend(
-      detail::coroutine_handle<detail::awaitable_frame<U, Executor>> h)
+      detail::coroutine_handle<U> h,
+      decltype(inherits_awaitable_frame(std::declval<U>()))= 0)
   {
     frame_->push_frame(&h.promise());
   }

--- a/asio/include/asio/coropose.hpp
+++ b/asio/include/asio/coropose.hpp
@@ -1,0 +1,229 @@
+// Copyright (c) 2021 Klemens D. Morgenstern
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#ifndef ASIO_COROPOSE_HPP
+#define ASIO_COROPOSE_HPP
+
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#include "asio/detail/config.hpp"
+
+#include "asio/co_spawn.hpp"
+#include "asio/async_result.hpp"
+#include "asio/awaitable.hpp"
+#include "asio/use_awaitable.hpp"
+#include "asio/experimental/coro.hpp"
+
+#include "asio/detail/push_options.hpp"
+
+namespace asio {
+
+template<typename Signature>
+struct async_coropose_tag
+{
+};
+
+template<typename Signature, typename CompletionToken>
+struct coropose_awaitable_frame;
+
+template<typename T, typename CompletionToken>
+struct coropose_awaitable_frame<void(T), CompletionToken>: asio::detail::awaitable_frame<T, any_io_executor>
+{
+  using asio::detail::awaitable_frame<T, any_io_executor>::await_transform;
+
+  template<typename Context,
+          typename ... Args>
+  coropose_awaitable_frame(Context && ctx, Args && ... args)
+  {
+    auto l =
+            [cpl = std::move(std::get<sizeof...(Args) - 2>(std::forward_as_tuple(args...)))](std::exception_ptr e, T && t) mutable
+            {
+              if (e)
+                std::rethrow_exception(e); // so run() throws e
+              std::move(cpl)(std::forward<T>(t));
+            };
+
+    asio::co_spawn(std::forward<Context>(ctx),
+                   asio::detail::awaitable_frame<T, any_io_executor>::get_return_object(),
+                   std::move(l)
+                   );
+  }
+
+  void get_return_object()
+  {
+  }
+};
+
+template<typename T, typename CompletionToken>
+struct coropose_awaitable_frame<void(std::exception_ptr, T), CompletionToken>: asio::detail::awaitable_frame<T, any_io_executor>
+{
+  using asio::detail::awaitable_frame<T, any_io_executor>::await_transform;
+
+  template<typename Context,
+          typename ... Args>
+  coropose_awaitable_frame(Context && ctx, Args && ... args)
+  {
+    asio::co_spawn(std::forward<Context>(ctx),
+                   asio::detail::awaitable_frame<T, any_io_executor>::get_return_object(),
+                   std::move(std::get<sizeof...(Args) - 2>(std::forward_as_tuple(args...)))
+    );
+  }
+
+  void get_return_object()
+  {
+    // NOOP:
+  }
+};
+
+//template<typename
+template<typename Signature, typename CompletionToken>
+struct async_coropose_traits
+{
+  using promise_type = coropose_awaitable_frame<Signature, CompletionToken>;
+  using type = void;
+};
+
+
+template<typename T, typename Executor>
+struct async_coropose_traits<void(T), asio::use_awaitable_t<Executor>>
+{
+  using type = asio::awaitable<T, Executor>;
+};
+
+template<typename T, typename Executor>
+struct async_coropose_traits<void(asio::error_code, T), asio::use_awaitable_t<Executor>>
+{
+  using type = asio::awaitable<T, Executor>;
+};
+
+template<typename T, typename Executor>
+struct async_coropose_traits<void(std::exception_ptr, T), asio::use_awaitable_t<Executor>>
+{
+  using type = asio::awaitable<T, Executor>;
+};
+
+
+template<typename T, typename Executor>
+struct async_coropose_traits<void(T), asio::experimental::use_coro_t<Executor>>
+{
+  using type = asio::experimental::coro<void() noexcept, T, Executor>;
+};
+
+template<typename T, typename Executor>
+struct async_coropose_traits<void(asio::error_code, T), asio::experimental::use_coro_t<Executor>>
+{
+  using type = asio::experimental::coro<void() noexcept, std::variant<error_code, T>, Executor>;
+};
+
+template<typename T, typename Executor>
+struct async_coropose_traits<void(std::exception_ptr, T), asio::experimental::use_coro_t<Executor>>
+{
+  using type = asio::experimental::coro<void, T, Executor>;
+};
+
+template<typename Signature, typename CompletionToken>
+using async_coropose_t = typename async_coropose_traits<Signature, std::decay_t<CompletionToken>>::type;
+
+} // namespace asio
+
+#if defined(ASIO_HAS_STD_COROUTINE)
+namespace std
+#else // defined(ASIO_HAS_STD_COROUTINE)
+namespace std::experimental
+#endif // defined(ASIO_HAS_STD_COROUTINE)
+{
+
+template<typename Context, typename CompletionToken, typename Signature>
+struct coroutine_traits<void, Context,
+                        CompletionToken, asio::async_coropose_tag<Signature> >
+{
+  using promise_type = typename asio::async_coropose_traits<Signature, std::decay_t<CompletionToken>>::promise_type;
+};
+
+
+template<typename Context, typename T0, typename CompletionToken, typename Signature>
+struct coroutine_traits<void, Context,
+        T0,
+        CompletionToken, asio::async_coropose_tag<Signature> >
+{
+  using promise_type = typename asio::async_coropose_traits<Signature, std::decay_t<CompletionToken>>::promise_type;
+};
+
+template<typename Context, typename T0, typename T1, typename CompletionToken, typename Signature>
+struct coroutine_traits<void, Context,
+        T0, T1,
+        CompletionToken, asio::async_coropose_tag<Signature> >
+{
+  using promise_type = typename asio::async_coropose_traits<Signature, std::decay_t<CompletionToken>>::promise_type;
+};
+
+template<typename Context, typename T0, typename T1, typename T2, typename CompletionToken, typename Signature>
+struct coroutine_traits<void, Context,
+        T0, T1, T2,
+        CompletionToken, asio::async_coropose_tag<Signature> >
+{
+  using promise_type = typename asio::async_coropose_traits<Signature, std::decay_t<CompletionToken>>::promise_type;
+};
+
+template<typename Context, typename T0, typename T1,  typename T2,  typename T3, typename CompletionToken, typename Signature>
+struct coroutine_traits<void, Context,
+        T0, T1, T2, T3,
+        CompletionToken, asio::async_coropose_tag<Signature> >
+{
+  using promise_type = typename asio::async_coropose_traits<Signature, std::decay_t<CompletionToken>>::promise_type;
+};
+
+template<typename Context,
+        typename T0, typename T1, typename T2, typename T3, typename T4,
+        typename CompletionToken, typename Signature>
+struct coroutine_traits<void, Context,
+        T0, T1, T2, T3, T4,
+        CompletionToken, asio::async_coropose_tag<Signature> >
+{
+  using promise_type = typename asio::async_coropose_traits<Signature, std::decay_t<CompletionToken>>::promise_type;
+};
+
+template<typename Context,
+        typename T0, typename T1, typename T2, typename T3, typename T4, typename T5,
+        typename CompletionToken, typename Signature>
+struct coroutine_traits<void, Context,
+        T0, T1, T2, T3, T4, T5,
+        CompletionToken, asio::async_coropose_tag<Signature> >
+{
+  using promise_type = typename asio::async_coropose_traits<Signature, std::decay_t<CompletionToken>>::promise_type;
+};
+
+template<typename Context,
+        typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6,
+        typename CompletionToken, typename Signature>
+struct coroutine_traits<void, Context,
+        T0, T1, T2, T3, T4, T5, T6,
+        CompletionToken, asio::async_coropose_tag<Signature> >
+{
+  using promise_type = typename asio::async_coropose_traits<Signature, std::decay_t<CompletionToken>>::promise_type;
+};
+
+template<typename Context,
+        typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7,
+        typename CompletionToken, typename Signature>
+struct coroutine_traits<void, Context,
+        T0, T1, T2, T3, T4, T5, T6, T7,
+        CompletionToken, asio::async_coropose_tag<Signature> >
+{
+  using promise_type = typename asio::async_coropose_traits<Signature, std::decay_t<CompletionToken>>::promise_type;
+};
+
+
+
+}
+
+
+#include "asio/detail/pop_options.hpp"
+
+#include "asio/impl/compose.hpp"
+
+#endif //ASIO_COROPOSE_HPP

--- a/asio/include/asio/experimental/impl/coro.hpp
+++ b/asio/include/asio/experimental/impl/coro.hpp
@@ -674,6 +674,29 @@ struct coro_promise final :
     return exec_helper{executor_};
   }
 
+
+  auto await_transform(this_coro::token_t) noexcept
+  {
+    struct result
+    {
+      bool await_ready() const noexcept
+      {
+        return true;
+      }
+
+      void await_suspend(coroutine_handle<void>) noexcept
+      {
+      }
+
+      auto await_resume() const noexcept
+      {
+        return use_coro_t<Executor>{};
+      }
+    };
+
+    return result{};
+  }
+
   auto await_transform(this_coro::cancellation_state_t) const
   {
     struct exec_helper
@@ -1013,7 +1036,7 @@ struct coro<Yield, Return, Executor>::initiate_async_resume
       assert(ch && !ch.done());
       assert(coro->awaited_from == detail::noop_coroutine());
 
-      coro->awaited_from = post_coroutine(std::move(exec), std::move(h));
+      coro->awaited_from = detail::post_coroutine(std::move(exec), std::move(h));
       coro->reset_error();
       ch.resume();
     };

--- a/asio/include/asio/impl/awaitable.hpp
+++ b/asio/include/asio/impl/awaitable.hpp
@@ -33,6 +33,10 @@
 #include "asio/detail/push_options.hpp"
 
 namespace asio {
+
+template<typename Executor>
+struct use_awaitable_t;
+
 namespace detail {
 
 struct awaitable_thread_has_context_switched {};
@@ -216,6 +220,29 @@ public:
 
     return result{this};
   }
+
+  auto await_transform(this_coro::token_t) noexcept
+  {
+    struct result
+    {
+      bool await_ready() const noexcept
+      {
+        return true;
+      }
+
+      void await_suspend(coroutine_handle<void>) noexcept
+      {
+      }
+
+      auto await_resume() const noexcept
+      {
+        return use_awaitable_t<Executor>{};
+      }
+    };
+
+    return result{};
+  }
+
 
   // This await transformation resets the associated cancellation state.
   auto await_transform(this_coro::reset_cancellation_state_0_t) noexcept

--- a/asio/include/asio/this_coro.hpp
+++ b/asio/include/asio/this_coro.hpp
@@ -38,6 +38,21 @@ constexpr executor_t executor;
 __declspec(selectany) executor_t executor;
 #endif
 
+/// Awaitable type that returns the default completion token of the current coroutine.
+struct token_t
+{
+  ASIO_CONSTEXPR token_t()
+  {
+  }
+};
+
+/// Awaitable object that returns the default completion token based on the coro type.
+#if defined(ASIO_HAS_CONSTEXPR) || defined(GENERATING_DOCUMENTATION)
+constexpr token_t token;
+#elif defined(ASIO_MSVC)
+__declspec(selectany) token_t token;
+#endif
+
 /// Awaitable type that returns the cancellation state of the current coroutine.
 struct cancellation_state_t
 {

--- a/asio/src/tests/unit/coropose.cpp
+++ b/asio/src/tests/unit/coropose.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2021 Klemens D. Morgenstern
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+// Disable autolinking for unit tests.
+#if !defined(BOOST_ALL_NO_LIB)
+#define BOOST_ALL_NO_LIB 1
+#endif // !defined(BOOST_ALL_NO_LIB)
+
+// Test that header file is self-contained.
+#include <asio/this_coro.hpp>
+#include <asio/post.hpp>
+#include <asio/io_context.hpp>
+#include "asio/coropose.hpp"
+
+#include "unit_test.hpp"
+
+
+template<typename ContextOrExecutor, typename CompletionToken>
+auto async_divide(ContextOrExecutor && ctx, int x, int y,
+               CompletionToken && completion_token,
+               asio::async_coropose_tag<void(int)> = {})
+  -> asio::async_coropose_t<void(int), CompletionToken>
+{
+  co_await asio::post(ctx, co_await asio::this_coro::token);
+
+  if (y == 0)
+    throw std::runtime_error("divide by zero");
+
+  co_return x / y;
+}
+
+template<typename ContextOrExecutor, typename CompletionToken>
+auto async_throw(ContextOrExecutor && ctx, int x,
+               CompletionToken && completion_token,
+               asio::async_coropose_tag<void(int)> = {})
+-> asio::async_coropose_t<void(asio::error_code, int), CompletionToken>
+{
+  co_await asio::post(ctx, co_await asio::this_coro::token);
+
+  co_return std::tuple{asio::error_code{asio::error::access_denied}, x};
+}
+
+
+void coropose()
+{
+  asio::io_context ctx;
+
+  int res = 0;
+  async_divide(ctx, 144, 12, [&](int i){ res = i;});
+
+  asio::co_spawn(ctx, async_divide(ctx, 100, 10, asio::use_awaitable), [](std::exception_ptr e, int i) {ASIO_CHECK(i == 10);});
+
+  auto cr = async_divide(ctx, 75, 5, asio::experimental::use_coro);
+  cr.async_resume([]( int i) {ASIO_CHECK(i == 15);});
+
+  ctx.run();
+  ASIO_CHECK(res == 12);
+
+  try
+  {
+    ctx.restart();
+    async_divide(ctx, 1, 0, [&](int i){ res = i;});
+    ctx.run();
+    ASIO_CHECK(false);
+
+  }
+  catch(std::runtime_error & re)
+  {
+    ASIO_CHECK(re.what() == std::string("divide by zero"));
+  }
+
+}
+
+
+
+
+ASIO_TEST_SUITE
+(
+  "corpose",
+  ASIO_TEST_CASE(coropose)
+)

--- a/asio/src/tests/unit/coropose.cpp
+++ b/asio/src/tests/unit/coropose.cpp
@@ -12,6 +12,7 @@
 // Test that header file is self-contained.
 #include <asio/this_coro.hpp>
 #include <asio/post.hpp>
+#include <asio/use_future.hpp>
 #include <asio/io_context.hpp>
 #include "asio/coropose.hpp"
 
@@ -50,6 +51,7 @@ void coropose()
 
   int res = 0;
   async_divide(ctx, 144, 12, [&](int i){ res = i;});
+  std::future<int> fut = async_divide(ctx, 96, 12, asio::use_future);
 
   asio::co_spawn(ctx, async_divide(ctx, 100, 10, asio::use_awaitable), [](std::exception_ptr e, int i) {ASIO_CHECK(i == 10);});
 
@@ -58,9 +60,10 @@ void coropose()
 
   ctx.run();
   ASIO_CHECK(res == 12);
+  ASIO_CHECK(fut.get() == 8);
 
   try
-  {
+    {
     ctx.restart();
     async_divide(ctx, 1, 0, [&](int i){ res = i;});
     ctx.run();

--- a/asio/src/tests/unit/experimental/coro/simple_test.cpp
+++ b/asio/src/tests/unit/experimental/coro/simple_test.cpp
@@ -116,6 +116,10 @@ void run_generator_test()
 
 asio::experimental::coro<void, int> task_test(asio::io_context&)
 {
+  auto tk = co_await asio::this_coro::token;
+  const auto eq = std::is_same_v<decltype(tk), asio::experimental::use_coro_t<asio::any_io_executor>>;
+  ASIO_CHECK(eq);
+
   co_return 42;
 }
 


### PR DESCRIPTION
Heya Chris,

I've written a minimal PoC for a coroutine based async_compose alternative, that is the easiest solution I could come up with. IT does currently only handle callbacks, use_coro & use_awaitable, and now modifiers. But it does work

Let's say we have a composed operation that reads one line and yield the content:

```cpp
template<typename Stream, typename CompletionToken>
auto async_read_line(Stream & stream,  CompletionToken && completion_token,
               asio::async_coropose_tag<void(error_code, std::string)> = {})
               // ^ this tag is where the magic happens, so we can look up the coro type.
      -> asio::async_coropose_t<void(error_code, std::string), CompletionToken>
{
  auto tk = co_await asio::this_coro::token; //yields use_awaitable or use_coro ... or something else in the future
  
  std::string buf;
  auto [sz, ec] = co_await asio::async_read_until(str, asio::dynamic_buffer(buf), asio::as_tuple(tk));
  buf.resize(sz); 
  co_return std::make_tuple{ec, buf};
}
```

The tag allows the `coroutine_traits` to pick up on it being a coroutine. If `completion_token is a lambda, the core promise  becomes the `coropose_awaitable_frame` with the return type being `void`. The interal frame just spawns itself onto the executor of `stream` and does the work.

`async_read_line(stream, function<void(error_code, std::string)>) -> void`.

For a `experimental::coro` and `awaitable` `asio::async_coropose_t<void(error_code, std::string), CompletionToken>` just picks the corresponding type:

```cpp
async_read_line(stream, asio::use_awaitable<Executor>) -> asio::awaitable<std::string>
async_read_line(stream, asio::exp::use_coro<Executor>) -> asio::exp::coro<std::string>
```

Further work would require adding support for modifiers and more tokens, but I think this concept would make writing extensions so much easier; the only easier style would be to just use awaitables everywhere.