### PR TITLE
Fixed a potential null pointer dereference

### DIFF
--- a/asio/include/asio/detail/impl/scheduler.ipp
+++ b/asio/include/asio/detail/impl/scheduler.ipp
@@ -326,8 +326,8 @@ void scheduler::restart()
 
 void scheduler::compensating_work_started()
 {
-  thread_info_base* this_thread = thread_call_stack::contains(this);
-  ++static_cast<thread_info*>(this_thread)->private_outstanding_work;
+  if (thread_info_base* this_thread = thread_call_stack::contains(this))
+    ++static_cast<thread_info*>(this_thread)->private_outstanding_work;
 }
 
 bool scheduler::can_dispatch()


### PR DESCRIPTION
PR fixes a potential null pointer dereference with GCC 12.2 [-Wnull-dereference] -- same condition as in void scheduler::capture_current_exception() or other functions here in scheduler.ipp