### PR TITLE
Fix initialization of sqe->user_data for reuse by io_uring_service.

### DIFF
--- a/asio/include/asio/detail/impl/io_uring_service.ipp
+++ b/asio/include/asio/detail/impl/io_uring_service.ipp
@@ -687,7 +687,10 @@ __kernel_timespec io_uring_service::get_timeout() const
     sqe = ::io_uring_get_sqe(&ring_);
   }
   if (sqe)
+  {
+    ::io_uring_sqe_set_data(sqe, nullptr);
     ++pending_sqes_;
+  }
   return sqe;
 }
 


### PR DESCRIPTION
The value of user_data in a submission queue entry is only initialized with with the ring itself, remaining unchanged after use and even through calls to io_uring_get_sqe(3). Many submission paths apply io_uring_sqe_set_data(3) but the remainder are submitted with stale values that can apply completion operations on the wrong queues with the wrong results, causing obscure bugs.