### PR TITLE
Move file offset to the end when `file_base::append` is specified for windows iocp file service.

### DIFF
--- a/asio/include/asio/detail/impl/win_iocp_file_service.ipp
+++ b/asio/include/asio/detail/impl/win_iocp_file_service.ipp
@@ -97,15 +97,26 @@ asio::error_code win_iocp_file_service::open(
   HANDLE handle = ::CreateFileA(path, access, share, 0, disposition, flags, 0);
   if (handle != INVALID_HANDLE_VALUE)
   {
-    if (disposition == OPEN_ALWAYS && (open_flags & file_base::truncate) != 0)
-    {
-      if (!::SetEndOfFile(handle))
+    if (disposition == OPEN_ALWAYS) {
+      if ((open_flags & file_base::truncate) != 0)
       {
-        DWORD last_error = ::GetLastError();
-        ::CloseHandle(handle);
-        ec.assign(last_error, asio::error::get_system_category());
-        ASIO_ERROR_LOCATION(ec);
-        return ec;
+        if (!::SetEndOfFile(handle))
+        {
+          DWORD last_error = ::GetLastError();
+          ::CloseHandle(handle);
+          ec.assign(last_error, asio::error::get_system_category());
+          ASIO_ERROR_LOCATION(ec);
+          return ec;
+        }
+      } else if ((open_flags & file_base::append) != 0) {
+        if (::SetFilePointer(handle, 0, NULL, FILE_END) ==
+            INVALID_SET_FILE_POINTER) {
+          DWORD last_error = ::GetLastError();
+          ::CloseHandle(handle);
+          ec.assign(last_error, asio::error::get_system_category());
+          ASIO_ERROR_LOCATION(ec);
+          return ec;
+        }
       }
     }
 


### PR DESCRIPTION
`asio::file_base::append` has no effect when opening `asio::stream_file` on windows due to the lack of equivalent functionality of `O_APPEND` for Window APIs.

The workaround is to move the file offset to the end after opening the file for the `win_iocp_file_service::open()`, or the documentation should mention such limitation ?

`O_APPEND`: always write the data to the end of file no matter where the file offset is.