### PR TITLE
Make changes to fix the port binding problem on Mac

### DIFF
--- a/asio/src/examples/cpp11/operations/composed_1.cpp
+++ b/asio/src/examples/cpp11/operations/composed_1.cpp
@@ -67,7 +67,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -93,7 +93,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -126,7 +126,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp11/operations/composed_2.cpp
+++ b/asio/src/examples/cpp11/operations/composed_2.cpp
@@ -137,7 +137,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -163,7 +163,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -196,7 +196,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp11/operations/composed_3.cpp
+++ b/asio/src/examples/cpp11/operations/composed_3.cpp
@@ -145,7 +145,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -171,7 +171,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -204,7 +204,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp11/operations/composed_4.cpp
+++ b/asio/src/examples/cpp11/operations/composed_4.cpp
@@ -161,7 +161,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -187,7 +187,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -219,7 +219,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp11/operations/composed_5.cpp
+++ b/asio/src/examples/cpp11/operations/composed_5.cpp
@@ -197,7 +197,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -223,7 +223,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -256,7 +256,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp11/operations/composed_6.cpp
+++ b/asio/src/examples/cpp11/operations/composed_6.cpp
@@ -257,7 +257,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -283,7 +283,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -316,7 +316,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp11/operations/composed_7.cpp
+++ b/asio/src/examples/cpp11/operations/composed_7.cpp
@@ -176,7 +176,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -202,7 +202,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -235,7 +235,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp11/operations/composed_8.cpp
+++ b/asio/src/examples/cpp11/operations/composed_8.cpp
@@ -171,7 +171,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -197,7 +197,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -230,7 +230,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp14/operations/composed_1.cpp
+++ b/asio/src/examples/cpp14/operations/composed_1.cpp
@@ -63,7 +63,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -89,7 +89,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -122,7 +122,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp14/operations/composed_2.cpp
+++ b/asio/src/examples/cpp14/operations/composed_2.cpp
@@ -127,7 +127,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -153,7 +153,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -186,7 +186,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp14/operations/composed_3.cpp
+++ b/asio/src/examples/cpp14/operations/composed_3.cpp
@@ -135,7 +135,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -161,7 +161,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -194,7 +194,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp14/operations/composed_4.cpp
+++ b/asio/src/examples/cpp14/operations/composed_4.cpp
@@ -151,7 +151,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -177,7 +177,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -209,7 +209,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp14/operations/composed_5.cpp
+++ b/asio/src/examples/cpp14/operations/composed_5.cpp
@@ -188,7 +188,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -214,7 +214,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -247,7 +247,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp14/operations/composed_6.cpp
+++ b/asio/src/examples/cpp14/operations/composed_6.cpp
@@ -248,7 +248,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -274,7 +274,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -307,7 +307,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp14/operations/composed_7.cpp
+++ b/asio/src/examples/cpp14/operations/composed_7.cpp
@@ -169,7 +169,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -195,7 +195,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -228,7 +228,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp14/operations/composed_8.cpp
+++ b/asio/src/examples/cpp14/operations/composed_8.cpp
@@ -162,7 +162,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -188,7 +188,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -221,7 +221,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp17/coroutines_ts/echo_server.cpp
+++ b/asio/src/examples/cpp17/coroutines_ts/echo_server.cpp
@@ -45,14 +45,22 @@ awaitable<void> echo(tcp::socket socket)
   }
 }
 
-awaitable<void> listener()
+awaitable<void> listener(asio::io_context& io_context)
 {
-  auto executor = co_await this_coro::executor;
-  tcp::acceptor acceptor(executor, {tcp::v4(), 55555});
-  for (;;)
+  try
   {
-    tcp::socket socket = co_await acceptor.async_accept(use_awaitable);
-    co_spawn(executor, echo(std::move(socket)), detached);
+    auto executor = co_await this_coro::executor;
+    tcp::acceptor acceptor(executor, {tcp::v4(), 55555});
+    for (;;)
+    {
+      tcp::socket socket = co_await acceptor.async_accept(use_awaitable);
+      co_spawn(executor, echo(std::move(socket)), detached);
+    }
+  }
+  catch (std::exception& e)
+  {
+    std::printf("Exception: %s\n", e.what());
+    io_context.stop();
   }
 }
 
