### PR TITLE
Missing colon symbol in stream.hpp

### DIFF
--- a/asio/include/asio/ssl/stream.hpp
+++ b/asio/include/asio/ssl/stream.hpp
@@ -55,7 +55,7 @@ namespace ssl {
  * @code
  * asio::io_context my_context;
  * asio::ssl::context ctx(asio::ssl::context::sslv23);
- * asio::ssl::stream<asio:ip::tcp::socket> sock(my_context, ctx);
+ * asio::ssl::stream<asio::ip::tcp::socket> sock(my_context, ctx);
  * @endcode
  *
  * @par Concepts:


### PR DESCRIPTION
Add missing colon symbol in ssl/stream.hpp example code.

Ps. I'm also not sure about the default context in your example, should that not be a client context (eg. `boost::asio::ssl::context::tlsv12_client`)? But I digress...