### PR TITLE
SSL Keylogging

### DIFF
--- a/asio/include/asio/ssl/context.hpp
+++ b/asio/include/asio/ssl/context.hpp
@@ -11,6 +11,8 @@
 #ifndef ASIO_SSL_CONTEXT_HPP
 #define ASIO_SSL_CONTEXT_HPP
 
+#define KEYLOG_DATA 29001
+
 #if defined(_MSC_VER) && (_MSC_VER >= 1200)
 # pragma once
 #endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
@@ -670,6 +672,29 @@ public:
   ASIO_DECL ASIO_SYNC_OP_VOID use_tmp_dh_file(
       const std::string& filename, asio::error_code& ec);
 
+  /// Log OpenSSL key exchange data to for debugging purposes
+  /**
+   * This function is use to log SSL key exchange data to use for debugging
+   * programs like Wireshark.
+   *
+   * @param filename The name of the file that will hold the SSL key information
+   *
+   * @throws asio::system_error Thrown on failure.
+   */
+  ASIO_DECL void use_keylog_file(const std::string& filename);
+
+  /// Log OpenSSL key exchange data to for debugging purposes
+  /**
+   * This function is use to log SSL key exchange data to use for debugging
+   * programs like Wireshark.
+   *
+   * @param filename The name of the file that will hold the SSL key information
+   *
+   * @param ec Set to indicate what error occurred, if any.
+   */
+  ASIO_DECL ASIO_SYNC_OP_VOID use_keylog_file(
+      const std::string& filename, asio::error_code& ec);
+
   /// Set the password callback.
   /**
    * This function is used to specify a callback function to obtain password
@@ -717,6 +742,8 @@ private:
   struct evp_pkey_cleanup;
   struct rsa_cleanup;
   struct dh_cleanup;
+
+  ASIO_DECL static void keylog_callback( const SSL *ssl, const char *line );
 
   // Helper function used to set a peer certificate verification callback.
   ASIO_DECL ASIO_SYNC_OP_VOID do_set_verify_callback(

--- a/asio/include/asio/ssl/impl/context.ipp
+++ b/asio/include/asio/ssl/impl/context.ipp
@@ -1195,6 +1195,38 @@ ASIO_SYNC_OP_VOID context::do_use_tmp_dh(
   ASIO_SYNC_OP_VOID_RETURN(ec);
 }
 
+void context::use_keylog_file(const std::string& filename)
+{
+  asio::error_code ec;
+  use_keylog_file(filename, ec);
+  asio::detail::throw_error(ec, "use_keylog_file");
+}
+
+ASIO_SYNC_OP_VOID context::use_keylog_file(
+      const std::string& filename, asio::error_code& ec)
+{
+  ::ERR_clear_error();
+
+  if (BIO *b = (BIO *) SSL_CTX_get_app_data(handle_)) {
+    BIO_free( b );
+  }
+
+  BIO* bio = ::BIO_new_file(filename.c_str(), "w");
+
+  if (bio)
+  {
+    ::SSL_CTX_set_ex_data( handle_, KEYLOG_DATA, bio );
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+    ::SSL_CTX_set_keylog_callback( handle_, keylog_callback );
+#endif // (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+  }
+
+  ec = asio::error_code(
+      static_cast<int>(::ERR_get_error()),
+      asio::error::get_ssl_category());
+  ASIO_SYNC_OP_VOID_RETURN(ec);
+}
+
 ASIO_SYNC_OP_VOID context::do_set_verify_callback(
     detail::verify_callback_base* callback, asio::error_code& ec)
 {
@@ -1312,6 +1344,18 @@ asio::error_code context::translate_error(long error)
   return asio::error_code(static_cast<int>(error),
       asio::error::get_ssl_category());
 }
+
+void context::keylog_callback( const SSL *ssl, const char *line )
+{
+    if( SSL_CTX* handle = ::SSL_get_SSL_CTX( ssl ) ) {
+        if( BIO *b = (BIO *)::SSL_CTX_get_ex_data( handle, KEYLOG_DATA ) ) {
+            BIO_printf( b, "%s\n", line );
+            BIO_flush( b );
+        }
+    }
+}
+
+
 
 } // namespace ssl
 } // namespace asio


### PR DESCRIPTION
Adds functions to enable SSL keylogging through the OpenSSL API (https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_keylog_callback.html