@@ -65,7 +73,7 @@ int main()
     asio::signal_set signals(io_context, SIGINT, SIGTERM);
     signals.async_wait([&](auto, auto){ io_context.stop(); });
 
-    co_spawn(io_context, listener(), detached);
+    co_spawn(io_context, listener(io_context), detached);
 
     io_context.run();
   }

--- a/asio/src/examples/cpp17/coroutines_ts/echo_server.cpp
+++ b/asio/src/examples/cpp17/coroutines_ts/echo_server.cpp
@@ -50,7 +50,7 @@ awaitable<void> listener(asio::io_context& io_context)
   try
   {
     auto executor = co_await this_coro::executor;
-    tcp::acceptor acceptor(executor, {tcp::v4(), 55555});
+    tcp::acceptor acceptor(executor, {tcp::v4(), 55557});
     for (;;)
     {
       tcp::socket socket = co_await acceptor.async_accept(use_awaitable);

--- a/asio/src/examples/cpp17/coroutines_ts/echo_server_with_as_single_default.cpp
+++ b/asio/src/examples/cpp17/coroutines_ts/echo_server_with_as_single_default.cpp
@@ -45,7 +45,7 @@ awaitable<void> listener(asio::io_context& io_context)
   try
   {
     auto executor = co_await this_coro::executor;
-    tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
+    tcp_acceptor acceptor(executor, {tcp::v4(), 55557});
     for (;;)
     {
       if (auto [e, socket] = co_await acceptor.async_accept(); socket.is_open())

--- a/asio/src/examples/cpp17/coroutines_ts/echo_server_with_as_single_default.cpp
+++ b/asio/src/examples/cpp17/coroutines_ts/echo_server_with_as_single_default.cpp
@@ -40,14 +40,22 @@ awaitable<void> echo(tcp_socket socket)
   }
 }
 
-awaitable<void> listener()
+awaitable<void> listener(asio::io_context& io_context)
 {
-  auto executor = co_await this_coro::executor;
-  tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
-  for (;;)
+  try
   {
-    if (auto [e, socket] = co_await acceptor.async_accept(); socket.is_open())
-      co_spawn(executor, echo(std::move(socket)), detached);
+    auto executor = co_await this_coro::executor;
+    tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
+    for (;;)
+    {
+      if (auto [e, socket] = co_await acceptor.async_accept(); socket.is_open())
+        co_spawn(executor, echo(std::move(socket)), detached);
+    }
+  }
+  catch (std::exception& e)
+  {
+    std::printf("Exception: %s\n", e.what());
+    io_context.stop();
   }
 }
 
@@ -60,7 +68,7 @@ int main()
     asio::signal_set signals(io_context, SIGINT, SIGTERM);
     signals.async_wait([&](auto, auto){ io_context.stop(); });
 
-    co_spawn(io_context, listener(), detached);
+    co_spawn(io_context, listener(io_context), detached);
 
     io_context.run();
   }

--- a/asio/src/examples/cpp17/coroutines_ts/echo_server_with_as_tuple_default.cpp
+++ b/asio/src/examples/cpp17/coroutines_ts/echo_server_with_as_tuple_default.cpp
@@ -45,7 +45,7 @@ awaitable<void> listener(asio::io_context& io_context)
   try
   {
     auto executor = co_await this_coro::executor;
-    tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
+    tcp_acceptor acceptor(executor, {tcp::v4(), 55557});
     for (;;)
     {
       if (auto [e, socket] = co_await acceptor.async_accept(); socket.is_open())

--- a/asio/src/examples/cpp17/coroutines_ts/echo_server_with_as_tuple_default.cpp
+++ b/asio/src/examples/cpp17/coroutines_ts/echo_server_with_as_tuple_default.cpp
@@ -40,14 +40,22 @@ awaitable<void> echo(tcp_socket socket)
   }
 }
 
-awaitable<void> listener()
+awaitable<void> listener(asio::io_context& io_context)
 {
-  auto executor = co_await this_coro::executor;
-  tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
-  for (;;)
+  try
   {
-    if (auto [e, socket] = co_await acceptor.async_accept(); socket.is_open())
-      co_spawn(executor, echo(std::move(socket)), detached);
+    auto executor = co_await this_coro::executor;
+    tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
+    for (;;)
+    {
+      if (auto [e, socket] = co_await acceptor.async_accept(); socket.is_open())
+        co_spawn(executor, echo(std::move(socket)), detached);
+    }
+  }
+  catch (std::exception& e)
+  {
+    std::printf("Exception: %s\n", e.what());
+    io_context.stop();
   }
 }
 
@@ -60,7 +68,7 @@ int main()
     asio::signal_set signals(io_context, SIGINT, SIGTERM);
     signals.async_wait([&](auto, auto){ io_context.stop(); });
 
-    co_spawn(io_context, listener(), detached);
+    co_spawn(io_context, listener(io_context), detached);
 
     io_context.run();
   }

