### PR TITLE
Made cancelled public on a composed_op.

### DIFF
--- a/asio/include/asio/compose.hpp
+++ b/asio/include/asio/compose.hpp
@@ -439,6 +439,11 @@ public:
         ASIO_MOVE_CAST(InFilter)(in_filter),
         ASIO_MOVE_CAST(OutFilter)(out_filter));
   }
+  
+  cancellation_type_t cancelled() const ASIO_NOEXCEPT
+  {
+    return base_from_cancellation_state::cancelled();
+  }
 
 //private:
   Impl impl_;


### PR DESCRIPTION
This is needed for many composed operatoins, among them boostorg/beast#2512