### PR TITLE
Check for null target in query/require/prefer

### DIFF
--- a/asio/include/asio/execution/any_executor.hpp
+++ b/asio/include/asio/execution/any_executor.hpp
@@ -1823,9 +1823,17 @@ public:
         >::value
       >::type* = 0) const
   {
-    typedef find_convertible_property<Property> found;
-    prop_fns_[found::index].query(0, object_fns_->target(*this),
-        &static_cast<const typename found::type&>(p));
+    if (target_)
+    {
+      typedef find_convertible_property<Property> found;
+      prop_fns_[found::index].query(0, object_fns_->target(*this),
+          &static_cast<const typename found::type&>(p));
+    }
+    else
+    {
+      bad_executor ex;
+      asio::detail::throw_exception(ex);
+    }
   }
 
   template <typename Property>
@@ -1842,12 +1850,20 @@ public:
         >::value
       >::type* = 0) const
   {
-    typedef find_convertible_property<Property> found;
-    typename remove_reference<
-      typename found::query_result_type>::type* result = 0;
-    prop_fns_[found::index].query(&result, object_fns_->target(*this),
-        &static_cast<const typename found::type&>(p));
-    return *result;
+    if (target_)
+    {
+      typedef find_convertible_property<Property> found;
+      typename remove_reference<
+        typename found::query_result_type>::type* result = 0;
+      prop_fns_[found::index].query(&result, object_fns_->target(*this),
+          &static_cast<const typename found::type&>(p));
+      return *result;
+    }
+    else
+    {
+      bad_executor ex;
+      asio::detail::throw_exception(ex);
+    }
   }
 
   template <typename Property>
@@ -1864,11 +1880,19 @@ public:
         >::value
       >::type* = 0) const
   {
-    typedef find_convertible_property<Property> found;
-    typename found::query_result_type result;
-    prop_fns_[found::index].query(&result, object_fns_->target(*this),
-        &static_cast<const typename found::type&>(p));
-    return result;
+    if (target_)
+    {
+      typedef find_convertible_property<Property> found;
+      typename found::query_result_type result;
+      prop_fns_[found::index].query(&result, object_fns_->target(*this),
+          &static_cast<const typename found::type&>(p));
+      return result;
+    }
+    else
+    {
+      bad_executor ex;
+      asio::detail::throw_exception(ex);
+    }
   }
 
   template <typename Property>
@@ -1889,12 +1913,20 @@ public:
         >::value
       >::type* = 0) const
   {
-    typedef find_convertible_property<Property> found;
-    typename found::query_result_type* result;
-    prop_fns_[found::index].query(&result, object_fns_->target(*this),
-        &static_cast<const typename found::type&>(p));
-    return *asio::detail::scoped_ptr<
-      typename found::query_result_type>(result);
+    if (target_)
+    {
+      typedef find_convertible_property<Property> found;
+      typename found::query_result_type* result;
+      prop_fns_[found::index].query(&result, object_fns_->target(*this),
+          &static_cast<const typename found::type&>(p));
+      return *asio::detail::scoped_ptr<
+        typename found::query_result_type>(result);
+    }
+    else
+    {
+      bad_executor ex;
+      asio::detail::throw_exception(ex);
+    }
   }
 
   template <typename T>
@@ -1909,9 +1941,17 @@ public:
         find_convertible_requirable_property<Property>::value
       >::type* = 0) const
   {
-    typedef find_convertible_requirable_property<Property> found;
-    return prop_fns_[found::index].require(object_fns_->target(*this),
-        &static_cast<const typename found::type&>(p));
+    if (target_)
+    {
+      typedef find_convertible_requirable_property<Property> found;
+      return prop_fns_[found::index].require(object_fns_->target(*this),
+          &static_cast<const typename found::type&>(p));
+    }
+    else
+    {
+      bad_executor ex;
+      asio::detail::throw_exception(ex);
+    }
   }
 
   template <typename T>
@@ -1926,9 +1966,17 @@ public:
         find_convertible_preferable_property<Property>::value
       >::type* = 0) const
   {
-    typedef find_convertible_preferable_property<Property> found;
-    return prop_fns_[found::index].prefer(object_fns_->target(*this),
-        &static_cast<const typename found::type&>(p));
+    if (target_)
+    {
+      typedef find_convertible_preferable_property<Property> found;
+      return prop_fns_[found::index].prefer(object_fns_->target(*this),
+          &static_cast<const typename found::type&>(p));
+    }
+    else
+    {
+      bad_executor ex;
+      asio::detail::throw_exception(ex);
+    }
   }
 
 //private:
