### PR TITLE
Make cancellation_signal movable

### DIFF
--- a/asio/include/asio/cancellation_signal.hpp
+++ b/asio/include/asio/cancellation_signal.hpp
@@ -111,6 +111,12 @@ public:
 
   ASIO_DECL ~cancellation_signal();
 
+#if defined(ASIO_HAS_MOVE)
+  ASIO_DECL cancellation_signal(cancellation_signal&& other) ASIO_NOEXCEPT;
+
+  ASIO_DECL cancellation_signal& operator=(cancellation_signal&& other) ASIO_NOEXCEPT;
+#endif // defined(ASIO_HAS_MOVE)
+
   /// Emits the signal and causes invocation of the slot's handler, if any.
   void emit(cancellation_type_t type)
   {


### PR DESCRIPTION
cancellation_signal is currently not movable, making it a bit cumbersome to use for my case. I tried adding the move assignment operator and constructor. It seems to work for my project. However, I don't  know how the handler destruction here works, so there might be more things that need to be taken care of...