--- a/asio/src/examples/cpp17/coroutines_ts/echo_server_with_default.cpp
+++ b/asio/src/examples/cpp17/coroutines_ts/echo_server_with_default.cpp
@@ -42,14 +42,22 @@ awaitable<void> echo(tcp_socket socket)
   }
 }
 
-awaitable<void> listener()
+awaitable<void> listener(asio::io_context& io_context)
 {
-  auto executor = co_await this_coro::executor;
-  tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
-  for (;;)
+  try
   {
-    auto socket = co_await acceptor.async_accept();
-    co_spawn(executor, echo(std::move(socket)), detached);
+    auto executor = co_await this_coro::executor;
+    tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
+    for (;;)
+    {
+      auto socket = co_await acceptor.async_accept();
+      co_spawn(executor, echo(std::move(socket)), detached);
+    }
+  }
+  catch (std::exception& e)
+  {
+    std::printf("Exception: %s\n", e.what());
+    io_context.stop();
   }
 }
 
@@ -62,7 +70,7 @@ int main()
     asio::signal_set signals(io_context, SIGINT, SIGTERM);
     signals.async_wait([&](auto, auto){ io_context.stop(); });
 
-    co_spawn(io_context, listener(), detached);
+    co_spawn(io_context, listener(io_context), detached);
 
     io_context.run();
   }

--- a/asio/src/examples/cpp17/coroutines_ts/echo_server_with_default.cpp
+++ b/asio/src/examples/cpp17/coroutines_ts/echo_server_with_default.cpp
@@ -47,7 +47,7 @@ awaitable<void> listener(asio::io_context& io_context)
   try
   {
     auto executor = co_await this_coro::executor;
-    tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
+    tcp_acceptor acceptor(executor, {tcp::v4(), 55557});
     for (;;)
     {
       auto socket = co_await acceptor.async_accept();

--- a/asio/src/examples/cpp17/coroutines_ts/range_based_for.cpp
+++ b/asio/src/examples/cpp17/coroutines_ts/range_based_for.cpp
@@ -90,7 +90,7 @@ int main()
     asio::signal_set signals(io_context, SIGINT, SIGTERM);
     signals.async_wait([&](auto, auto){ io_context.stop(); });
 
-    tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+    tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
     co_spawn(io_context, listener(std::move(acceptor)), detached);
 
     io_context.run();

--- a/asio/src/examples/cpp17/coroutines_ts/refactored_echo_server.cpp
+++ b/asio/src/examples/cpp17/coroutines_ts/refactored_echo_server.cpp
@@ -54,7 +54,7 @@ awaitable<void> listener(asio::io_context& io_context)
   try
   {
     auto executor = co_await this_coro::executor;
-    tcp::acceptor acceptor(executor, {tcp::v4(), 55555});
+    tcp::acceptor acceptor(executor, {tcp::v4(), 55557});
     for (;;)
     {
       tcp::socket socket = co_await acceptor.async_accept(use_awaitable);

--- a/asio/src/examples/cpp17/coroutines_ts/refactored_echo_server.cpp
+++ b/asio/src/examples/cpp17/coroutines_ts/refactored_echo_server.cpp
@@ -49,14 +49,22 @@ awaitable<void> echo(tcp::socket socket)
   }
 }
 
-awaitable<void> listener()
+awaitable<void> listener(asio::io_context& io_context)
 {
-  auto executor = co_await this_coro::executor;
-  tcp::acceptor acceptor(executor, {tcp::v4(), 55555});
-  for (;;)
+  try
   {
-    tcp::socket socket = co_await acceptor.async_accept(use_awaitable);
-    co_spawn(executor, echo(std::move(socket)), detached);
+    auto executor = co_await this_coro::executor;
+    tcp::acceptor acceptor(executor, {tcp::v4(), 55555});
+    for (;;)
+    {
+      tcp::socket socket = co_await acceptor.async_accept(use_awaitable);
+      co_spawn(executor, echo(std::move(socket)), detached);
+    }
+  }
+  catch (std::exception& e)
+  {
+    std::printf("Exception: %s\n", e.what());
+    io_context.stop();
   }
 }
 
@@ -69,7 +77,7 @@ int main()
     asio::signal_set signals(io_context, SIGINT, SIGTERM);
     signals.async_wait([&](auto, auto){ io_context.stop(); });
 
-    co_spawn(io_context, listener(), detached);
+    co_spawn(io_context, listener(io_context), detached);
 
     io_context.run();
   }

--- a/asio/src/examples/cpp20/coroutines/echo_server.cpp
+++ b/asio/src/examples/cpp20/coroutines/echo_server.cpp
@@ -45,14 +45,22 @@ awaitable<void> echo(tcp::socket socket)
   }
 }
 
