### PR TITLE
Fix possible loss of socket descriptor in reactor_op_cancellation on 64-bit platforms

### DIFF
--- a/asio/include/asio/detail/reactive_socket_service_base.hpp
+++ b/asio/include/asio/detail/reactive_socket_service_base.hpp
@@ -700,7 +700,7 @@ protected:
   {
   public:
     reactor_op_cancellation(reactor* r,
-        reactor::per_descriptor_data* p, int d, int o)
+        reactor::per_descriptor_data* p, socket_type d, int o)
       : reactor_(r),
         reactor_data_(p),
         descriptor_(d),
@@ -723,7 +723,7 @@ protected:
   private:
     reactor* reactor_;
     reactor::per_descriptor_data* reactor_data_;
-    int descriptor_;
+    socket_type descriptor_;
     int op_type_;
   };
 


### PR DESCRIPTION
The `descriptor_` field of `reactor_op_cancellation` has `int` type and it is used to store the socket descriptor, but in 64-bit Windows the `SOCKET` type is an alias of `ULONG_PTR` and has size of 64 bits.

This may cause:
- possible loss of socket descriptor in conversion of `socket_type` to `int` in 64-bit Windows
- appearance of lot of conversion warnings when compiling `asio` dependent code for 64-bit Windows.

This pull requests fixes the issue.