### PR TITLE
fix join() deadlock in thread_pool with no internal threads

### DIFF
--- a/asio/include/asio/impl/thread_pool.ipp
+++ b/asio/include/asio/impl/thread_pool.ipp
@@ -114,11 +114,11 @@ void thread_pool::attach()
 
 void thread_pool::join()
 {
-  if (!threads_.empty())
-  {
+  if (num_threads_)
     scheduler_.work_finished();
+
+  if (!threads_.empty())
     threads_.join();
-  }
 }
 
 detail::scheduler& thread_pool::add_scheduler(detail::scheduler* s)


### PR DESCRIPTION
I believe I've ran into an edge case with `thread_pool`. I'm trying to create a thread pool which doesn't spawn worker threads, instead all the workers `attach()` to it:

```cpp
#include <boost/asio/thread_pool.hpp>
#include <cstddef>
#include <thread>
#include <vector>

struct my_thread_pool : public boost::asio::thread_pool
{
  explicit my_thread_pool(size_t thread_count) :
    boost::asio::thread_pool(0)  // don't spawn threads on your own
  {
    // instead use these std::threads
    for (size_t x = 0; x < thread_count; ++x)
    {
      threads_.emplace_back(
        [this]()
        {
        // ... some thread init code, e.g. change thread priority ...
        boost::asio::thread_pool::attach();
      });
    }
  }

  void join()
  {
    boost::asio::thread_pool::join();
    for (auto& thread : threads_)
      thread.join();
    threads_.clear();
  }

  ~my_thread_pool()
  {
    stop();
    join();
  }

private:
  std::vector<std::thread> threads_;
};
```

However, this code will deadlock

```cpp
int main()
{
  my_thread_pool pool(1);
  pool.join();
}
```

The reason is that the `boost::asio::thread_pool::join()` call is a no-op in case there are 0 internal threads, so attached threads never leave the `attach()`. This contradicts the documentation for `attach()`:

> Blocks the calling thread until the pool is stopped or joined and has no outstanding work.

The fix seems simple enough.

EDIT: I got my code working by calling `boost::asio::thread_pool::wait()` instead of `boost::asio::thread_pool::join()`; this thing does what I wanted it to - It's not explicitly stated in the documentation for `attach()`, but it will also unblock it, unconditionally.