### PR TITLE
config.hpp: define ASIO_HAS_BOOST_SOURCE_LOCATION only without BOOST_…

### DIFF
--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -1455,7 +1455,7 @@
 // Boost support for source_location and system errors.
 #if !defined(ASIO_HAS_BOOST_SOURCE_LOCATION)
 # if !defined(ASIO_DISABLE_BOOST_SOURCE_LOCATION)
-#  if defined(ASIO_HAS_BOOST_CONFIG) && (BOOST_VERSION >= 107900)
+#  if defined(ASIO_HAS_BOOST_CONFIG) && (BOOST_VERSION >= 107900) && !defined(BOOST_NO_EXCEPTIONS)
 #   define ASIO_HAS_BOOST_SOURCE_LOCATION 1
 #  endif // defined(ASIO_HAS_BOOST_CONFIG) && (BOOST_VERSION >= 107900)
 # endif // !defined(ASIO_DISABLE_BOOST_SOURCE_LOCATION)


### PR DESCRIPTION
…NO_EXCEPTIONS

* some code which uses asio started to fail after upgrade to boost-1.80.0 with: function boost::asio::detail::posix_tss_ptr_create(unsigned int&): error: undefined reference to 'boost::throw_exception(std::exception const&, boost::source_location const&)'

* from the preprocessor it looks like BOOST_ASIO_HAS_BOOST_THROW_EXCEPTION is set, so asio/detail/throw_exception.hpp does only: #if defined(BOOST_ASIO_HAS_BOOST_THROW_EXCEPTION) using boost::throw_exception;

  and doesn't define throw_exception functions which respect to BOOST_ASIO_SOURCE_LOCATION_PARAM (which is in this case enabled)

  then asio/detail/impl/throw_error.ipp calls throw_exception with BOOST_ASIO_SOURCE_LOCATION_ARG and it ends undefined, because

  setting BOOST_ASIO_SOURCE_LOCATION_ARG to empty in throw_error.ipp "fixed" the build for me, so I guess there is inconsistency between detail/throw_exception.hpp and impl/throw_error.ipp expectations from boost/throw_exception.hpp

Signed-off-by: Martin Jansa <Martin.Jansa@gmail.com>