### PR TITLE
Fixes result handling for promise.

### DIFF
--- a/asio/include/asio/experimental/impl/promise.hpp
+++ b/asio/include/asio/experimental/impl/promise.hpp
@@ -228,7 +228,12 @@ struct promise_handler<void(Ts...), Executor, Allocator>
     impl_->done = true;
 
     if (impl_->completion)
-      impl_->complete(std::move(ts)...);
+      impl_->apply(
+        [this](std::remove_reference_t<Ts>... ts_)
+        {
+          impl_->complete(std::move(ts_)...);
+        }
+      );
   }
 };
 

--- a/asio/src/tests/unit/experimental/promise.cpp
+++ b/asio/src/tests/unit/experimental/promise.cpp
@@ -18,6 +18,7 @@
 #include "asio/experimental/promise.hpp"
 
 #include "asio/bind_cancellation_slot.hpp"
+#include "asio/append.hpp"
 #include "asio/compose.hpp"
 #include "asio/deferred.hpp"
 #include "asio/experimental/use_promise.hpp"
@@ -83,7 +84,7 @@ void promise_slot_tester()
   const auto started_when = steady_clock::now();
   timer1.expires_at(started_when + milliseconds(2500));
   timer2.expires_at(started_when + milliseconds(1000));
-  auto p = timer1.async_wait(experimental::use_promise);
+  auto p = timer1.async_wait(asio::append(experimental::use_promise, 123));
 
   steady_clock::time_point completed_when;
   asio::error_code ec;
@@ -93,8 +94,9 @@ void promise_slot_tester()
 
   p(asio::bind_cancellation_slot(
         sig.slot(),
-        [&](asio::error_code ec_)
+        [&](asio::error_code ec_, int i)
         {
+          ASIO_CHECK(i == 123);
           ec = ec_;
           called = true;
           completed_when = steady_clock::now();


### PR DESCRIPTION
I've had a bug where the promise used moved-from values when delivering results & the promise is already waiting. This should fix it.


Closes #1204