### PR TITLE
Prevent new_registration leak on error paths

### DIFF
--- a/asio/include/asio/detail/impl/signal_set_service.ipp
+++ b/asio/include/asio/detail/impl/signal_set_service.ipp
@@ -386,6 +386,7 @@ asio::error_code signal_set_service::add(
         if (state->flags_[signal_number] != signal_set_base::flags::dont_care)
         {
           ec = asio::error::invalid_argument;
+          delete new_registration;
           return ec;
         }
         struct sigaction sa;
@@ -397,6 +398,7 @@ asio::error_code signal_set_service::add(
         {
           ec = asio::error_code(errno,
               asio::error::get_system_category());
+          delete new_registration;
           return ec;
         }
         state->flags_[signal_number] = f;


### PR DESCRIPTION
Since 50ad5e47793521a213eb461da701e8ddd3d5c70d the `new_registration` is leaked in the error paths. Maybe the allocation of `new_registration` could be moved closer to the usage, instead.