### PR TITLE
Early completion

### DIFF
--- a/asio/include/asio/basic_deadline_timer.hpp
+++ b/asio/include/asio/basic_deadline_timer.hpp
@@ -697,6 +697,17 @@ private:
           handler2.value, self_->impl_.get_executor());
     }
 
+    template<typename Handler>
+    bool early_complete(ASIO_MOVE_ARG(Handler) handler) const
+    {
+      ASIO_MOVE_CAST(Handler)(handler)(error_code());
+    }
+
+    bool can_complete_early() const
+    {
+      return self_->expired_from_now() < duration_type();
+    }
+
   private:
     basic_deadline_timer* self_;
   };

--- a/asio/include/asio/basic_deadline_timer.hpp
+++ b/asio/include/asio/basic_deadline_timer.hpp
@@ -698,15 +698,17 @@ private:
     }
 
     template<typename Handler>
-    bool early_complete(ASIO_MOVE_ARG(Handler) handler) const
+    bool try_complete(ASIO_MOVE_ARG(Handler) handler) const
     {
-      ASIO_MOVE_CAST(Handler)(handler)(error_code());
+      if (self_->expired_from_now() < duration_type())
+      {
+        ASIO_MOVE_CAST(Handler)(handler)(error_code());
+        return true;
+      }
+      else
+        return false;
     }
 
-    bool can_complete_early() const
-    {
-      return self_->expired_from_now() < duration_type();
-    }
 
   private:
     basic_deadline_timer* self_;

--- a/asio/include/asio/basic_waitable_timer.hpp
+++ b/asio/include/asio/basic_waitable_timer.hpp
@@ -817,14 +817,15 @@ private:
     }
 
     template<typename Handler>
-    void complete_early(ASIO_MOVE_ARG(Handler) handler) const
+    bool try_complete(ASIO_MOVE_ARG(Handler) handler) const
     {
-      ASIO_MOVE_CAST(Handler)(handler)(error_code());
-    }
-
-    bool can_complete_early() const
-    {
-      return self_->expires_at() < clock_type::now();
+      if (self_->expires_at() < clock_type::now())
+      {
+        ASIO_MOVE_CAST(Handler)(handler)(error_code());
+        return true;
+      }
+      else
+        return false;
     }
 
   private:

--- a/asio/include/asio/basic_waitable_timer.hpp
+++ b/asio/include/asio/basic_waitable_timer.hpp
@@ -816,6 +816,17 @@ private:
           handler2.value, self_->impl_.get_executor());
     }
 
+    template<typename Handler>
+    void complete_early(ASIO_MOVE_ARG(Handler) handler) const
+    {
+      ASIO_MOVE_CAST(Handler)(handler)(error_code());
+    }
+
+    bool can_complete_early() const
+    {
+      return self_->expires_at() < clock_type::now();
+    }
+
   private:
     basic_waitable_timer* self_;
   };

--- a/asio/include/asio/early_complete.hpp
+++ b/asio/include/asio/early_complete.hpp
@@ -18,6 +18,10 @@
 #include "asio/associator.hpp"
 #include "asio/async_result.hpp"
 #include "asio/detail/type_traits.hpp"
+// lazy solution
+#include "asio/experimental/detail/channel_payload.hpp"
+#include <optional>
+#include <cassert>
 
 #include "asio/detail/push_options.hpp"
 
@@ -38,72 +42,26 @@ struct early_completion_probe<void(Args...)>
 
 }
 
-template<typename Initiation, typename Signature,
-         typename = void>
+template<typename Initiation, typename InitArgTuple, typename Signature,
+         typename = bool>
 struct has_early_completion_step : false_type
 {
 };
 
-template<typename Initiation, typename Signature>
+template<typename Initiation, typename ...InitArgs,typename Signature>
 struct has_early_completion_step<
