### PR TITLE
Fixed the call to select_reactor::run with a boolean

### DIFF
--- a/asio/include/asio/detail/impl/select_reactor.ipp
+++ b/asio/include/asio/detail/impl/select_reactor.ipp
@@ -309,7 +309,7 @@ void select_reactor::run_thread()
   {
     lock.unlock();
     op_queue<operation> ops;
-    run(true, ops);
+    run(-1, ops);
     scheduler_.post_deferred_completions(ops);
     lock.lock();
   }


### PR DESCRIPTION
After updating the signature of `select_reactor::run(bool block, op_queue& ops)` to `select_reactor::run(long usec, op_queue& ops)` (https://github.com/boostorg/asio/commit/b60e92b13ef68dfbb9af180d76eae41d22e19356#diff-de75c3dac52db210acae8bbdeb3d9eb437bdb716cc420e0169987986c9ed625cR189),
it was still called with a boolean.