### PR TITLE
only test the windows version when targeting old windows versions

### DIFF
--- a/asio/include/asio/detail/impl/win_iocp_io_context.ipp
+++ b/asio/include/asio/detail/impl/win_iocp_io_context.ipp
@@ -530,6 +530,7 @@ size_t win_iocp_io_context::do_one(DWORD msec,
 
 DWORD win_iocp_io_context::get_gqcs_timeout()
 {
+#if !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0600)
   OSVERSIONINFOEX osvi;
   ZeroMemory(&osvi, sizeof(osvi));
   osvi.dwOSVersionInfoSize = sizeof(osvi);
@@ -540,6 +541,7 @@ DWORD win_iocp_io_context::get_gqcs_timeout()
 
   if (!!::VerifyVersionInfo(&osvi, VER_MAJORVERSION, condition_mask))
     return INFINITE;
+#endif // !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0600)
 
   return default_gqcs_timeout;
 }


### PR DESCRIPTION
On non desktop windows targets `VerSetConditionMask` and `VerifyVersionInfo` are not always available. When targeting platforms >= Windows Vista we can skip this check, since it is guaranteed to be true.