### PR TITLE
Fix pipe::release() on io_uring

### DIFF
--- a/asio/include/asio/detail/impl/io_uring_descriptor_service.ipp
+++ b/asio/include/asio/detail/impl/io_uring_descriptor_service.ipp
@@ -144,7 +144,8 @@ asio::error_code io_uring_descriptor_service::close(
 
 io_uring_descriptor_service::native_handle_type
 io_uring_descriptor_service::release(
-    io_uring_descriptor_service::implementation_type& impl)
+    io_uring_descriptor_service::implementation_type& impl,
+    asio::error_code&)
 {
   native_handle_type descriptor = impl.descriptor_;
 

--- a/asio/include/asio/detail/io_uring_descriptor_service.hpp
+++ b/asio/include/asio/detail/io_uring_descriptor_service.hpp
@@ -117,7 +117,8 @@ public:
   }
 
   // Release ownership of the native descriptor representation.
-  ASIO_DECL native_handle_type release(implementation_type& impl);
+  ASIO_DECL native_handle_type release(implementation_type& impl,
+      asio::error_code& ec);
 
   // Cancel all operations associated with the descriptor.
   ASIO_DECL asio::error_code cancel(implementation_type& impl,

--- a/asio/include/asio/detail/io_uring_file_service.hpp
+++ b/asio/include/asio/detail/io_uring_file_service.hpp
@@ -131,8 +131,7 @@ public:
   native_handle_type release(implementation_type& impl,
       asio::error_code& ec)
   {
-    ec = success_ec_;
-    return descriptor_service_.release(impl);
+    return descriptor_service_.release(impl, ec);
   }
 
   // Cancel all operations associated with the file.

--- a/asio/include/asio/posix/basic_descriptor.hpp
+++ b/asio/include/asio/posix/basic_descriptor.hpp
@@ -377,7 +377,8 @@ public:
    */
   native_handle_type release()
   {
-    return impl_.get_service().release(impl_.get_implementation());
+    asio::error_code ignored_ec;
+    return impl_.get_service().release(impl_.get_implementation(), ignored_ec);
   }
 
   /// Cancel all asynchronous operations associated with the descriptor.


### PR DESCRIPTION
Code such as the following was failing to build on io_uring prior to this commit:

```cpp
asio::readable_pipe pipe;
pipe.release(ec);
```

Fixes #1184