### PR TITLE
Set SO_REUSEPORT on Linux if available

### DIFF
--- a/asio/include/asio/detail/impl/socket_ops.ipp
+++ b/asio/include/asio/detail/impl/socket_ops.ipp
@@ -1980,7 +1980,8 @@ int setsockopt(socket_type s, state_type& state, int level, int optname,
   {
 #if defined(__MACH__) && defined(__APPLE__) \
   || defined(__NetBSD__) || defined(__FreeBSD__) \
-  || defined(__OpenBSD__) || defined(__QNX__)
+  || defined(__OpenBSD__) || defined(__QNX__) \
+  || (defined(__linux__) && defined(SO_REUSEPORT))
     // To implement portable behaviour for SO_REUSEADDR with UDP sockets we
     // need to also set SO_REUSEPORT on BSD-based platforms.
     if ((state & datagram_oriented)


### PR DESCRIPTION
Closes https://github.com/chriskohlhoff/asio/issues/106.

Since Linux 3.9 the SO_REUSEPORT option is also available. This allows for e.g. to use several UDP sockets listening to the same broadcasts within a process.

I'm not sure if it would be better to add a `asio::socket_base::reuse_port` instead, since one might want to set one but not the other.