-        Initiation, Signature,
-        decltype(declval<Initiation>().complete_early(declval<detail::early_completion_probe<Signature>>()))> : true_type
+        Initiation, std::tuple<InitArgs...>, Signature,
+        decltype(declval<Initiation>().
+          try_complete(declval<detail::early_completion_probe<Signature>>(),
+                       declval<InitArgs>()...))> : true_type
 {
 };
 
-template<typename Initiation, typename ... Signatures>
+template<typename Initiation, typename InitArgTuple, typename ... Signatures>
 struct has_early_completion
-    : conjunction<has_early_completion_step<Initiation, Signatures>...>
+    : conjunction<has_early_completion_step<Initiation, InitArgTuple, Signatures>...>
 {
 };
-
-
-namespace detail
-{
-
-template<typename Initiation, typename Handler>
-ASIO_CONSTEXPR void invoke_early_completion_impl(ASIO_MOVE_ARG(Initiation), ASIO_MOVE_ARG(Handler), false_type)
-{
-}
-
-template<typename Initiation, typename Handler>
-void invoke_early_completion_impl(ASIO_MOVE_ARG(Initiation) init, ASIO_MOVE_ARG(Handler) handler, true_type)
-{
-  ASIO_MOVE_CAST(Initiation)(init).complete_early(ASIO_MOVE_CAST(Handler)(handler));
-}
-
-template<typename Initiation>
-ASIO_CONSTEXPR bool check_early_completion_impl(ASIO_MOVE_ARG(Initiation), false_type)
-{
-  return false;
-}
-
-template<typename Initiation>
-bool check_early_completion_impl(ASIO_MOVE_ARG(Initiation) init, true_type)
-{
-  return ASIO_MOVE_CAST(Initiation)(init).can_complete_early();
-}
-
-}
-
-template<typename ... Signatures, typename Initiation, typename Handler>
-void invoke_early_completion(ASIO_MOVE_ARG(Initiation) init, ASIO_MOVE_ARG(Handler) handler)
-{
-  detail::invoke_early_completion_impl(
-          ASIO_MOVE_CAST(Initiation)(init),
-          ASIO_MOVE_CAST(Handler)(handler),
-          has_early_completion<typename decay<Initiation>::type, Signatures...>{});
-}
-
-template<typename ... Signatures, typename Initiation>
-bool check_early_completion(ASIO_MOVE_ARG(Initiation) init)
-{
-  return detail::check_early_completion_impl(
-          ASIO_MOVE_CAST(Initiation)(init),
-          has_early_completion<typename decay<Initiation>::type, Signatures...>{});
-}
-
-
 
 template<typename Token>
 struct allow_recursion_t
@@ -122,32 +80,93 @@ allow_recursion_t<typename decay<Token>::type> allow_recursion(ASIO_MOVE_ARG(Tok
           );
 }
 
-
 namespace detail
 {
 
-template<typename Initiation>
-struct immediate_initiate
+template<typename Derived, typename Sig>
+struct early_completion_helper_try_tpl_base;
+
+template<typename Derived, typename ... Args>
+struct early_completion_helper_try_tpl_base<Derived, void(Args...)>
 {
-  Initiation init;
-  template<typename Init_>
-  immediate_initiate(ASIO_MOVE_ARG(Init_) init) : init(ASIO_MOVE_CAST(Init_)(init)) {}
-
-  template<typename Handler>
-  void operator()(ASIO_MOVE_ARG(Handler) handler)
+  // not idealy, but does for now
+  void operator()(Args ... args)
   {
-    invoke_early_completion(ASIO_MOVE_OR_LVALUE(Initiation)(init),
-                            ASIO_MOVE_CAST(Handler)(handler));
+    static_cast<Derived*>(this)->payload.emplace(experimental::detail::channel_message<void(Args...)>(0, ASIO_MOVE_CAST(Args)(args)...));
   }
-
 };
+
+
 
 }
 
