### PR TITLE
Default construct T

### DIFF
--- a/asio/include/asio/execution/prefer_only.hpp
+++ b/asio/include/asio/execution/prefer_only.hpp
@@ -210,7 +210,7 @@ struct prefer_only :
 
   template <typename E, typename T = decltype(prefer_only::static_query<E>())>
   static ASIO_CONSTEXPR const T static_query_v
-    = prefer_only::static_query<E>();
+    = {};
 #endif // defined(ASIO_HAS_DEDUCED_STATIC_QUERY_TRAIT)
        //   && defined(ASIO_HAS_SFINAE_VARIABLE_TEMPLATES)
 


### PR DESCRIPTION
Default construct T instead of always constructing prefer_only::static_query<E>()

I am getting a compile error without this change: 
```
error: constexpr variable 'static_query_v<boost::asio::io_context::basic_executor_type<std::allocator<void>, 0>, const boost::asio::execution::detail::outstanding_work_t<0>>' must be initialized by a constant expression
  static BOOST_ASIO_CONSTEXPR const T static_query_v
```
I am still verifying the compiler version, but I am fairly certain it is clang.

I do not know if this is the correct solution. But I figure if I bring it up, you could at least explain to me what the correct solution is and then I can learn more. Thank you for taking a look at this.