### PR TITLE
reset timer_thread_ in shutdown

### DIFF
--- a/asio/include/asio/detail/impl/win_iocp_io_context.ipp
+++ b/asio/include/asio/detail/impl/win_iocp_io_context.ipp
@@ -168,7 +168,10 @@ void win_iocp_io_context::shutdown()
   }
 
   if (timer_thread_.get())
+  {
     timer_thread_->join();
+    timer_thread_.reset();
+  }
 }
 
 asio::error_code win_iocp_io_context::register_handle(


### PR DESCRIPTION
Resets timer_thread in shutdown for the case when shutdown is called more than once. Fixes https://github.com/chriskohlhoff/asio/issues/1251