-template <typename Init, typename... Signatures>
-struct async_result<allow_recursion_t<Init>, Signatures ...>
+template<typename Initiation, typename Token, typename ... Signatures>
+struct early_completion_helper
 {
-  typedef typename async_result<Init, Signatures...>::return_type return_type;
+  typedef typename async_result<Token, Signatures...>::return_type return_type;
+
+  Initiation init;
+
+  std::optional<experimental::detail::channel_payload<Signatures...>> payload;
+
+  struct try_tpl  : detail::early_completion_helper_try_tpl_base<try_tpl, Signatures> ...
+  {
+    std::optional<experimental::detail::channel_payload<Signatures...>>  &payload;
+
+    using detail::early_completion_helper_try_tpl_base<try_tpl, Signatures> ::operator()...;
+
+    template<typename ... Args>
+    void operator()(ASIO_MOVE_ARG(Args) ... args)
+    {
+      payload = experimental::detail::channel_payload<Signatures...>({0, ASIO_MOVE_CAST(Args)(args)...});
+    }
+  };
+
+  struct immediate_initiation
+  {
+    experimental::detail::channel_payload<Signatures...>  &payload;
+    template<typename Handler>
+    void operator()(ASIO_MOVE_ARG(Handler) handler)
+    {
+      payload.receive(handler);
+    }
+  };
+
+  early_completion_helper(ASIO_MOVE_ARG(Initiation) init) : init(ASIO_MOVE_CAST(Initiation)(init)) {}
+
+  template<typename ... InitArgs>
+  bool try_complete_impl(false_type,
+                         ASIO_MOVE_ARG(InitArgs)... init_args)
+  {
+    return false;
+  }
+
+  template<typename ... InitArgs>
+  bool try_complete_impl(true_type,
+                         ASIO_MOVE_ARG(InitArgs)... init_args)
+  {
+    return ASIO_MOVE_CAST(Initiation)(init).try_complete(try_tpl{{},payload}, ASIO_MOVE_CAST(InitArgs)(init_args)...);
+  }
+
+  template<typename ... InitArgs>
+  bool try_complete(ASIO_MOVE_ARG(InitArgs)... init_args)
+  {
+    return this->try_complete_impl(has_early_completion<Initiation, std::tuple<InitArgs...>, Signatures...>{},
+                                   ASIO_MOVE_CAST(InitArgs)(init_args)...);
+  }
+
+  template<typename RawCompletionToken>
+  return_type get_result(ASIO_MOVE_ARG(RawCompletionToken) token)
+  {
+    return async_result<Token, Signatures...>::initiate(
+            immediate_initiation{*payload},
+            ASIO_MOVE_CAST(RawCompletionToken)(token));  }
+};
+
+template <typename Token, typename... Signatures>
+struct async_result<allow_recursion_t<Token>, Signatures ...>
+{
+  typedef typename async_result<Token, Signatures...>::return_type return_type;
 
 
   template <typename Initiation, typename RawCompletionToken, typename... InitArgs>
@@ -155,15 +174,15 @@ struct async_result<allow_recursion_t<Init>, Signatures ...>
                               ASIO_MOVE_ARG(RawCompletionToken) wrapped_token,
                               ASIO_MOVE_ARG(InitArgs)... init_args)
   {
-    if (check_early_completion<Signatures...>(ASIO_MOVE_CAST(Initiation)(init)))
-        return async_result<Init, Signatures...>::initiate(
-                detail::immediate_initiate<Initiation>(ASIO_MOVE_CAST(Initiation)(init)),
-                ASIO_MOVE_CAST(Init)(wrapped_token.token),
-                ASIO_MOVE_CAST(InitArgs)(init_args)...);
+    early_completion_helper<Initiation,
+                            Token,
+                            Signatures...> ech(ASIO_MOVE_CAST(Initiation)(init));
+    if (ech.try_complete(ASIO_MOVE_CAST(InitArgs)(init_args)...))
+      return ech.get_result(ASIO_MOVE_CAST(Token)(wrapped_token.token));
 
-    return async_result<Init, Signatures...>::initiate(
+    return async_result<Token, Signatures...>::initiate(
             ASIO_MOVE_CAST(Initiation)(init),
-            ASIO_MOVE_CAST(Init)(wrapped_token.token),
+            ASIO_MOVE_CAST(Token)(wrapped_token.token),
             ASIO_MOVE_CAST(InitArgs)(init_args)...);
   }
 };

