### PR TITLE
Fix `ASIO_ASSUME` definition on older compilers.

### DIFF
--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -2149,11 +2149,11 @@
 # if __has_builtin(__builtin_assume)
 #  define ASIO_ASSUME(expr) __builtin_assume(expr)
 # endif // __has_builtin(__builtin_assume)
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5))
 # define ASIO_ASSUME(expr) if (expr) {} else { __builtin_unreachable(); }
 #endif // defined(__GNUC__)
 #if !defined(ASIO_ASSUME)
-# define ASIO_ASSUME (void)0
+# define ASIO_ASSUME(expr) (void)0
 #endif // !defined(ASIO_ASSUME)
 
 // Support the co_await keyword on compilers known to allow it.


### PR DESCRIPTION
1. gcc 4.4 does not support `__builtin_unreachable`, which makes the `__GNUC__` branch definition to fail.

2. clang 3.5 doesn't support `__builtin_assume` and uses the last fallback option. There, `ASIO_ASSUME` is defined without arguments, meaning it expands to incorrect code like `(void)0(base != 0)`. This also affects any other compilers that are not handled by prior branches.

Fixes https://github.com/chriskohlhoff/asio/issues/1270.

Please, also merge this to Boost before Boost.1.82 is released.