@@ -2306,9 +2354,17 @@ inline void swap(any_executor<SupportableProperties...>& a,
           >::value \
         >::type* = 0) const \
     { \
-      typedef find_convertible_property<Property> found; \
-      prop_fns_[found::index].query(0, object_fns_->target(*this), \
-          &static_cast<const typename found::type&>(p)); \
+      if (target_) \
+      { \
+        typedef find_convertible_property<Property> found; \
+        prop_fns_[found::index].query(0, object_fns_->target(*this), \
+            &static_cast<const typename found::type&>(p)); \
+      } \
+      else \
+      { \
+        bad_executor ex; \
+        asio::detail::throw_exception(ex); \
+      } \
     } \
     \
     template <typename Property> \
@@ -2325,12 +2381,20 @@ inline void swap(any_executor<SupportableProperties...>& a,
           >::value \
         >::type* = 0) const \
     { \
-      typedef find_convertible_property<Property> found; \
-      typename remove_reference< \
-        typename found::query_result_type>::type* result; \
-      prop_fns_[found::index].query(&result, object_fns_->target(*this), \
-          &static_cast<const typename found::type&>(p)); \
-      return *result; \
+      if (target_) \
+      { \
+        typedef find_convertible_property<Property> found; \
+        typename remove_reference< \
+          typename found::query_result_type>::type* result; \
+        prop_fns_[found::index].query(&result, object_fns_->target(*this), \
+            &static_cast<const typename found::type&>(p)); \
+        return *result; \
+      } \
+      else \
+      { \
+        bad_executor ex; \
+        asio::detail::throw_exception(ex); \
+      } \
     } \
     \
     template <typename Property> \
@@ -2347,11 +2411,19 @@ inline void swap(any_executor<SupportableProperties...>& a,
           >::value \
         >::type* = 0) const \
     { \
-      typedef find_convertible_property<Property> found; \
-      typename found::query_result_type result; \
-      prop_fns_[found::index].query(&result, object_fns_->target(*this), \
-          &static_cast<const typename found::type&>(p)); \
-      return result; \
+      if (target_) \
+      { \
+        typedef find_convertible_property<Property> found; \
+        typename found::query_result_type result; \
+        prop_fns_[found::index].query(&result, object_fns_->target(*this), \
+            &static_cast<const typename found::type&>(p)); \
+        return result; \
+      } \
+      else \
+      { \
+        bad_executor ex; \
+        asio::detail::throw_exception(ex); \
+      } \
     } \
     \
     template <typename Property> \
@@ -2372,12 +2444,20 @@ inline void swap(any_executor<SupportableProperties...>& a,
           >::value \
         >::type* = 0) const \
     { \
-      typedef find_convertible_property<Property> found; \
-      typename found::query_result_type* result; \
-      prop_fns_[found::index].query(&result, object_fns_->target(*this), \
-          &static_cast<const typename found::type&>(p)); \
-      return *asio::detail::scoped_ptr< \
-        typename found::query_result_type>(result); \
+      if (target_) \
+      { \
+        typedef find_convertible_property<Property> found; \
+        typename found::query_result_type* result; \
+        prop_fns_[found::index].query(&result, object_fns_->target(*this), \
+            &static_cast<const typename found::type&>(p)); \
+        return *asio::detail::scoped_ptr< \
+          typename found::query_result_type>(result); \
+      } \
+      else \
+      { \
+        bad_executor ex; \
+        asio::detail::throw_exception(ex); \
+      } \
     } \
     \
     template <typename T> \
@@ -2392,9 +2472,17 @@ inline void swap(any_executor<SupportableProperties...>& a,
           find_convertible_requirable_property<Property>::value \
         >::type* = 0) const \
     { \
-      typedef find_convertible_requirable_property<Property> found; \
-      return prop_fns_[found::index].require(object_fns_->target(*this), \
-          &static_cast<const typename found::type&>(p)); \
+      if (target_) \
+      { \
+        typedef find_convertible_requirable_property<Property> found; \
+        return prop_fns_[found::index].require(object_fns_->target(*this), \
+            &static_cast<const typename found::type&>(p)); \
+      } \
+      else \
+      { \
+        bad_executor ex; \
+        asio::detail::throw_exception(ex); \
+      } \
     } \
     \
     template <typename T> \
@@ -2409,9 +2497,17 @@ inline void swap(any_executor<SupportableProperties...>& a,
           find_convertible_preferable_property<Property>::value \
         >::type* = 0) const \
     { \
-      typedef find_convertible_preferable_property<Property> found; \
-      return prop_fns_[found::index].prefer(object_fns_->target(*this), \
-          &static_cast<const typename found::type&>(p)); \
+      if (target_) \
+      { \
+        typedef find_convertible_preferable_property<Property> found; \
+        return prop_fns_[found::index].prefer(object_fns_->target(*this), \
+            &static_cast<const typename found::type&>(p)); \
+      } \
+      else \
+      { \
+        bad_executor ex; \
+        asio::detail::throw_exception(ex); \
+      } \
     } \
     \
     template <typename Ex> \


### PR DESCRIPTION
and throw bad_executor if empty. Fixes #1322.