--- a/asio/include/asio/early_complete.hpp
+++ b/asio/include/asio/early_complete.hpp
@@ -1,0 +1,84 @@
+//
+// early_completion.hpp
+// ~~~~~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2022 Klemens D. Morgenstern
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#ifndef ASIO_EARLY_COMPLETE_HPP
+#define ASIO_EARLY_COMPLETE_HPP
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#include "asio/detail/config.hpp"
+
+#include "asio/detail/type_traits.hpp"
+
+#include "asio/detail/push_options.hpp"
+
+namespace asio
+{
+
+namespace detail
+{
+
+template<typename Signature>
+struct early_completion_probe;
+
+template<typename ... Args>
+struct early_completion_probe<void(Args...)>
+{
+  void operator()(ASIO_MOVE_ARG(Args) ... );
+};
+
+}
+
+template<typename Signature, typename Initiation, typename = void>
+struct has_early_completion : false_type
+{
+};
+
+template<typename Signature, typename Initiation>
+struct has_early_completion<
+        Signature, Initiation,
+        decltype(std::declval<Initiation>().complete_early(
+                std::declval<detail::early_completion_probe<Signature>>())
+                )> : true_type
+{
+};
+
+namespace detail
+{
+
+template<typename Signature, typename Initiation, typename Handler>
+ASIO_CONSTEXPR bool invoke_early_completion_impl(ASIO_MOVE_ARG(Initiation), ASIO_MOVE_ARG(Handler), false_type)
+{
+  return false;
+}
+
+template<typename Signature, typename Initiation, typename Handler>
+bool invoke_early_completion_impl(ASIO_MOVE_ARG(Initiation) init, ASIO_MOVE_ARG(Handler) handler, true_type)
+{
+  return ASIO_MOVE_CAST(Initiation)(init).complete_early(ASIO_MOVE_CAST(Handler)(handler));
+}
+
+}
+
+template<typename Signature, typename Initiation, typename Handler>
+bool invoke_early_completion(ASIO_MOVE_ARG(Initiation) init, ASIO_MOVE_ARG(Handler) handler)
+{
+  return detail::invoke_early_completion_impl(
+          ASIO_MOVE_CAST(Initiation)(init),
+          ASIO_MOVE_CAST(Handler)(handler),
+          has_early_completion<Signature, typename std::decay<Initiation>::type>{});
+}
+
+}
+
+#include "asio/detail/pop_options.hpp"
+
+
+#endif //ASIO_EARLY_COMPLETE_HPP

--- a/asio/include/asio/early_complete.hpp
+++ b/asio/include/asio/early_complete.hpp
@@ -15,6 +15,8 @@
 
 #include "asio/detail/config.hpp"
 
+#include "asio/associator.hpp"
+#include "asio/async_result.hpp"
 #include "asio/detail/type_traits.hpp"
 
 #include "asio/detail/push_options.hpp"
@@ -31,50 +33,141 @@ struct early_completion_probe;
 template<typename ... Args>
 struct early_completion_probe<void(Args...)>
 {
-  void operator()(ASIO_MOVE_ARG(Args) ... );
+  void operator()(ASIO_MOVE_ARG(Args) ... ) const;
 };
 
 }
 
-template<typename Signature, typename Initiation, typename = void>
-struct has_early_completion : false_type
+template<typename Initiation, typename Signature,
+         typename = void>
+struct has_early_completion_step : false_type
 {
 };
 
-template<typename Signature, typename Initiation>
-struct has_early_completion<
-        Signature, Initiation,
-        decltype(std::declval<Initiation>().complete_early(
-                std::declval<detail::early_completion_probe<Signature>>())
-                )> : true_type
+template<typename Initiation, typename Signature>
+struct has_early_completion_step<
+        Initiation, Signature,
+        decltype(declval<Initiation>().complete_early(declval<detail::early_completion_probe<Signature>>()))> : true_type
 {
 };