-awaitable<void> listener()
+awaitable<void> listener(asio::io_context& io_context)
 {
-  auto executor = co_await this_coro::executor;
-  tcp::acceptor acceptor(executor, {tcp::v4(), 55555});
-  for (;;)
+  try
   {
-    tcp::socket socket = co_await acceptor.async_accept(use_awaitable);
-    co_spawn(executor, echo(std::move(socket)), detached);
+    auto executor = co_await this_coro::executor;
+    tcp::acceptor acceptor(executor, {tcp::v4(), 55555});
+    for (;;)
+    {
+      tcp::socket socket = co_await acceptor.async_accept(use_awaitable);
+      co_spawn(executor, echo(std::move(socket)), detached);
+    }
+  }
+  catch (std::exception& e)
+  {
+    std::printf("Exception: %s\n", e.what());
+    io_context.stop();
   }
 }
 
@@ -65,7 +73,7 @@ int main()
     asio::signal_set signals(io_context, SIGINT, SIGTERM);
     signals.async_wait([&](auto, auto){ io_context.stop(); });
 
-    co_spawn(io_context, listener(), detached);
+    co_spawn(io_context, listener(io_context), detached);
 
     io_context.run();
   }

--- a/asio/src/examples/cpp20/coroutines/echo_server.cpp
+++ b/asio/src/examples/cpp20/coroutines/echo_server.cpp
@@ -50,7 +50,7 @@ awaitable<void> listener(asio::io_context& io_context)
   try
   {
     auto executor = co_await this_coro::executor;
-    tcp::acceptor acceptor(executor, {tcp::v4(), 55555});
+    tcp::acceptor acceptor(executor, {tcp::v4(), 55557});
     for (;;)
     {
       tcp::socket socket = co_await acceptor.async_accept(use_awaitable);

--- a/asio/src/examples/cpp20/coroutines/echo_server_with_as_single_default.cpp
+++ b/asio/src/examples/cpp20/coroutines/echo_server_with_as_single_default.cpp
@@ -45,7 +45,7 @@ awaitable<void> listener(asio::io_context& io_context)
   try
   {
     auto executor = co_await this_coro::executor;
-    tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
+    tcp_acceptor acceptor(executor, {tcp::v4(), 55557});
     for (;;)
     {
       if (auto [e, socket] = co_await acceptor.async_accept(); socket.is_open())

--- a/asio/src/examples/cpp20/coroutines/echo_server_with_as_single_default.cpp
+++ b/asio/src/examples/cpp20/coroutines/echo_server_with_as_single_default.cpp
@@ -40,14 +40,22 @@ awaitable<void> echo(tcp_socket socket)
   }
 }
 
-awaitable<void> listener()
+awaitable<void> listener(asio::io_context& io_context)
 {
-  auto executor = co_await this_coro::executor;
-  tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
-  for (;;)
+  try
   {
-    if (auto [e, socket] = co_await acceptor.async_accept(); socket.is_open())
-      co_spawn(executor, echo(std::move(socket)), detached);
+    auto executor = co_await this_coro::executor;
+    tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
+    for (;;)
+    {
+      if (auto [e, socket] = co_await acceptor.async_accept(); socket.is_open())
+        co_spawn(executor, echo(std::move(socket)), detached);
+    }
+  }
+  catch (std::exception& e)
+  {
+    std::printf("Exception: %s\n", e.what());
+    io_context.stop();
   }
 }
 
@@ -60,7 +68,7 @@ int main()
     asio::signal_set signals(io_context, SIGINT, SIGTERM);
     signals.async_wait([&](auto, auto){ io_context.stop(); });
 
-    co_spawn(io_context, listener(), detached);
+    co_spawn(io_context, listener(io_context), detached);
 
     io_context.run();
   }

--- a/asio/src/examples/cpp20/coroutines/echo_server_with_as_tuple_default.cpp
+++ b/asio/src/examples/cpp20/coroutines/echo_server_with_as_tuple_default.cpp
@@ -45,7 +45,7 @@ awaitable<void> listener(asio::io_context& io_context)
   try
   {
     auto executor = co_await this_coro::executor;
-    tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
+    tcp_acceptor acceptor(executor, {tcp::v4(), 55557});
     for (;;)
     {
       if (auto [e, socket] = co_await acceptor.async_accept(); socket.is_open())

--- a/asio/src/examples/cpp20/coroutines/echo_server_with_as_tuple_default.cpp
+++ b/asio/src/examples/cpp20/coroutines/echo_server_with_as_tuple_default.cpp
@@ -40,14 +40,22 @@ awaitable<void> echo(tcp_socket socket)
   }
 }
 
-awaitable<void> listener()
+awaitable<void> listener(asio::io_context& io_context)
 {
-  auto executor = co_await this_coro::executor;
-  tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
-  for (;;)
+  try
   {
-    if (auto [e, socket] = co_await acceptor.async_accept(); socket.is_open())
-      co_spawn(executor, echo(std::move(socket)), detached);
+    auto executor = co_await this_coro::executor;
+    tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
+    for (;;)
+    {
+      if (auto [e, socket] = co_await acceptor.async_accept(); socket.is_open())
+        co_spawn(executor, echo(std::move(socket)), detached);
+    }
+  }
+  catch (std::exception& e)
+  {
+    std::printf("Exception: %s\n", e.what());
+    io_context.stop();
   }
 }
 
@@ -60,7 +68,7 @@ int main()
     asio::signal_set signals(io_context, SIGINT, SIGTERM);
     signals.async_wait([&](auto, auto){ io_context.stop(); });
 
-    co_spawn(io_context, listener(), detached);
+    co_spawn(io_context, listener(io_context), detached);
 
     io_context.run();
   }

