### PR TITLE
Set SA_RESTART when establishing an UNIX signal handler by default

### DIFF
--- a/asio/include/asio/detail/impl/signal_set_service.ipp
+++ b/asio/include/asio/detail/impl/signal_set_service.ipp
@@ -342,6 +342,9 @@ asio::error_code signal_set_service::add(
       struct sigaction sa;
       memset(&sa, 0, sizeof(sa));
       sa.sa_handler = asio_signal_handler;
+#  if !defined(ASIO_NO_SET_SA_RESTART)
+      sa.sa_flags = SA_RESTART;
+#  endif
       sigfillset(&sa.sa_mask);
       if (::sigaction(signal_number, &sa, 0) == -1)
 # else // defined(ASIO_HAS_SIGACTION)

--- a/asio/src/doc/using.qbk
+++ b/asio/src/doc/using.qbk
@@ -400,6 +400,13 @@ functionality, and behaviour of Asio.
       types are not passed across shared library API boundaries.
     ]
   ]
+  [
+    [`ASIO_NO_SET_SA_RESTART`]
+    [
+      Disables the use of the flag `SA_RESTART` when establishing signal
+      handlers.
+    ]
+  ]
 ]
 
 [include platform_macros.qbk]


### PR DESCRIPTION
The user doesn't have control over 3rd party library code that he uses in his project. If any code forgets to make use of a macro such as TEMP_FAILURE_RETRY() in *any* syscall, we have a bug.

Signals that interrupt syscalls are a bad default and BSD acknowledged that problem when it changed the default signal semantics to SA_RESTART way back at the release of 4.2BSD. POSIX upstreamed this option through the use of SA_RESTART, and ASIO should be making use of this flag by default (hence this commit).

If any code wants the old behavior, it can opt-out of the new default by defining the macro ASIO_NO_SET_SA_RESTART.

SA_RESTART is only meaningful when we establish a signal handler (asio_signal_handler), so we skip SA_RESTART altogether when sa_handler is set to any other value (SIG_DFL).

Fixes #646