### PR TITLE
Fixed wrong configuration for ASIO_HAS_CO_AWAIT

### DIFF
--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -2070,23 +2070,29 @@
 #endif // !defined(ASIO_UNUSED_VARIABLE)
 
 // Support the co_await keyword on compilers known to allow it.
+// Support the co_await keyword on compilers known to allow it.
 #if !defined(ASIO_HAS_CO_AWAIT)
 # if !defined(ASIO_DISABLE_CO_AWAIT)
-#  if defined(ASIO_MSVC)
-#   if (_MSC_VER >= 1928) && (_MSVC_LANG >= 201705) && !defined(__clang__)
+#  if has_include(<version>) && has_include(<coroutine>) && defined(__cpp_coroutines) && (__cpp_coroutines >= 201707L) 
+#   include <version>
+#   if defined(__cpp_lib_coroutine) && (__cpp_lib_coroutine >= 201902L)
+#    define ASIO_HAS_CO_AWAIT 1
+#   endif // defined(__cpp_lib_coroutine) && (__cpp_lib_coroutine >= 201902L)
+#  if !defined(ASIO_HAS_CO_AWAIT) && defined(ASIO_MSVC)
+#   if (_MSC_VER >= 1928) && (_MSVC_LANG >= 201705) 
 #    define ASIO_HAS_CO_AWAIT 1
 #   elif (_MSC_FULL_VER >= 190023506)
 #    if defined(_RESUMABLE_FUNCTIONS_SUPPORTED)
 #     define ASIO_HAS_CO_AWAIT 1
 #    endif // defined(_RESUMABLE_FUNCTIONS_SUPPORTED)
 #   endif // (_MSC_FULL_VER >= 190023506)
-#  elif defined(__clang__)
+#  if !defined(ASIO_HAS_CO_AWAIT) && defined(__clang__)
 #   if (__cplusplus >= 201703) && (__cpp_coroutines >= 201703)
 #    if __has_include(<experimental/coroutine>)
 #     define ASIO_HAS_CO_AWAIT 1
 #    endif // __has_include(<experimental/coroutine>)
 #   endif // (__cplusplus >= 201703) && (__cpp_coroutines >= 201703)
-#  elif defined(__GNUC__)
+#  if !defined(ASIO_HAS_CO_AWAIT) && defined(__GNUC__)
 #   if (__cplusplus >= 201709) && (__cpp_impl_coroutine >= 201902)
 #    if __has_include(<coroutine>)
 #     define ASIO_HAS_CO_AWAIT 1

--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -2078,6 +2078,7 @@
 #   if defined(__cpp_lib_coroutine) && (__cpp_lib_coroutine >= 201902L)
 #    define ASIO_HAS_CO_AWAIT 1
 #   endif // defined(__cpp_lib_coroutine) && (__cpp_lib_coroutine >= 201902L)
+#  endif //has_include(<version>) && has_include(<coroutine>) && defined(__cpp_coroutines) && (__cpp_coroutines >= 201707L) 
 #  if !defined(ASIO_HAS_CO_AWAIT) && defined(ASIO_MSVC)
 #   if (_MSC_VER >= 1928) && (_MSVC_LANG >= 201705) 
 #    define ASIO_HAS_CO_AWAIT 1
@@ -2086,12 +2087,14 @@
 #     define ASIO_HAS_CO_AWAIT 1
 #    endif // defined(_RESUMABLE_FUNCTIONS_SUPPORTED)
 #   endif // (_MSC_FULL_VER >= 190023506)
+#  endif // !defined(ASIO_HAS_CO_AWAIT) && defined(ASIO_MSVC)
 #  if !defined(ASIO_HAS_CO_AWAIT) && defined(__clang__)
 #   if (__cplusplus >= 201703) && (__cpp_coroutines >= 201703)
 #    if __has_include(<experimental/coroutine>)
 #     define ASIO_HAS_CO_AWAIT 1
 #    endif // __has_include(<experimental/coroutine>)
 #   endif // (__cplusplus >= 201703) && (__cpp_coroutines >= 201703)
+#  endif // !defined(ASIO_HAS_CO_AWAIT) && defined(__clang__)
 #  if !defined(ASIO_HAS_CO_AWAIT) && defined(__GNUC__)
 #   if (__cplusplus >= 201709) && (__cpp_impl_coroutine >= 201902)
 #    if __has_include(<coroutine>)

--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -2070,7 +2070,6 @@
 #endif // !defined(ASIO_UNUSED_VARIABLE)
 
 // Support the co_await keyword on compilers known to allow it.
-// Support the co_await keyword on compilers known to allow it.
 #if !defined(ASIO_HAS_CO_AWAIT)
 # if !defined(ASIO_DISABLE_CO_AWAIT)
 #  if ((defined(__cpp_coroutines) && (__cpp_coroutines >= 201707L)) || (defined(__cpp_impl_coroutine) && (__cpp_impl_coroutine >= 201902L))) 
