### PR TITLE
add window unicode file path support

### DIFF
--- a/asio/include/asio/basic_stream_file.hpp
+++ b/asio/include/asio/basic_stream_file.hpp
@@ -198,6 +198,35 @@ public:
         path.c_str(), open_flags, ec);
     asio::detail::throw_error(ec, "open");
   }
+  
+#if defined(_MSC_VER) && (_MSC_VER >= 1700)
+  /// Construct and open a basic_stream_file.
+  /**
+   * This constructor initialises and opens a file.
+   *
+   * @param ex The I/O executor that the file will use, by default, to
+   * dispatch handlers for any asynchronous operations performed on the file.
+   *
+   * @param path windows wchar_t path.from filesystem path().u16string().
+   *
+   * @param open_flags A set of flags that determine how the file should be
+   * opened.
+   *
+   * @throws asio::system_error Thrown on failure.
+   */
+  basic_stream_file(const executor_type& ex,
+      const std::u16string &path, file_base::flags open_flags)
+    : basic_file<Executor>(ex)
+  {
+    asio::error_code ec;
+    this->impl_.get_service().set_is_stream(
+        this->impl_.get_implementation(), true);
+    this->impl_.get_service().open(
+        this->impl_.get_implementation(),
+        path, open_flags, ec);
+    asio::detail::throw_error(ec, "open");
+  }
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1700)
 
   /// Construct and open a basic_stream_file.
   /**

--- a/asio/include/asio/detail/win_iocp_file_service.hpp
+++ b/asio/include/asio/detail/win_iocp_file_service.hpp
@@ -102,6 +102,12 @@ public:
   ASIO_DECL asio::error_code open(implementation_type& impl,
       const char* path, file_base::flags open_flags,
       asio::error_code& ec);
+#if defined(_MSC_VER) && (_MSC_VER >= 1700)
+  // Open the file using the specified path name. wchar_t version;
+  ASIO_DECL asio::error_code open(implementation_type& impl,
+      const std::u16string &path, file_base::flags open_flags,
+      asio::error_code& ec);
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1700)
 
   // Assign a native handle to a file implementation.
   asio::error_code assign(implementation_type& impl,


### PR DESCRIPTION
pass std::u16string to CreateFileW; can get it from filesystem path; .fobj.path().u16string(); or ....

std::string p("d:/蒼井そら/蒼.av");
std::filesystem::directory_entry fobj( std::filesystem::u8path(p));
auto loop = co_await this_coro::executor;
stream_file f(loop,  fobj.path().u16string(), stream_file::read_only);