--- a/asio/src/examples/cpp20/coroutines/echo_server_with_default.cpp
+++ b/asio/src/examples/cpp20/coroutines/echo_server_with_default.cpp
@@ -42,14 +42,22 @@ awaitable<void> echo(tcp_socket socket)
   }
 }
 
-awaitable<void> listener()
+awaitable<void> listener(asio::io_context& io_context)
 {
-  auto executor = co_await this_coro::executor;
-  tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
-  for (;;)
+  try
   {
-    auto socket = co_await acceptor.async_accept();
-    co_spawn(executor, echo(std::move(socket)), detached);
+    auto executor = co_await this_coro::executor;
+    tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
+    for (;;)
+    {
+      auto socket = co_await acceptor.async_accept();
+      co_spawn(executor, echo(std::move(socket)), detached);
+    }
+  }
+  catch (std::exception& e)
+  {
+    std::printf("Exception: %s\n", e.what());
+    io_context.stop();
   }
 }
 
@@ -62,7 +70,7 @@ int main()
     asio::signal_set signals(io_context, SIGINT, SIGTERM);
     signals.async_wait([&](auto, auto){ io_context.stop(); });
 
-    co_spawn(io_context, listener(), detached);
+    co_spawn(io_context, listener(io_context), detached);
 
     io_context.run();
   }

