### PR TITLE
Support non-experimental headers with clang

### DIFF
--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -2117,9 +2117,9 @@
 #   endif // (_MSC_FULL_VER >= 190023506)
 #  elif defined(__clang__)
 #   if (__cplusplus >= 201703) && (__cpp_coroutines >= 201703)
-#    if __has_include(<experimental/coroutine>)
+#    if __has_include(<experimental/coroutine>) || __has_include(<coroutine>)
 #     define ASIO_HAS_CO_AWAIT 1
-#    endif // __has_include(<experimental/coroutine>)
+#    endif // __has_include(<experimental/coroutine>) || __has_include(<coroutine>)
 #   endif // (__cplusplus >= 201703) && (__cpp_coroutines >= 201703)
 #  elif defined(__GNUC__)
 #   if (__cplusplus >= 201709) && (__cpp_impl_coroutine >= 201902)


### PR DESCRIPTION
clang-15 with libstdc++-12 can work with coroutines but needs non experimental headers