+
+template<typename Initiation, typename ... Signatures>
+struct has_early_completion
+    : conjunction<has_early_completion_step<Initiation, Signatures>...>
+{
+};
+
 
 namespace detail
 {
 
-template<typename Signature, typename Initiation, typename Handler>
-ASIO_CONSTEXPR bool invoke_early_completion_impl(ASIO_MOVE_ARG(Initiation), ASIO_MOVE_ARG(Handler), false_type)
+template<typename Initiation, typename Handler>
+ASIO_CONSTEXPR void invoke_early_completion_impl(ASIO_MOVE_ARG(Initiation), ASIO_MOVE_ARG(Handler), false_type)
+{
+}
+
+template<typename Initiation, typename Handler>
+void invoke_early_completion_impl(ASIO_MOVE_ARG(Initiation) init, ASIO_MOVE_ARG(Handler) handler, true_type)
+{
+  ASIO_MOVE_CAST(Initiation)(init).complete_early(ASIO_MOVE_CAST(Handler)(handler));
+}
+
+template<typename Initiation>
+ASIO_CONSTEXPR bool check_early_completion_impl(ASIO_MOVE_ARG(Initiation), false_type)
 {
   return false;
 }
 
-template<typename Signature, typename Initiation, typename Handler>
-bool invoke_early_completion_impl(ASIO_MOVE_ARG(Initiation) init, ASIO_MOVE_ARG(Handler) handler, true_type)
+template<typename Initiation>
+bool check_early_completion_impl(ASIO_MOVE_ARG(Initiation) init, true_type)
 {
-  return ASIO_MOVE_CAST(Initiation)(init).complete_early(ASIO_MOVE_CAST(Handler)(handler));
+  return ASIO_MOVE_CAST(Initiation)(init).can_complete_early();
 }
 
 }
 
-template<typename Signature, typename Initiation, typename Handler>
-bool invoke_early_completion(ASIO_MOVE_ARG(Initiation) init, ASIO_MOVE_ARG(Handler) handler)
+template<typename ... Signatures, typename Initiation, typename Handler>
+void invoke_early_completion(ASIO_MOVE_ARG(Initiation) init, ASIO_MOVE_ARG(Handler) handler)
 {
-  return detail::invoke_early_completion_impl(
+  detail::invoke_early_completion_impl(
           ASIO_MOVE_CAST(Initiation)(init),
           ASIO_MOVE_CAST(Handler)(handler),
-          has_early_completion<Signature, typename std::decay<Initiation>::type>{});
+          has_early_completion<typename decay<Initiation>::type, Signatures...>{});
 }
