### PR TITLE
Add the pkgconfigdir location

### DIFF
--- a/asio/Makefile.am
+++ b/asio/Makefile.am
@@ -1,6 +1,7 @@
 AUTOMAKE_OPTIONS = foreign dist-bzip2 dist-zip
 
 pkgconfig_DATA = asio.pc
+pkgconfigdir = $(libdir)/pkgconfig
 
 SUBDIRS = include src
 


### PR DESCRIPTION
Hello Everyone,

Thank you for the great project!

This change is necessary, because while building asio in yocto the compilation is failing and is complaining because the variable is undefined

KR,
Vasileios