### PR TITLE
solaris compile fix

### DIFF
--- a/asio/include/asio/detail/dev_poll_reactor.hpp
+++ b/asio/include/asio/detail/dev_poll_reactor.hpp
@@ -108,7 +108,7 @@ public:
   {
     start_op(op_type, descriptor, descriptor_data,
         op, is_continuation, allow_speculative,
-        &epoll_reactor::call_post_immediate_completion, this);
+        &dev_poll_reactor::call_post_immediate_completion, this);
   }
 
 


### PR DESCRIPTION
The use of epoll_reactor in dev_poll_reactor.hpp breaks the build on Solaris 10.
I assume this is a copy paste from epoll_reactor.hpp error. This change fixes the build.