### PR TITLE
Fix broken get_nt_set_info() for overlapped handles

### DIFF
--- a/asio/include/asio/detail/impl/win_iocp_handle_service.ipp
+++ b/asio/include/asio/detail/impl/win_iocp_handle_service.ipp
@@ -68,6 +68,7 @@ public:
 win_iocp_handle_service::win_iocp_handle_service(execution_context& context)
   : execution_context_service_base<win_iocp_handle_service>(context),
     iocp_service_(asio::use_service<win_iocp_io_context>(context)),
+    nt_set_info_(0),
     mutex_(),
     impl_list_(0)
 {


### PR DESCRIPTION
When calling handle->release(), ASIO uses
kernel-provided NtSetInformationFile() routine
to remove IOCP for the specific handle. Since this routine is not part of SDK, ASIO retrives the address of that function from NTDLL.DLL and caches it
into nt_set_info_ class member. The fact that
address is cached is checked by comparing
it to 0.

The bug is that class member is not initialized
and contains undefined value, so ASIO assumes
that the address is already retrieved and uses
undefined value, which leads to acces violation.

Fix by initializing nt_set_info_ to zero, as it is done for sockets in win_iocp_socket_service_base.ipp.

Signed-off-by: Lev Stipakov <lev@openvpn.net>