### PR TITLE
Use WSAConnect when socket has been created by WSASocket

### DIFF
--- a/asio/include/asio/detail/impl/socket_ops.ipp
+++ b/asio/include/asio/detail/impl/socket_ops.ipp
@@ -467,8 +467,13 @@ template <typename SockLenType>
 inline int call_connect(SockLenType msghdr::*,
     socket_type s, const void* addr, std::size_t addrlen)
 {
+#if defined(ASIO_WINDOWS) || defined(__CYGWIN__)
+  return ::WSAConnect(s, static_cast<const socket_addr_type*>(addr),
+      (SockLenType)addrlen, 0, 0, 0, 0);
+#else
   return ::connect(s, static_cast<const socket_addr_type*>(addr),
       (SockLenType)addrlen);
+#endif
 }
 
 int connect(socket_type s, const void* addr,


### PR DESCRIPTION
Otherwise it is possible that the ::connect() might return code

    10038 An operation was attempted on something that is not a socket.

In particular it happens when trying to use ASIO inside Ruby native extension on Windows (which is using MinGW).