### PR TITLE
Workaround MSVC compiler error in promise_impl

### DIFF
--- a/asio/include/asio/experimental/impl/promise.hpp
+++ b/asio/include/asio/experimental/impl/promise.hpp
@@ -32,6 +32,12 @@ struct promise;
 
 namespace detail {
 
+// MSVC error C2027
+template<typename... Ts>
+struct result_workaround : std::tuple<Ts...>
+{
+};
+
 template<typename Signature, typename Executor, typename Allocator>
 struct promise_impl;
 
@@ -56,8 +62,8 @@ struct promise_impl<void(Ts...), Executor, Allocator>
       reinterpret_cast<result_type*>(&result)->~result_type();
   }
 
-  typename aligned_storage<sizeof(result_type),
-    alignof(result_type)>::type result;
+  typename aligned_storage<sizeof(result_workaround<Ts...>),
+    alignof(result_workaround<Ts...>)>::type result;
   std::atomic<bool> done{false};
   cancellation_signal cancel;
   Allocator allocator;


### PR DESCRIPTION
Simply including boost/asio/experimental/promise.hpp results in compilation error (VS 17.4 toolset v143) that looks like a compiler error since the tuple header has clearly been included.
```
1>C:\.conan\7aa99f\1\include\boost\asio\experimental\impl\promise.hpp(61,1): error C2027: use of undefined type 'std::tuple<_Types...>' (compiling source file xxx)
1>C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.34.31933\include\utility(533,19): message : see declaration of 'std::tuple<_Types...>' (compiling source file xxx)
1>C:\.conan\7aa99f\1\include\boost\asio\experimental\impl\promise.hpp(173,2): message : see reference to class template instantiation 'boost::asio::experimental::detail::promise_impl<void(Ts...),Executor,Allocator>' being compiled (compiling source file xxx)
```

This is a workaround for that compiles.