### PR TITLE
Add more signal_set_base::flags_t constants

### DIFF
--- a/asio/include/asio/detail/socket_types.hpp
+++ b/asio/include/asio/detail/socket_types.hpp
@@ -180,6 +180,8 @@ typedef int signed_size_type;
 # define ASIO_OS_DEF_AI_ALL 0x100
 # define ASIO_OS_DEF_AI_ADDRCONFIG 0x400
 # define ASIO_OS_DEF_SA_RESTART 0x1
+# define ASIO_OS_DEF_SA_NOCLDSTOP 0x2
+# define ASIO_OS_DEF_SA_NOCLDWAIT 0x4
 #elif defined(ASIO_WINDOWS) || defined(__CYGWIN__)
 typedef SOCKET socket_type;
 const SOCKET invalid_socket = INVALID_SOCKET;
@@ -288,6 +290,8 @@ const int max_iov_len = 64;
 const int max_iov_len = 16;
 # endif
 # define ASIO_OS_DEF_SA_RESTART 0x1
+# define ASIO_OS_DEF_SA_NOCLDSTOP 0x2
+# define ASIO_OS_DEF_SA_NOCLDWAIT 0x4
 #else
 typedef int socket_type;
 const int invalid_socket = -1;
@@ -408,6 +412,8 @@ const int max_iov_len = IOV_MAX;
 const int max_iov_len = 16;
 # endif
 # define ASIO_OS_DEF_SA_RESTART SA_RESTART
+# define ASIO_OS_DEF_SA_NOCLDSTOP SA_NOCLDSTOP
+# define ASIO_OS_DEF_SA_NOCLDWAIT SA_NOCLDWAIT
 #endif
 const int custom_socket_option_level = 0xA5100000;
 const int enable_connection_aborted_option = 1;

--- a/asio/include/asio/signal_set_base.hpp
+++ b/asio/include/asio/signal_set_base.hpp
@@ -41,6 +41,12 @@ public:
     /// fail with error::interrupted.
     restart = implementation_defined,
 
+    /// Do not generate SIGCHLD when children stop or stopped children continue.
+    nocldstop = implementation_defined,
+
+    /// Do not transform children into zombies when they terminate.
+    nocldwait = implementation_defined,
+
     /// Special value to indicate that the signal registration does not care
     /// which flags are set, and so will not conflict with any prior
     /// registrations of the same signal.
@@ -54,6 +60,8 @@ public:
   {
     none = 0,
     restart = ASIO_OS_DEF(SA_RESTART),
+    nocldstop = ASIO_OS_DEF(SA_NOCLDSTOP),
+    nocldwait = ASIO_OS_DEF(SA_NOCLDWAIT),
     dont_care = -1
   };
 
@@ -65,6 +73,8 @@ public:
     {
       none = 0,
       restart = ASIO_OS_DEF(SA_RESTART),
+      nocldstop = ASIO_OS_DEF(SA_NOCLDSTOP),
+      nocldwait = ASIO_OS_DEF(SA_NOCLDWAIT),
       dont_care = -1
     };
   };


### PR DESCRIPTION
This commit only adds useful POSIX constants that don't conflict with asio's signal handling strategy (e.g. SA_SIGINFO would break asio interface, so it's avoided). Non-POSIX constants specific to certain operating systems (e.g. Linux's SA_UNSUPPORTED) are ignored.