### PR TITLE
Workaround for experimental::coro compile error with MSVC

### DIFF
--- a/asio/include/asio/experimental/impl/coro.hpp
+++ b/asio/include/asio/experimental/impl/coro.hpp
@@ -1069,17 +1069,17 @@ struct coro<Yield, Return, Executor, Allocator>::initiate_async_resume
       std::true_type /* error is noexcept */,
       std::true_type /* result is void */)  //noexcept
   {
-    return [this, coro = coro_,
+    return [this, coro_promise_ = coro_,
         h = std::forward<WaitHandler>(handler),
         exec = std::move(exec)]() mutable
     {
-      assert(coro);
+      assert(coro_promise_);
 
-      auto ch = detail::coroutine_handle<promise_type>::from_promise(*coro);
+      auto ch = detail::coroutine_handle<promise_type>::from_promise(*coro_promise_);
       assert(ch && !ch.done());
 
-      coro->awaited_from = post_coroutine(std::move(exec), std::move(h));
-      coro->reset_error();
+      coro_promise_->awaited_from = post_coroutine(std::move(exec), std::move(h));
+      coro_promise_->reset_error();
       ch.resume();
     };
   }
@@ -1090,18 +1090,18 @@ struct coro<Yield, Return, Executor, Allocator>::initiate_async_resume
       std::true_type /* error is noexcept */,
       std::false_type  /* result is void */)  //noexcept
   {
-    return [coro = coro_,
+    return [coro_promise_ = coro_,
         h = std::forward<WaitHandler>(handler),
         exec = std::move(exec)]() mutable
     {
-      assert(coro);
+      assert(coro_promise_);
 
-      auto ch = detail::coroutine_handle<promise_type>::from_promise(*coro);
+      auto ch = detail::coroutine_handle<promise_type>::from_promise(*coro_promise_);
       assert(ch && !ch.done());
 
-      coro->awaited_from = detail::post_coroutine(
-          exec, std::move(h), coro->result_).handle;
-      coro->reset_error();
+      coro_promise_->awaited_from = detail::post_coroutine(
+          exec, std::move(h), coro_promise_->result_).handle;
+      coro_promise_->reset_error();
       ch.resume();
     };
   }
@@ -1111,16 +1111,16 @@ struct coro<Yield, Return, Executor, Allocator>::initiate_async_resume
       std::false_type /* error is noexcept */,
       std::true_type /* result is void */)
   {
-    return [coro = coro_,
+    return [coro_promise_ = coro_,
         h = std::forward<WaitHandler>(handler),
         exec = std::move(exec)]() mutable
     {
-      if (!coro)
+      if (!coro_promise_)
         return asio::post(exec,
             asio::append(std::move(h),
               detail::coro_error<error_type>::invalid()));
 
-      auto ch = detail::coroutine_handle<promise_type>::from_promise(*coro);
+      auto ch = detail::coroutine_handle<promise_type>::from_promise(*coro_promise_);
       if (!ch)
         return asio::post(exec,
             asio::append(std::move(h),
@@ -1131,9 +1131,9 @@ struct coro<Yield, Return, Executor, Allocator>::initiate_async_resume
               detail::coro_error<error_type>::done()));
       else
       {
-        coro->awaited_from = detail::post_coroutine(
-            exec, std::move(h), coro->error_).handle;
-        coro->reset_error();
+        coro_promise_->awaited_from = detail::post_coroutine(
+            exec, std::move(h), coro_promise_->error_).handle;
+        coro_promise_->reset_error();
         ch.resume();
       }
     };
@@ -1144,17 +1144,17 @@ struct coro<Yield, Return, Executor, Allocator>::initiate_async_resume
       std::false_type /* error is noexcept */,
       std::false_type  /* result is void */)
   {
-    return [coro = coro_,
+    return [coro_promise_ = coro_,
         h = std::forward<WaitHandler>(handler),
         exec = std::move(exec)]() mutable
     {
-      if (!coro)
+      if (!coro_promise_)
         return asio::post(exec,
             asio::append(std::move(h),
               detail::coro_error<error_type>::invalid(), result_type{}));
 
       auto ch =
-        detail::coroutine_handle<promise_type>::from_promise(*coro);
+        detail::coroutine_handle<promise_type>::from_promise(*coro_promise_);
       if (!ch)
         return asio::post(exec,
             asio::append(std::move(h),
@@ -1165,9 +1165,9 @@ struct coro<Yield, Return, Executor, Allocator>::initiate_async_resume
               detail::coro_error<error_type>::done(), result_type{}));
       else
       {
-        coro->awaited_from = detail::post_coroutine(
-            exec, std::move(h), coro->error_, coro->result_).handle;
-        coro->reset_error();
+        coro_promise_->awaited_from = detail::post_coroutine(
+            exec, std::move(h), coro_promise_->error_, coro_promise_->result_).handle;
+        coro_promise_->reset_error();
         ch.resume();
       }
     };
@@ -1203,9 +1203,9 @@ struct coro<Yield, Return, Executor, Allocator>::initiate_async_resume
         [h = handle(exec, std::forward<WaitHandler>(handler),
             std::integral_constant<bool, is_noexcept>{},
             std::is_void<result_type>{}),
-            in = std::forward<Input>(input), coro = coro_]() mutable
+            in = std::forward<Input>(input), coro_promise_ = coro_]() mutable
         {
-          coro->input_ = std::move(in);
+          coro_promise_->input_ = std::move(in);
           std::move(h)();
         });
   }


### PR DESCRIPTION
This addresses a problem with MSVC where it incorrectly reports a syntax error when compiling code that uses `asio::experimental::coro`. There is an [existing bug report](https://developercommunity.visualstudio.com/t/Syntax-Error-when-using-boost::asio::exp/10224448) on the Microsoft developer community. However, this can also be fixed in ASIO itself by renaming a few captured lambda variables.