+
+template<typename ... Signatures, typename Initiation>
+bool check_early_completion(ASIO_MOVE_ARG(Initiation) init)
+{
+  return detail::check_early_completion_impl(
+          ASIO_MOVE_CAST(Initiation)(init),
+          has_early_completion<typename decay<Initiation>::type, Signatures...>{});
+}
+
+
+
+template<typename Token>
+struct allow_recursion_t
+{
+  template<typename T>
+  allow_recursion_t(ASIO_MOVE_ARG(T) token) : token(ASIO_MOVE_CAST(T)(token)) {}
+  Token token;
+};
+
+template<typename Token>
+allow_recursion_t<typename decay<Token>::type> allow_recursion(ASIO_MOVE_ARG(Token) token)
+{
+  return allow_recursion_t<typename decay<Token>::type>
+          (
+              ASIO_MOVE_CAST(Token)(token)
+          );
+}
+
+
+namespace detail
+{
+
+template<typename Initiation>
+struct immediate_initiate
+{
+  Initiation init;
+  template<typename Init_>
+  immediate_initiate(ASIO_MOVE_ARG(Init_) init) : init(ASIO_MOVE_CAST(Init_)(init)) {}
+
+  template<typename Handler>
+  void operator()(ASIO_MOVE_ARG(Handler) handler)
+  {
+    invoke_early_completion(ASIO_MOVE_OR_LVALUE(Initiation)(init),
+                            ASIO_MOVE_CAST(Handler)(handler));
+  }
+
+};
+
+}
+
+template <typename Init, typename... Signatures>
+struct async_result<allow_recursion_t<Init>, Signatures ...>
+{
+  typedef typename async_result<Init, Signatures...>::return_type return_type;
+
+
+  template <typename Initiation, typename RawCompletionToken, typename... InitArgs>
+  static return_type initiate(ASIO_MOVE_ARG(Initiation) init,
+                              ASIO_MOVE_ARG(RawCompletionToken) wrapped_token,
+                              ASIO_MOVE_ARG(InitArgs)... init_args)
+  {
+    if (check_early_completion<Signatures...>(ASIO_MOVE_CAST(Initiation)(init)))
+        return async_result<Init, Signatures...>::initiate(
+                detail::immediate_initiate<Initiation>(ASIO_MOVE_CAST(Initiation)(init)),
+                ASIO_MOVE_CAST(Init)(wrapped_token.token),
+                ASIO_MOVE_CAST(InitArgs)(init_args)...);
+
+    return async_result<Init, Signatures...>::initiate(
+            ASIO_MOVE_CAST(Initiation)(init),
+            ASIO_MOVE_CAST(Init)(wrapped_token.token),
+            ASIO_MOVE_CAST(InitArgs)(init_args)...);
+  }
+};
+
 
 }
 

--- a/asio/include/asio/experimental/basic_channel.hpp
+++ b/asio/include/asio/experimental/basic_channel.hpp
@@ -440,6 +440,23 @@ private:
           ASIO_MOVE_CAST(payload_type)(payload),
           handler2.value, self_->get_executor());
     }
+    template <typename SendHandler>
+    bool try_complete(ASIO_MOVE_ARG(SendHandler) handler,
+                      ASIO_MOVE_ARG(payload_type) payload) const
+    {
+        // another improvisation really
+        bool did_send = false;
+        auto h =
+          [&](auto && ... args)
+          {
+            did_send = self_->try_send(std::move(args)...);
+            if (did_send)
+              ASIO_MOVE_CAST(SendHandler)(handler)(asio::error_code{});
+
+          };
+        payload.receive(h);
+        return did_send;
+    }
 
   private:
     basic_channel* self_;
@@ -466,6 +483,12 @@ private:
       asio::detail::non_const_lvalue<ReceiveHandler> handler2(handler);
       self_->service_->async_receive(self_->impl_,
           handler2.value, self_->get_executor());
+    }
+
+    template <typename ReceiveHandler>
+    bool try_complete(ASIO_MOVE_ARG(ReceiveHandler) handler) const
+    {
+      return self_->try_receive(ASIO_MOVE_CAST(ReceiveHandler)(handler));
     }
 
   private:

--- a/asio/src/tests/unit/early_complete.cpp
+++ b/asio/src/tests/unit/early_complete.cpp
@@ -10,6 +10,7 @@
 
 // Test that header file is self-contained.
 #include "asio/early_complete.hpp"
+#include "asio/steady_timer.hpp"
 
 #include "./unit_test.hpp"
 
@@ -18,18 +19,48 @@ struct dummy_init
   template<typename Func>
   auto complete_early(Func && func) -> decltype(std::declval<Func>()(int()));
 
