### PR TITLE
Added public getter for `concurrency_hint` on the io_context.

### DIFF
--- a/asio/include/asio/impl/io_context.ipp
+++ b/asio/include/asio/impl/io_context.ipp
@@ -169,6 +169,11 @@ void io_context::service::fork_service(io_context::fork_event)
 }
 #endif // !defined(ASIO_NO_DEPRECATED)
 
+int io_context::get_concurrency_hint() const
+{
+  return impl_.concurrency_hint();
+}
+
 } // namespace asio
 
 #include "asio/detail/pop_options.hpp"

--- a/asio/include/asio/io_context.hpp
+++ b/asio/include/asio/io_context.hpp
@@ -628,6 +628,12 @@ public:
   wrap(Handler handler);
 #endif // !defined(ASIO_NO_DEPRECATED)
 
+  /// Get the concurrency_hint passed on construction.
+  /** This hint is a suggestion to the implementation on how many
+   * threads it should allow to run simultaneously.
+   */
+  ASIO_DECL int get_concurrency_hint() const;
+
 private:
   io_context(const io_context&) ASIO_DELETED;
   io_context& operator=(const io_context&) ASIO_DELETED;


### PR DESCRIPTION
This can be very useful for other libraries, as they can use it to base their own concurrency policy on it.

I specifically needs this for my async_mutex library. That is, my mutex will be much simpler for single-threaded environments, which I would like to check by querying the io_context.