### PR TITLE
Add macro ASIO_DISABLE_FIONBIO

### DIFF
--- a/asio/include/asio/detail/impl/descriptor_ops.ipp
+++ b/asio/include/asio/detail/impl/descriptor_ops.ipp
@@ -63,11 +63,11 @@ int close(int d, state_type& state, asio::error_code& ec)
       // current OS where this behaviour is seen, Windows, says that the socket
       // remains open. Therefore we'll put the descriptor back into blocking
       // mode and have another attempt at closing it.
-#if defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__)
+#if defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__) || defined(ASIO_DISABLE_FIONBIO)
       int flags = ::fcntl(d, F_GETFL, 0);
       if (flags >= 0)
         ::fcntl(d, F_SETFL, flags & ~O_NONBLOCK);
-#else // defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__)
+#else // defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__) || defined(ASIO_DISABLE_FIONBIO)
       ioctl_arg_type arg = 0;
 # if defined(ENOTTY)
       result = ::ioctl(d, FIONBIO, &arg);
@@ -81,7 +81,7 @@ int close(int d, state_type& state, asio::error_code& ec)
 # else // defined(ENOTTY)
       ::ioctl(d, FIONBIO, &arg);
 # endif // defined(ENOTTY)
-#endif // defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__)
+#endif // defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__) || defined(ASIO_DISABLE_FIONBIO)
       state &= ~non_blocking;
 
       result = ::close(d);
@@ -101,7 +101,7 @@ bool set_user_non_blocking(int d, state_type& state,
     return false;
   }
 
-#if defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__)
+#if defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__) || defined(ASIO_DISABLE_FIONBIO)
   int result = ::fcntl(d, F_GETFL, 0);
   get_last_error(ec, result < 0);
   if (result >= 0)
@@ -110,7 +110,7 @@ bool set_user_non_blocking(int d, state_type& state,
     result = ::fcntl(d, F_SETFL, flag);
     get_last_error(ec, result < 0);
   }
-#else // defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__)
+#else // defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__) || defined(ASIO_DISABLE_FIONBIO)
   ioctl_arg_type arg = (value ? 1 : 0);
   int result = ::ioctl(d, FIONBIO, &arg);
   get_last_error(ec, result < 0);
@@ -127,7 +127,7 @@ bool set_user_non_blocking(int d, state_type& state,
     }
   }
 # endif // defined(ENOTTY)
-#endif // defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__)
+#endif // defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__) || defined(ASIO_DISABLE_FIONBIO)
 
   if (result >= 0)
   {
@@ -164,7 +164,7 @@ bool set_internal_non_blocking(int d, state_type& state,
     return false;
   }
 
-#if defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__)
+#if defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__) || defined(ASIO_DISABLE_FIONBIO)
   int result = ::fcntl(d, F_GETFL, 0);
   get_last_error(ec, result < 0);
   if (result >= 0)
@@ -173,7 +173,7 @@ bool set_internal_non_blocking(int d, state_type& state,
     result = ::fcntl(d, F_SETFL, flag);
     get_last_error(ec, result < 0);
   }
-#else // defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__)
+#else // defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__) || defined(ASIO_DISABLE_FIONBIO)
   ioctl_arg_type arg = (value ? 1 : 0);
   int result = ::ioctl(d, FIONBIO, &arg);
   get_last_error(ec, result < 0);
@@ -190,7 +190,7 @@ bool set_internal_non_blocking(int d, state_type& state,
     }
   }
 # endif // defined(ENOTTY)
-#endif // defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__)
+#endif // defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__) || defined(ASIO_DISABLE_FIONBIO)
 
   if (result >= 0)
   {

--- a/asio/include/asio/detail/impl/socket_ops.ipp
+++ b/asio/include/asio/detail/impl/socket_ops.ipp
@@ -333,14 +333,14 @@ int close(socket_type s, state_type& state,
       ioctl_arg_type arg = 0;
       ::ioctlsocket(s, FIONBIO, &arg);
 #else // defined(ASIO_WINDOWS) || defined(__CYGWIN__)
-# if defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__)
+# if defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__) || defined(ASIO_DISABLE_FIONBIO)
       int flags = ::fcntl(s, F_GETFL, 0);
       if (flags >= 0)
         ::fcntl(s, F_SETFL, flags & ~O_NONBLOCK);
-# else // defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__)
+# else // defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__) || defined(ASIO_DISABLE_FIONBIO)
       ioctl_arg_type arg = 0;
       ::ioctl(s, FIONBIO, &arg);
-# endif // defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__)
+# endif // defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__) || defined(ASIO_DISABLE_FIONBIO)
 #endif // defined(ASIO_WINDOWS) || defined(__CYGWIN__)
       state &= ~non_blocking;
 
@@ -369,7 +369,7 @@ bool set_user_non_blocking(socket_type s,
   ioctl_arg_type arg = (value ? 1 : 0);
   int result = ::ioctlsocket(s, FIONBIO, &arg);
   get_last_error(ec, result < 0);
-#elif defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__)
+#elif defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__) || defined(ASIO_DISABLE_FIONBIO)
   int result = ::fcntl(s, F_GETFL, 0);
   get_last_error(ec, result < 0);
   if (result >= 0)
@@ -423,7 +423,7 @@ bool set_internal_non_blocking(socket_type s,
   ioctl_arg_type arg = (value ? 1 : 0);
   int result = ::ioctlsocket(s, FIONBIO, &arg);
   get_last_error(ec, result < 0);
-#elif defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__)
+#elif defined(__SYMBIAN32__) || defined(__EMSCRIPTEN__) || defined(ASIO_DISABLE_FIONBIO)
   int result = ::fcntl(s, F_GETFL, 0);
   get_last_error(ec, result < 0);
   if (result >= 0)

--- a/asio/src/doc/using.qbk
+++ b/asio/src/doc/using.qbk
@@ -240,6 +240,17 @@ functionality, and behaviour of Asio.
     ]
   ]
   [
+    [`ASIO_DISABLE_FIONBIO`]
+    [
+      Explicitly disables `FIONBIO` support, forcing the use of a `fcntl`-based
+      implementation.
+
+      `FIONBIO` is known to cause assorted problems, specially on FreeBSD
+      (e.g. capsicum, nested kqueue). Use this macro if you're one of the
+      affected users.
+    ]
+  ]
+  [
     [`ASIO_DISABLE_DEV_POLL`]
     [
       Explicitly disables [^/dev/poll] support on Solaris, forcing the use of


### PR DESCRIPTION
On FreeBSD, sockets received from capsicum processes will return ENOTCAPABLE on ioctls. In this scenario, fcntl() is the preferred approach to put the file descriptor in non-blocking mode.

Furthermore, nested kqueues are prevented w/o this patch. FIONBIO is not implemented by kqueue file descriptors. So it's impossible to use ASIO (nested kqueue through posix::stream_descriptor) to await for a procdesc to finish, as an example.

It's also generally unsafe to perform any ioctl on file descriptors received from untrusted processes. Linux is slowly adding support for this type of sandbox through Landlock, so it's not just a FreeBSD problem.

FIONBIO already caused problems to ASIO in this past (cf. commit 607f99ba80df71f1a96f0df71725059ee71e46ff). This patch only exposes a knob that users can also resort to when FIONBIO fail on them.