### PR TITLE
Explicitly state `shutdown` thread-safety

### DIFF
--- a/asio/include/asio/basic_datagram_socket.hpp
+++ b/asio/include/asio/basic_datagram_socket.hpp
@@ -46,10 +46,10 @@ class basic_datagram_socket;
  * @e Distinct @e objects: Safe.@n
  * @e Shared @e objects: Unsafe.
  *
- * Synchronous @c send, @c send_to, @c receive, @c receive_from, and @c connect
- * operations are thread safe with respect to each other, if the underlying
- * operating system calls are also thread safe. This means that it is permitted
- * to perform concurrent calls to these synchronous operations on a single
+ * Synchronous @c send, @c send_to, @c receive, @c receive_from, @c connect, and
+ * @c shutdown operations are thread safe with respect to each other, if the
+ * underlying operating system calls are also thread safe. This means that it is
+ * permitted to perform concurrent calls to these synchronous operations on a single
  * socket object. Other synchronous operations, such as @c open or @c close, are
  * not thread safe.
  */

--- a/asio/include/asio/basic_raw_socket.hpp
+++ b/asio/include/asio/basic_raw_socket.hpp
@@ -46,10 +46,10 @@ class basic_raw_socket;
  * @e Distinct @e objects: Safe.@n
  * @e Shared @e objects: Unsafe.
  *
- * Synchronous @c send, @c send_to, @c receive, @c receive_from, and @c connect
- * operations are thread safe with respect to each other, if the underlying
- * operating system calls are also thread safe. This means that it is permitted
- * to perform concurrent calls to these synchronous operations on a single
+ * Synchronous @c send, @c send_to, @c receive, @c receive_from, @c connect, and
+ * @c shutdown operations are thread safe with respect to each other, if the
+ * underlying operating system calls are also thread safe. This means that it is
+ * permitted to perform concurrent calls to these synchronous operations on a single
  * socket object. Other synchronous operations, such as @c open or @c close, are
  * not thread safe.
  */

--- a/asio/include/asio/basic_seq_packet_socket.hpp
+++ b/asio/include/asio/basic_seq_packet_socket.hpp
@@ -44,11 +44,11 @@ class basic_seq_packet_socket;
  * @e Distinct @e objects: Safe.@n
  * @e Shared @e objects: Unsafe.
  *
- * Synchronous @c send, @c receive, and @c connect operations are thread safe
- * with respect to each other, if the underlying operating system calls are
- * also thread safe. This means that it is permitted to perform concurrent
- * calls to these synchronous operations on a single socket object. Other
- * synchronous operations, such as @c open or @c close, are not thread safe.
+ * Synchronous @c send, @c receive, @c connect, and @c shutdown operations are
+ * thread safe with respect to each other, if the underlying operating system
+ * calls are also thread safe. This means that it is permitted to perform
+ * concurrent calls to these synchronous operations on a single socket object.
+ * Other synchronous operations, such as @c open or @c close, are not thread safe.
  */
 template <typename Protocol, typename Executor>
 class basic_seq_packet_socket

--- a/asio/include/asio/basic_stream_socket.hpp
+++ b/asio/include/asio/basic_stream_socket.hpp
@@ -46,11 +46,11 @@ class basic_stream_socket;
  * @e Distinct @e objects: Safe.@n
  * @e Shared @e objects: Unsafe.
  *
- * Synchronous @c send, @c receive, and @c connect operations are thread safe
- * with respect to each other, if the underlying operating system calls are
- * also thread safe. This means that it is permitted to perform concurrent
- * calls to these synchronous operations on a single socket object. Other
- * synchronous operations, such as @c open or @c close, are not thread safe.
+ * Synchronous @c send, @c receive, @c connect, and @c shutdown operations are
+ * thread safe with respect to each other, if the underlying operating system
+ * calls are also thread safe. This means that it is permitted to perform
+ * concurrent calls to these synchronous operations on a single socket object.
+ * Other synchronous operations, such as @c open or @c close, are not thread safe.
  *
  * @par Concepts:
  * AsyncReadStream, AsyncWriteStream, Stream, SyncReadStream, SyncWriteStream.


### PR DESCRIPTION
We are having a nice discussion [here](https://github.com/eProsima/Fast-DDS/pull/2646#issuecomment-1104914775) regarding the thread-safety of `shutdown(what, ec)` with respect to `receive_from`. Looking at the code, I see no reason for the `shutdown` socket operation to be thread-unsafe, so this PR adds the `shutdown` to the list of thread-safe ones.