### PR TITLE
Fix there is no warning number 'XXXX' in windows

### DIFF
--- a/asio/include/asio/detail/push_options.hpp
+++ b/asio/include/asio/detail/push_options.hpp
@@ -163,7 +163,7 @@
 //
 // Must remain the last #elif since some other vendors (Metrowerks, for example)
 // also #define _MSC_VER
-
+#  pragma warning (disable : 4619) // get rid of there is no warning number 'XXXX' spam
 # pragma warning (disable:4103)
 # pragma warning (push)
 # pragma warning (disable:4127)


### PR DESCRIPTION
In newer versions of MSVC a number of warning numbers which are disabled in this header are removed so builds using boost asio gets spammed with "there is no warning number 'XXXX'"

Current production builds at work contain this warning in excess of 50,000 times in our build output