### PR TITLE
Fix build issue with epoll/io_uring backends for pipes

### DIFF
--- a/asio/include/asio/basic_readable_pipe.hpp
+++ b/asio/include/asio/basic_readable_pipe.hpp
@@ -382,10 +382,8 @@ public:
 #endif
   native_handle_type release()
   {
-    asio::error_code ec;
     native_handle_type s = impl_.get_service().release(
-        impl_.get_implementation(), ec);
-    asio::detail::throw_error(ec, "release");
+        impl_.get_implementation());
     return s;
   }
 
@@ -408,9 +406,9 @@ public:
         "operation_not_supported when used on Windows versions "
         "prior to Windows 8.1."))
 #endif
-  native_handle_type release(asio::error_code& ec)
+  native_handle_type release(asio::error_code&)
   {
-    return impl_.get_service().release(impl_.get_implementation(), ec);
+    return impl_.get_service().release(impl_.get_implementation());
   }
 
   /// Get the native pipe representation.

--- a/asio/include/asio/basic_writable_pipe.hpp
+++ b/asio/include/asio/basic_writable_pipe.hpp
@@ -382,10 +382,8 @@ public:
 #endif
   native_handle_type release()
   {
-    asio::error_code ec;
     native_handle_type s = impl_.get_service().release(
-        impl_.get_implementation(), ec);
-    asio::detail::throw_error(ec, "release");
+        impl_.get_implementation());
     return s;
   }
 
@@ -408,9 +406,9 @@ public:
         "operation_not_supported when used on Windows versions "
         "prior to Windows 8.1."))
 #endif
-  native_handle_type release(asio::error_code& ec)
+  native_handle_type release(asio::error_code&)
   {
-    return impl_.get_service().release(impl_.get_implementation(), ec);
+    return impl_.get_service().release(impl_.get_implementation());
   }
 
   /// Get the native pipe representation.


### PR DESCRIPTION
Code such as the following was failing to build on io_uring prior to this commit:

```cpp
asio::readable_pipe pipe;
pipe.release(ec);
```

I'm not sure if it breaks Windows builds that make uses of `pipe.release()`, but it does fixes the current failing builds on Linux. I'd be happy to update the code to follow any changes required to have this PR merged.

Fixes #1184