### PR TITLE
Update cirrus image to freebsd-14-0

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-13-0
+  image_family: freebsd-14-0
   cpu: 1
 
 env:


### PR DESCRIPTION
* freebsd-13-0 image is no longer available

Updated to use latest available release
https://cirrus-ci.org/guide/FreeBSD/#list-of-available-image-families