--- a/asio/src/examples/cpp20/coroutines/echo_server_with_default.cpp
+++ b/asio/src/examples/cpp20/coroutines/echo_server_with_default.cpp
@@ -47,7 +47,7 @@ awaitable<void> listener(asio::io_context& io_context)
   try
   {
     auto executor = co_await this_coro::executor;
-    tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
+    tcp_acceptor acceptor(executor, {tcp::v4(), 55557});
     for (;;)
     {
       auto socket = co_await acceptor.async_accept();

--- a/asio/src/examples/cpp20/coroutines/echo_server_with_deferred.cpp
+++ b/asio/src/examples/cpp20/coroutines/echo_server_with_deferred.cpp
@@ -46,7 +46,7 @@ awaitable<void> listener(asio::io_context& io_context)
   try
   {
     auto executor = co_await this_coro::executor;
-    tcp::acceptor acceptor(executor, {tcp::v4(), 55555});
+    tcp::acceptor acceptor(executor, {tcp::v4(), 55557});
     for (;;)
     {
       tcp::socket socket = co_await acceptor.async_accept(deferred);

--- a/asio/src/examples/cpp20/coroutines/echo_server_with_deferred.cpp
+++ b/asio/src/examples/cpp20/coroutines/echo_server_with_deferred.cpp
@@ -41,14 +41,22 @@ awaitable<void> echo(tcp::socket socket)
   }
 }
 
-awaitable<void> listener()
+awaitable<void> listener(asio::io_context& io_context)
 {
-  auto executor = co_await this_coro::executor;
-  tcp::acceptor acceptor(executor, {tcp::v4(), 55555});
-  for (;;)
+  try
   {
-    tcp::socket socket = co_await acceptor.async_accept(deferred);
-    co_spawn(executor, echo(std::move(socket)), detached);
+    auto executor = co_await this_coro::executor;
+    tcp::acceptor acceptor(executor, {tcp::v4(), 55555});
+    for (;;)
+    {
+      tcp::socket socket = co_await acceptor.async_accept(deferred);
+      co_spawn(executor, echo(std::move(socket)), detached);
+    }
+  }
+  catch (std::exception& e)
+  {
+    std::printf("Exception: %s\n", e.what());
+    io_context.stop();
   }
 }
 
@@ -61,7 +69,7 @@ int main()
     asio::signal_set signals(io_context, SIGINT, SIGTERM);
     signals.async_wait([&](auto, auto){ io_context.stop(); });
 
-    co_spawn(io_context, listener(), detached);
+    co_spawn(io_context, listener(io_context), detached);
 
     io_context.run();
   }

--- a/asio/src/examples/cpp20/coroutines/echo_server_with_deferred_default.cpp
+++ b/asio/src/examples/cpp20/coroutines/echo_server_with_deferred_default.cpp
@@ -48,7 +48,7 @@ awaitable<void> listener(asio::io_context& io_context)
   try
   {
     auto executor = co_await this_coro::executor;
-    tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
+    tcp_acceptor acceptor(executor, {tcp::v4(), 55557});
     for (;;)
     {
       tcp::socket socket = co_await acceptor.async_accept();

--- a/asio/src/examples/cpp20/coroutines/echo_server_with_deferred_default.cpp
+++ b/asio/src/examples/cpp20/coroutines/echo_server_with_deferred_default.cpp
@@ -43,14 +43,22 @@ awaitable<void> echo(tcp_socket socket)
   }
 }
 
-awaitable<void> listener()
+awaitable<void> listener(asio::io_context& io_context)
 {
-  auto executor = co_await this_coro::executor;
-  tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
-  for (;;)
+  try
   {
-    tcp::socket socket = co_await acceptor.async_accept();
-    co_spawn(executor, echo(std::move(socket)), detached);
+    auto executor = co_await this_coro::executor;
+    tcp_acceptor acceptor(executor, {tcp::v4(), 55555});
+    for (;;)
+    {
+      tcp::socket socket = co_await acceptor.async_accept();
+      co_spawn(executor, echo(std::move(socket)), detached);
+    }
+  }
+  catch (std::exception& e)
+  {
+    std::printf("Exception: %s\n", e.what());
+    io_context.stop();
   }
 }
 
@@ -63,7 +71,7 @@ int main()
     asio::signal_set signals(io_context, SIGINT, SIGTERM);
     signals.async_wait([&](auto, auto){ io_context.stop(); });
 
-    co_spawn(io_context, listener(), detached);
+    co_spawn(io_context, listener(io_context), detached);
 
     io_context.run();
   }

