### PR TITLE
Fix documented minimum G++ version for asio

### DIFF
--- a/asio/src/doc/using.qbk
+++ b/asio/src/doc/using.qbk
@@ -11,7 +11,7 @@
 
 The following platform and compiler combinations are regularly tested:
 
-* Linux using g++ 4.6 or later
+* Linux using g++ 5.0 or later
 * Linux using clang 3.4 or later
 * FreeBSD using g++ 9 or later
 * macOS using Xcode 10 or later


### PR DESCRIPTION
per https://gcc.gnu.org/bugzilla/show_bug.cgi?id=57350 g++ before 5.0 does not have std::align, which asio uses in `asio/detail/memory.hpp` without checking for it's availability, meaning g++ 5 is the minimum version supported.