### PR TITLE
Enable interrupts to be work again after poll() has been called.

### DIFF
--- a/asio/include/asio/detail/impl/scheduler.ipp
+++ b/asio/include/asio/detail/impl/scheduler.ipp
@@ -587,6 +587,10 @@ std::size_t scheduler::do_poll_one(mutex::scoped_lock& lock,
   if (o == &task_operation_)
   {
     op_queue_.pop();
+
+    bool more_handlers = (!op_queue_.empty());
+    task_interrupted_ = more_handlers;
+
     lock.unlock();
 
     {


### PR DESCRIPTION
I would like to merge this change because I have a custom event loop that calls poll() whenever the reactor is interrupted.  However, because poll() does not reset ```task_interrupted_``` after it has run the task, posting events to the io_context from another thread does not interrupt the io_context like calling run() or wait() does.

I hope its an acceptable bug fix, as this change is essentially making the behavior of poll() match the state change that read() and wait() make,  although I accept my use case integrating asio inside an external event-loop is a bit unusual.