--- a/asio/src/examples/cpp20/coroutines/refactored_echo_server.cpp
+++ b/asio/src/examples/cpp20/coroutines/refactored_echo_server.cpp
@@ -54,7 +54,7 @@ awaitable<void> listener(asio::io_context& io_context)
   try
   {
     auto executor = co_await this_coro::executor;
-    tcp::acceptor acceptor(executor, {tcp::v4(), 55555});
+    tcp::acceptor acceptor(executor, {tcp::v4(), 55557});
     for (;;)
     {
       tcp::socket socket = co_await acceptor.async_accept(use_awaitable);

--- a/asio/src/examples/cpp20/coroutines/refactored_echo_server.cpp
+++ b/asio/src/examples/cpp20/coroutines/refactored_echo_server.cpp
@@ -49,14 +49,22 @@ awaitable<void> echo(tcp::socket socket)
   }
 }
 
-awaitable<void> listener()
+awaitable<void> listener(asio::io_context& io_context)
 {
-  auto executor = co_await this_coro::executor;
-  tcp::acceptor acceptor(executor, {tcp::v4(), 55555});
-  for (;;)
+  try
   {
-    tcp::socket socket = co_await acceptor.async_accept(use_awaitable);
-    co_spawn(executor, echo(std::move(socket)), detached);
+    auto executor = co_await this_coro::executor;
+    tcp::acceptor acceptor(executor, {tcp::v4(), 55555});
+    for (;;)
+    {
+      tcp::socket socket = co_await acceptor.async_accept(use_awaitable);
+      co_spawn(executor, echo(std::move(socket)), detached);
+    }
+  }
+  catch (std::exception& e)
+  {
+    std::printf("Exception: %s\n", e.what());
+    io_context.stop();
   }
 }
 
@@ -69,7 +77,7 @@ int main()
     asio::signal_set signals(io_context, SIGINT, SIGTERM);
     signals.async_wait([&](auto, auto){ io_context.stop(); });
 
-    co_spawn(io_context, listener(), detached);
+    co_spawn(io_context, listener(io_context), detached);
 
     io_context.run();
   }

--- a/asio/src/examples/cpp20/operations/composed_1.cpp
+++ b/asio/src/examples/cpp20/operations/composed_1.cpp
@@ -65,7 +65,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -91,7 +91,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -124,7 +124,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp20/operations/composed_2.cpp
+++ b/asio/src/examples/cpp20/operations/composed_2.cpp
@@ -133,7 +133,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -159,7 +159,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -192,7 +192,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp20/operations/composed_3.cpp
+++ b/asio/src/examples/cpp20/operations/composed_3.cpp
@@ -139,7 +139,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -165,7 +165,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -198,7 +198,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp20/operations/composed_4.cpp
+++ b/asio/src/examples/cpp20/operations/composed_4.cpp
@@ -155,7 +155,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -181,7 +181,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -214,7 +214,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp20/operations/composed_5.cpp
+++ b/asio/src/examples/cpp20/operations/composed_5.cpp
@@ -192,7 +192,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -218,7 +218,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -251,7 +251,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp20/operations/composed_6.cpp
+++ b/asio/src/examples/cpp20/operations/composed_6.cpp
@@ -253,7 +253,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -279,7 +279,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -312,7 +312,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp20/operations/composed_7.cpp
+++ b/asio/src/examples/cpp20/operations/composed_7.cpp
@@ -170,7 +170,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -196,7 +196,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -229,7 +229,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.

--- a/asio/src/examples/cpp20/operations/composed_8.cpp
+++ b/asio/src/examples/cpp20/operations/composed_8.cpp
@@ -163,7 +163,7 @@ void test_callback()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using a lambda as a callback.
@@ -189,7 +189,7 @@ void test_deferred()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the deferred completion token. This
@@ -222,7 +222,7 @@ void test_future()
 {
   asio::io_context io_context;
 
-  tcp::acceptor acceptor(io_context, {tcp::v4(), 55555});
+  tcp::acceptor acceptor(io_context, {tcp::v4(), 55557});
   tcp::socket socket = acceptor.accept();
 
   // Test our asynchronous operation using the use_future completion token.


### PR DESCRIPTION
- Try and catch exceptions in echo server listener so that the examples are able to report port binding error.
- Change the use of port 55555 to 55557