### PR TITLE
Use thread_local when __thread is not available

### DIFF
--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -2067,8 +2067,13 @@
 # endif // !defined(ASIO_DISABLE_HANDLER_HOOKS)
 #endif // !defined(ASIO_HAS_HANDLER_HOOKS)
 
-// Support for the __thread keyword extension.
+// Support for the __thread or thread_local keyword extension. Prefer __thread
+// over thread_local when possible for performance reasons.
 #if !defined(ASIO_DISABLE_THREAD_KEYWORD_EXTENSION)
+# if !defined(BOOST_NO_CXX11_THREAD_LOCAL)
+#  define BOOST_ASIO_HAS_THREAD_KEYWORD_EXTENSION 1
+#  define BOOST_ASIO_THREAD_KEYWORD thread_local
+# endif // !defined(BOOST_NO_CXX11_THREAD_LOCAL)
 # if defined(__linux__)
 #  if defined(__GNUC__) && (defined(__i386__) || defined(__x86_64__))
 #   if ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3)) || (__GNUC__ > 3)
@@ -2078,6 +2083,7 @@
 #     define ASIO_THREAD_KEYWORD __thread
 #    elif defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 1100)
 #     define ASIO_HAS_THREAD_KEYWORD_EXTENSION 1
+#     define BOOST_ASIO_THREAD_KEYWORD __thread
 #    endif // defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 1100)
            // && !(defined(__clang__) && defined(__ANDROID__))
 #   endif // ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3)) || (__GNUC__ > 3)


### PR DESCRIPTION
Due to the current Boost module configuration, the mechanism used to store per-thread variables on Linux with x86 architectures with GCC is keyword `__thread`. On non-x86 architectures, the code uses a series of pthreads API calls, effectively making per-thread variables inaccessible after they are destroyed. This causes crashes if the `call_stack` variable present in `thread_context` is accessed after boost.asio global variables destructors (can happen if server is stopped in atexit handler or global destruction).

While it is always possible to reorder destructors (e.g. `__attribute(constructor(<priority>))` on GCC), there is no portable way to achieve this.

This change uses preexisting preprocessor definition `BOOST_NO_CXX11_THREAD_LOCAL` to determine whether or not keyword `thread_local` is available, and fallbacks on it in cases where `__thread` is not available. This is an easy, minimal and portable way to address the aforementioned issue.

Please note that many configurations support `__thread`. In the future, we could improve the checks to detect these configurations.