### PR TITLE
Default empty destructors

### DIFF
--- a/asio/include/asio/ip/bad_address_cast.hpp
+++ b/asio/include/asio/ip/bad_address_cast.hpp
@@ -46,7 +46,7 @@ public:
   }
 
   /// Destructor.
-  virtual ~bad_address_cast() noexcept {}
+  ~bad_address_cast() = default;
 
   /// Get the message associated with the exception.
   virtual const char* what() const noexcept


### PR DESCRIPTION
downstream: https://github.com/boostorg/asio/pull/407

The compiler-generated copy constructor and copy assignment operator are deprecated since C++11 on classes with user-declared destructors.

This change allows clean compilation with the -Wdeprecated-copy-dtor/-Wdeprecated-copy-with-user-provided-dtor flag.

cf. https://github.com/chriskohlhoff/asio/issues/792#issuecomment-1565179044