### PR TITLE
fix call buffer(const const_buffers_1&,size_t)  

### DIFF
--- a/asio/include/asio/buffer.hpp
+++ b/asio/include/asio/buffer.hpp
@@ -934,6 +934,26 @@ ASIO_NODISCARD inline ASIO_MUTABLE_BUFFER buffer(
         ));
 }
 
+#if (!defined(ASIO_NO_DEPRECATED))&&(!defined(ASIO_BUFFER_ARG_BUFFERS_1_IS_BUFFERSEQUENCE))
+
+/// Create a new modifiable buffer from an existing buffer.
+/// Prevents picking the incorrect generic overloads for continuos sequences/iterators
+/**
+ * @returns A mutable_buffer value equivalent to:
+ * @code mutable_buffer(
+ *     b.data(),
+ *     min(b.size(), max_size_in_bytes)); @endcode
+ */
+template <int unused=0>//template forces merging  multiple definitions at link-time (ODR rule)
+ASIO_NODISCARD inline ASIO_MUTABLE_BUFFER buffer(
+    const mutable_buffers_1& b,
+    std::size_t max_size_in_bytes) ASIO_NOEXCEPT
+{
+   return buffer(static_cast<const mutable_buffer&>(b),max_size_in_bytes);
+}
+#endif
+
+
 /// Create a new non-modifiable buffer from an existing buffer.
 /**
  * @returns <tt>const_buffer(b)</tt>.
@@ -963,6 +983,25 @@ ASIO_NODISCARD inline ASIO_CONST_BUFFER buffer(
 #endif // ASIO_ENABLE_BUFFER_DEBUGGING
       );
 }
+
+#if (!defined(ASIO_NO_DEPRECATED))&&(!defined(ASIO_BUFFER_ARG_BUFFERS_1_IS_BUFFERSEQUENCE))
+
+/// Create a new non-modifiable buffer from an existing buffer.
+/// Prevents picking the incorrect generic overloads for continuos sequences/iterator
+/**
+ * @returns A const_buffer value equivalent to:
+ * @code const_buffer(
+ *     b.data(),
+ *     min(b.size(), max_size_in_bytes)); @endcode
+ */
+template <int unused=0>//template forces merging  multiple definitions at link-time (ODR rule)
+ASIO_NODISCARD inline ASIO_CONST_BUFFER buffer(
+    const const_buffers_1& b,
+    std::size_t max_size_in_bytes) ASIO_NOEXCEPT
+{
+   return buffer(static_cast<const const_buffer&>(b),max_size_in_bytes);
+}
+#endif
 
 /// Create a new modifiable buffer that represents the given memory range.
 /**


### PR DESCRIPTION
and call buffer(const mutable_buffers_1&,size_t)  to get it working 
like they did in boost 1.79/asio 1.22 and before (compatibility issue) 
unless ASIO_BUFFER_ARG_BUFFERS_1_IS_BUFFERSEQUENCE is defined. 
There is a breaking undisclosed runtime change introduced in Asio 1.24.0 / Boost 1.80 : 
"Added buffer() overloads for contiguous containers, such as std::span"
That change invokes incorrectly the generic overloads of function buffer 
designed for Generic Contiguous  Sequences/Containers that 
const_buffers_1 meets technically ,but the sequence creates buffer of buffers 
pointing to const_buffers_1 class location , rather than to its underlaying data