### PR TITLE
Prefer Windows threads to pthreads

### DIFF
--- a/asio/include/asio/detail/thread.hpp
+++ b/asio/include/asio/detail/thread.hpp
@@ -19,8 +19,6 @@
 
 #if !defined(ASIO_HAS_THREADS)
 # include "asio/detail/null_thread.hpp"
-#elif defined(ASIO_HAS_PTHREADS)
-# include "asio/detail/posix_thread.hpp"
 #elif defined(ASIO_WINDOWS)
 # if defined(UNDER_CE)
 #  include "asio/detail/wince_thread.hpp"
@@ -29,6 +27,8 @@
 # else
 #  include "asio/detail/win_thread.hpp"
 # endif
+#elif defined(ASIO_HAS_PTHREADS)
+# include "asio/detail/posix_thread.hpp"
 #elif defined(ASIO_HAS_STD_THREAD)
 # include "asio/detail/std_thread.hpp"
 #else
@@ -40,8 +40,6 @@ namespace detail {
 
 #if !defined(ASIO_HAS_THREADS)
 typedef null_thread thread;
-#elif defined(ASIO_HAS_PTHREADS)
-typedef posix_thread thread;
 #elif defined(ASIO_WINDOWS)
 # if defined(UNDER_CE)
 typedef wince_thread thread;
@@ -50,6 +48,8 @@ typedef winapp_thread thread;
 # else
 typedef win_thread thread;
 # endif
+#elif defined(ASIO_HAS_PTHREADS)
+typedef posix_thread thread;
 #elif defined(ASIO_HAS_STD_THREAD)
 typedef std_thread thread;
 #endif


### PR DESCRIPTION
On mingw ASIO can only detect pthreads if the pthread header is included before it.  Since mingw can use both pthreads and Windows threads, if you have multiple source files that access an `io_context` and only some of them include pthreads before asio then they can use the wrong thread type and corrupt memory.  If asio instead prefers Windows threads to pthreads there will be no type confusion and no memory corruption.

The following program demonstrates the difference:
```c++
#if INCLUDE_PTHREAD
#include <pthread.h>
#endif
#include <asio.hpp>
#include <iostream>

int main() {
	std::cout << "asio::detail::thread is " << typeid(asio::detail::thread).name() << '\n';
}
```
When compiled with `-DINCLUDE_PTHREAD` it prints "asio::detail::thread is N4asio6detail12posix_threadE", but when compiled without that define prints "asio::detail::thread is N4asio6detail10win_threadE".  With this patch it always prints "asio::detail::thread is N4asio6detail10win_threadE".