@@ -2086,16 +2085,12 @@
 #  endif // !defined(ASIO_HAS_CO_AWAIT) && defined(ASIO_MSVC)
 #  if !defined(ASIO_HAS_CO_AWAIT) && defined(__clang__)
 #   if (__cplusplus >= 201703) && (__cpp_coroutines >= 201703)
-#    if __has_include(<experimental/coroutine>)
-#     define ASIO_HAS_CO_AWAIT 1
-#    endif // __has_include(<experimental/coroutine>)
+#    define ASIO_HAS_CO_AWAIT 1
 #   endif // (__cplusplus >= 201703) && (__cpp_coroutines >= 201703)
 #  endif // !defined(ASIO_HAS_CO_AWAIT) && defined(__clang__)
 #  if !defined(ASIO_HAS_CO_AWAIT) && defined(__GNUC__)
 #   if (__cplusplus >= 201709) && (__cpp_impl_coroutine >= 201902)
-#    if __has_include(<coroutine>)
-#     define ASIO_HAS_CO_AWAIT 1
-#    endif // __has_include(<coroutine>)
+#    define ASIO_HAS_CO_AWAIT 1
 #   endif // (__cplusplus >= 201709) && (__cpp_impl_coroutine >= 201902)
 #  endif // defined(__GNUC__)
 # endif // !defined(ASIO_DISABLE_CO_AWAIT)
@@ -2104,12 +2099,20 @@
 // Standard library support for coroutines.
 #if !defined(ASIO_HAS_STD_COROUTINE)
 # if !defined(ASIO_DISABLE_STD_COROUTINE)
-#  if defined(ASIO_MSVC)
+#  if __has_include(<version>)
+#   include <version>
+#  elif __has_include(<coroutine>)
+#   include <coroutine>
+#  endif //__has_include(<coroutine>)
+#  if defined(__cpp_lib_coroutine) && (__cpp_lib_coroutine >= 201902)
+#   define ASIO_HAS_STD_COROUTINE 1
+#  endif // defined(__cpp_lib_coroutine) && (__cpp_lib_coroutine >= 201902)
+#  if !defined(ASIO_HAS_STD_COROUTINE) && defined(ASIO_MSVC)
 #   if (_MSC_VER >= 1928) && (_MSVC_LANG >= 201705)
 #    define ASIO_HAS_STD_COROUTINE 1
 #   endif // (_MSC_VER >= 1928) && (_MSVC_LANG >= 201705)
 #  endif // defined(ASIO_MSVC)
-#  if defined(__GNUC__)
+#  if !defined(ASIO_HAS_STD_COROUTINE) && defined(__GNUC__)
 #   if (__cplusplus >= 201709) && (__cpp_impl_coroutine >= 201902)
 #    if __has_include(<coroutine>)
 #     define ASIO_HAS_STD_COROUTINE 1

--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -2073,13 +2073,9 @@
 // Support the co_await keyword on compilers known to allow it.
 #if !defined(ASIO_HAS_CO_AWAIT)
 # if !defined(ASIO_DISABLE_CO_AWAIT)
-#  if has_include(<version>) && has_include(<coroutine>) && defined(__cpp_coroutines) && (__cpp_coroutines >= 201707L) 
-#   include <version>
-#   if defined(__cpp_lib_coroutine) && (__cpp_lib_coroutine >= 201902L)
-#    define ASIO_HAS_CO_AWAIT 1
-#   endif // defined(__cpp_lib_coroutine) && (__cpp_lib_coroutine >= 201902L)
-#  endif //has_include(<version>) && has_include(<coroutine>) && defined(__cpp_coroutines) && (__cpp_coroutines >= 201707L) 
-#  if !defined(ASIO_HAS_CO_AWAIT) && defined(ASIO_MSVC)
+#  if ((defined(__cpp_coroutines) && (__cpp_coroutines >= 201707L)) || (defined(__cpp_impl_coroutine) && (__cpp_impl_coroutine >= 201902L))) 
+#   define ASIO_HAS_CO_AWAIT 1
+#  elif !defined(ASIO_HAS_CO_AWAIT) && defined(ASIO_MSVC)
 #   if (_MSC_VER >= 1928) && (_MSVC_LANG >= 201705) 
 #    define ASIO_HAS_CO_AWAIT 1
 #   elif (_MSC_FULL_VER >= 190023506)


### PR DESCRIPTION
This adds a more general approach, to check for c++20 coroutines, which takes the feature test macros into account, defined since c++20:    Proposal: https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0912r5.html    cppreference: https://en.cppreference.com/w/User:D41D8CD98F/feature_testing_macros#C.2B.2B20  

I've kept the old macros, in the case compilers + stl-impl add the support, even, when they did not yet set the feature testing macros.
I've also made them more robust: The `#elif` were not mutually exclusive, so I've changed them to `if !defined(ASIO_HAS_CO_AWAIT) && ...`