### PR TITLE
Updated checkout action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,7 @@ jobs:
       CXX: ${{ matrix.compiler }}
       CXXFLAGS: -std=${{ matrix.cxx-std }} ${{ matrix.cxx-stdlib }} ${{ matrix.optim-level }} -Wall -Wextra ${{ matrix.no-deprecated }} ${{ matrix.select-reactor }} ${{ matrix.handler-tracking }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install autotools
       if: startsWith(matrix.runs-on, 'macos')
       run: brew install automake


### PR DESCRIPTION
Resolves warnings:
```
Node.js 16 actions are deprecated.
Please update the following actions to use Node.js 20: actions/checkout@v2.
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
```