### PR TITLE
Use std::aligned_alloc on Android when available

### DIFF
--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -387,7 +387,9 @@
 #    if defined(ASIO_HAS_CLANG_LIBCXX)
 #     if (_LIBCPP_STD_VER > 14) && defined(_LIBCPP_HAS_ALIGNED_ALLOC) \
         && !defined(_LIBCPP_MSVCRT) && !defined(__MINGW32__)
-#      if defined(__APPLE__)
+#      if defined(__ANDROID__) && (__ANDROID_API__ >= 28)
+#        define ASIO_HAS_STD_ALIGNED_ALLOC 1
+#      elif defined(__APPLE__)
 #       if defined(__MAC_OS_X_VERSION_MIN_REQUIRED)
 #        if (__MAC_OS_X_VERSION_MIN_REQUIRED >= 101500)
 #         define ASIO_HAS_STD_ALIGNED_ALLOC 1


### PR DESCRIPTION
`aligned_alloc` [was introduced](https://android.googlesource.com/platform/bionic/+/master/docs/status.md) along with Android API level 28.