### PR TITLE
allow change the size

### DIFF
--- a/asio/include/asio/completion_condition.hpp
+++ b/asio/include/asio/completion_condition.hpp
@@ -25,7 +25,16 @@ namespace asio {
 namespace detail {
 
 // The default maximum number of bytes to transfer in a single operation.
-enum default_max_transfer_size_t { default_max_transfer_size = 65536 };
+enum default_max_transfer_size_t 
+{
+#if defined(ASIO_HAS_FILE) \
+  && defined(ASIO_HAS_IO_URING) \
+  && defined(ASIO_SPEC_MAX_TRANSFER_SIZE)
+  default_max_transfer_size = ASIO_SPEC_MAX_TRANSFER_SIZE
+#else
+  default_max_transfer_size = 65536
+#endif
+};
 
 // Adapt result of old-style completion conditions (which had a bool result
 // where true indicated that the operation was complete).


### PR DESCRIPTION
change default_max_transfer_size_t for io_uring file,  because the default max size is not enough.

usage:

```
#define ASIO_SPEC_MAX_TRANSFER_SIZE 262144
```
read/read_at io_uring file will apply the value of default_max_transfer_size to  ASIO_SPEC_MAX_TRANSFER_SIZE.
