### PR TITLE
Use 2.2 Specification when initializing Winsock

### DIFF
--- a/asio/include/asio/detail/winsock_init.hpp
+++ b/asio/include/asio/detail/winsock_init.hpp
@@ -47,7 +47,7 @@ protected:
   ASIO_DECL static void throw_on_error(data& d);
 };
 
-template <int Major = 2, int Minor = 0>
+template <int Major = 2, int Minor = 2>
 class winsock_init : private winsock_init_base
 {
 public:


### PR DESCRIPTION
Closes #930.