### PR TITLE
Fix channel try_send failure after cancel

### DIFF
--- a/asio/include/asio/experimental/detail/impl/channel_service.hpp
+++ b/asio/include/asio/experimental/detail/impl/channel_service.hpp
@@ -246,7 +246,7 @@ void channel_service<Mutex>::cancel(
   if (impl.receive_state_ == waiter)
     impl.receive_state_ = block;
   if (impl.send_state_ == waiter)
-    impl.send_state_ = block;
+    impl.send_state_ = impl.max_buffer_size_ ? buffer : block;
 }
 
 template <typename Mutex>
@@ -294,7 +294,7 @@ void channel_service<Mutex>::cancel_by_key(
     if (impl.receive_state_ == waiter)
       impl.receive_state_ = block;
     if (impl.send_state_ == waiter)
-      impl.send_state_ = block;
+      impl.send_state_ = impl.max_buffer_size_ ? buffer : block;
   }
 }
 


### PR DESCRIPTION
The only case when `impl.send_state_` becomes `waiter` seems to be that an `async_receive` is awaiting on an empty channel, as found in [channel_service.hpp:557](https://github.com/chriskohlhoff/asio/blob/a71f5232d207b4f3bbd253eb1041e30b5e4ea606/asio/include/asio/experimental/detail/impl/channel_service.hpp#L557). As an empty channel, when no one is awaiting on it, whether `send_state_` is `buffer` or `block` should solely depend on whether the channel itself is buffered or not.

Fixes https://github.com/chriskohlhoff/asio/issues/1241