+  bool can_complete_early();
+
 };
 
 void trait_test()
 {
-  using t1 = asio::has_early_completion<void(), dummy_init>;
-  using t2 = asio::has_early_completion<void(int), dummy_init>;
+  using t1 = asio::has_early_completion<dummy_init, void()>;
+  using t2 = asio::has_early_completion<dummy_init, void(int)>;
   ASIO_CHECK(!t1::value);
   ASIO_CHECK(t2::value);
+}
+
+
+void timer_test()
+{
+  asio::io_context ctx;
+  asio::steady_timer tim{ctx};
+
+  // this thing doesn't dispatch, we're just completing immediately
+
+  bool done = false;
+  auto cpl =  [&](asio::error_code ec)
+              {
+                ASIO_CHECK(!ec);
+                done = true;
+              };
+
+  tim.async_wait(asio::allow_recursion(cpl));
+  ASIO_CHECK(done);
+  done = false;
+
+  tim.expires_after(std::chrono::milliseconds(50));
+  tim.async_wait(asio::allow_recursion(cpl));
+  ASIO_CHECK(!done);
+  ctx.run();
+  ASIO_CHECK(done);
+
 }
 
 ASIO_TEST_SUITE
 (
     "early_completion",
     ASIO_TEST_CASE(trait_test)
+    ASIO_TEST_CASE(timer_test)
 )

--- a/asio/src/tests/unit/early_complete.cpp
+++ b/asio/src/tests/unit/early_complete.cpp
@@ -16,20 +16,32 @@
 
 struct dummy_init
 {
-  template<typename Func>
-  auto complete_early(Func && func) -> decltype(std::declval<Func>()(int()));
+  template<typename Handler>
+  bool try_complete(Handler && handler, decltype(std::declval<Handler>()(int())) * = nullptr);
+};
 
-  bool can_complete_early();
-
+struct dummy_init_s
+{
+  template<typename Handler>
+  bool try_complete(Handler && handler, int, decltype(std::declval<Handler>()(int())) * = nullptr);
 };
 
 void trait_test()
 {
-  using t1 = asio::has_early_completion<dummy_init, void()>;
-  using t2 = asio::has_early_completion<dummy_init, void(int)>;
+  using t1 = asio::has_early_completion<dummy_init, std::tuple<>, void()>;
+  using t2 = asio::has_early_completion<dummy_init, std::tuple<>, void(int)>;
   ASIO_CHECK(!t1::value);
   ASIO_CHECK(t2::value);
+
+  using u1 = asio::has_early_completion<dummy_init_s, std::tuple<int>, void()>;
+  using u2 = asio::has_early_completion<dummy_init_s, std::tuple<int>, void(int)>;
+  using u3 = asio::has_early_completion<dummy_init_s, std::tuple<>, void(int)>;
+  ASIO_CHECK(!u1::value);
+  ASIO_CHECK(u2::value);
+  ASIO_CHECK(!u3::value);
+
 }
+
 
 
 void timer_test()

--- a/asio/src/tests/unit/early_complete.cpp
+++ b/asio/src/tests/unit/early_complete.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2022 Klemens D. Morgenstern
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#if !defined(BOOST_ALL_NO_LIB)
+#define BOOST_ALL_NO_LIB 1
+#endif // !defined(BOOST_ALL_NO_LIB)
+
+// Test that header file is self-contained.
+#include "asio/early_complete.hpp"
+
+#include "./unit_test.hpp"
+
+struct dummy_init
+{
+  template<typename Func>
+  auto complete_early(Func && func) -> decltype(std::declval<Func>()(int()));
+
+};
+
+void trait_test()
+{
+  using t1 = asio::has_early_completion<void(), dummy_init>;
+  using t2 = asio::has_early_completion<void(int), dummy_init>;
+  ASIO_CHECK(!t1::value);
+  ASIO_CHECK(t2::value);
+}
+
+ASIO_TEST_SUITE
+(
+    "early_completion",
+    ASIO_TEST_CASE(trait_test)
+)


### PR DESCRIPTION
This is a prototype for early_completion. This inserts an extra step into async_initialize that will check of we can complete immediately; some completion tokens should be able to do so (like use_awaitable, as done in this prototypes). This will need further work, e.g. on deferred and I'd be happy to do it, if you think this is useful.

My motivation is to make application code that is built on top of asio faster; that means non-IO primitives like channels or semaphores, which can be short-circuited without causing starvation.