### PR TITLE
Fix timer cancel issue

### DIFF
--- a/asio/include/asio/detail/timer_queue.hpp
+++ b/asio/include/asio/detail/timer_queue.hpp
@@ -186,8 +186,8 @@ public:
       while (wait_op* op = (num_cancelled != max_cancelled)
           ? timer.op_queue_.front() : 0)
       {
-        op->ec_ = asio::error::operation_aborted;
         timer.op_queue_.pop();
+        op->ec_ = asio::error::operation_aborted;
         ops.push(op);
         ++num_cancelled;
       }


### PR DESCRIPTION
This PR resolves this issue:
https://github.com/chriskohlhoff/asio/issues/1025

Running into an issue with cancelling a timer and it seems like we get into an infinite loop in cancel_timer() (timer_queue.hpp).

Based on this commit (made by @chriskohlhoff), it appears that setting the error code for completion handler should be done after the item has been popped on the op_queue:
https://github.com/boostorg/asio/commit/a51b9b819844a2c6150b36d8f565063c75a429c4