### PR TITLE
using constexpr inline for global tag types.

### DIFF
--- a/asio/include/asio/deferred.hpp
+++ b/asio/include/asio/deferred.hpp
@@ -704,7 +704,7 @@ inline auto operator|(Head head, Tail&& tail)
 /**
  * See the documentation for asio::deferred_t for a usage example.
  */
-constexpr deferred_t deferred;
+ASIO_INLINE_CONSTEXPR deferred_t deferred;
 
 } // namespace asio
 

--- a/asio/include/asio/detached.hpp
+++ b/asio/include/asio/detached.hpp
@@ -94,7 +94,7 @@ public:
 /**
  * See the documentation for asio::detached_t for a usage example.
  */
-constexpr detached_t detached;
+ASIO_INLINE_CONSTEXPR detached_t detached;
 
 } // namespace asio
 

--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -1419,4 +1419,10 @@
 # endif // !defined(ASIO_DISABLE_SNPRINTF)
 #endif // !defined(ASIO_HAS_SNPRINTF)
 
+#if defined(__cpp_inline_variables) && __cpp_inline_variables >= 201606L
+#define ASIO_INLINE_CONSTEXPR constexpr inline
+#else
+#define ASIO_INLINE_CONSTEXPR constexpr
+#endif
+
 #endif // ASIO_DETAIL_CONFIG_HPP

--- a/asio/include/asio/execution/allocator.hpp
+++ b/asio/include/asio/execution/allocator.hpp
@@ -63,7 +63,7 @@ struct allocator_t
 };
 
 /// A special value used for accessing the allocator_t property.
-constexpr allocator_t<void> allocator;
+ASIO_INLINE_CONSTEXPR allocator_t<void> allocator;
 
 } // namespace execution
 
@@ -225,7 +225,7 @@ const T allocator_t<void>::static_query_v;
 #endif // defined(ASIO_HAS_DEDUCED_STATIC_QUERY_TRAIT)
        //   && defined(ASIO_HAS_SFINAE_VARIABLE_TEMPLATES)
 
-constexpr allocator_t<void> allocator;
+ASIO_INLINE_CONSTEXPR allocator_t<void> allocator;
 
 } // namespace execution
 

--- a/asio/include/asio/execution/blocking.hpp
+++ b/asio/include/asio/execution/blocking.hpp
@@ -169,7 +169,7 @@ struct blocking_t
 };
 
 /// A special value used for accessing the blocking_t property.
-constexpr blocking_t blocking;
+ASIO_INLINE_CONSTEXPR blocking_t blocking;
 
 } // namespace execution
 
@@ -892,7 +892,7 @@ const T never_t<I>::static_query_v;
 
 typedef detail::blocking_t<> blocking_t;
 
-constexpr blocking_t blocking;
+ASIO_INLINE_CONSTEXPR blocking_t blocking;
 
 } // namespace execution
 

--- a/asio/include/asio/execution/blocking_adaptation.hpp
+++ b/asio/include/asio/execution/blocking_adaptation.hpp
@@ -136,7 +136,7 @@ struct blocking_adaptation_t
 };
 
 /// A special value used for accessing the blocking_adaptation_t property.
-constexpr blocking_adaptation_t blocking_adaptation;
+ASIO_INLINE_CONSTEXPR blocking_adaptation_t blocking_adaptation;
 
 } // namespace execution
 
@@ -718,7 +718,7 @@ void blocking_execute(
 
 typedef detail::blocking_adaptation_t<> blocking_adaptation_t;
 
-constexpr blocking_adaptation_t blocking_adaptation;
+ASIO_INLINE_CONSTEXPR blocking_adaptation_t blocking_adaptation;
 
 } // namespace execution
 

--- a/asio/include/asio/execution/context.hpp
+++ b/asio/include/asio/execution/context.hpp
@@ -53,7 +53,7 @@ struct context_t
 };
 
 /// A special value used for accessing the context_t property.
-constexpr context_t context;
+ASIO_INLINE_CONSTEXPR context_t context;
 
 } // namespace execution
 
@@ -138,7 +138,7 @@ const T context_t<I>::static_query_v;
 
 typedef detail::context_t<> context_t;
 
-constexpr context_t context;
+ASIO_INLINE_CONSTEXPR context_t context;
 
 } // namespace execution
 

--- a/asio/include/asio/execution/mapping.hpp
+++ b/asio/include/asio/execution/mapping.hpp
@@ -163,7 +163,7 @@ struct mapping_t
 };
 
 /// A special value used for accessing the mapping_t property.
-constexpr mapping_t mapping;
+ASIO_INLINE_CONSTEXPR mapping_t mapping;
 
 } // namespace execution
 
@@ -733,7 +733,7 @@ const T other_t<I>::static_query_v;
 
 typedef detail::mapping_t<> mapping_t;
 
-constexpr mapping_t mapping;
+ASIO_INLINE_CONSTEXPR mapping_t mapping;
 
 } // namespace execution
 

--- a/asio/include/asio/execution/occupancy.hpp
+++ b/asio/include/asio/execution/occupancy.hpp
@@ -49,7 +49,7 @@ struct occupancy_t
 };
 
 /// A special value used for accessing the occupancy_t property.
-constexpr occupancy_t occupancy;
+ASIO_INLINE_CONSTEXPR occupancy_t occupancy;
 
 } // namespace execution
 
@@ -131,7 +131,7 @@ const T occupancy_t<I>::static_query_v;
 
 typedef detail::occupancy_t<> occupancy_t;
 
-constexpr occupancy_t occupancy;
+ASIO_INLINE_CONSTEXPR occupancy_t occupancy;
 
 } // namespace execution
 

--- a/asio/include/asio/execution/outstanding_work.hpp
+++ b/asio/include/asio/execution/outstanding_work.hpp
@@ -131,7 +131,7 @@ struct outstanding_work_t
 };
 
 /// A special value used for accessing the outstanding_work_t property.
-constexpr outstanding_work_t outstanding_work;
+ASIO_INLINE_CONSTEXPR outstanding_work_t outstanding_work;
 
 } // namespace execution
 
@@ -544,7 +544,7 @@ const T tracked_t<I>::static_query_v;
 
 typedef detail::outstanding_work_t<> outstanding_work_t;
 
-constexpr outstanding_work_t outstanding_work;
+ASIO_INLINE_CONSTEXPR outstanding_work_t outstanding_work;
 
 } // namespace execution
 

--- a/asio/include/asio/execution/relationship.hpp
+++ b/asio/include/asio/execution/relationship.hpp
@@ -131,7 +131,7 @@ struct relationship_t
 };
 
 /// A special value used for accessing the relationship_t property.
-constexpr relationship_t relationship;
+ASIO_INLINE_CONSTEXPR relationship_t relationship;
 
 } // namespace execution
 
@@ -542,7 +542,7 @@ const T continuation_t<I>::static_query_v;
 
 typedef detail::relationship_t<> relationship_t;
 
-constexpr relationship_t relationship;
+ASIO_INLINE_CONSTEXPR relationship_t relationship;
 
 } // namespace execution
 

--- a/asio/include/asio/experimental/use_coro.hpp
+++ b/asio/include/asio/experimental/use_coro.hpp
@@ -173,9 +173,9 @@ private:
  * See the documentation for asio::use_coro_t for a usage example.
  */
 #if defined(GENERATING_DOCUMENTATION)
-constexpr use_coro_t<> use_coro;
+ASIO_INLINE_CONSTEXPR use_coro_t<> use_coro;
 #else
-constexpr use_coro_t<> use_coro(0, 0, 0);
+ASIO_INLINE_CONSTEXPR use_coro_t<> use_coro(0, 0, 0);
 #endif
 
 } // namespace experimental

--- a/asio/include/asio/experimental/use_promise.hpp
+++ b/asio/include/asio/experimental/use_promise.hpp
@@ -99,7 +99,7 @@ private:
   Allocator allocator_;
 };
 
-constexpr use_promise_t<> use_promise;
+ASIO_INLINE_CONSTEXPR use_promise_t<> use_promise;
 
 } // namespace experimental
 } // namespace asio

--- a/asio/include/asio/placeholders.hpp
+++ b/asio/include/asio/placeholders.hpp
@@ -58,12 +58,12 @@ unspecified signal_number;
 
 #else
 
-static constexpr auto& error = std::placeholders::_1;
-static constexpr auto& bytes_transferred = std::placeholders::_2;
-static constexpr auto& iterator = std::placeholders::_2;
-static constexpr auto& results = std::placeholders::_2;
-static constexpr auto& endpoint = std::placeholders::_2;
-static constexpr auto& signal_number = std::placeholders::_2;
+static ASIO_INLINE_CONSTEXPR auto& error = std::placeholders::_1;
+static ASIO_INLINE_CONSTEXPR auto& bytes_transferred = std::placeholders::_2;
+static ASIO_INLINE_CONSTEXPR auto& iterator = std::placeholders::_2;
+static ASIO_INLINE_CONSTEXPR auto& results = std::placeholders::_2;
+static ASIO_INLINE_CONSTEXPR auto& endpoint = std::placeholders::_2;
+static ASIO_INLINE_CONSTEXPR auto& signal_number = std::placeholders::_2;
 
 #endif
 

--- a/asio/include/asio/this_coro.hpp
+++ b/asio/include/asio/this_coro.hpp
@@ -32,7 +32,7 @@ struct executor_t
 };
 
 /// Awaitable object that returns the executor of the current coroutine.
-constexpr executor_t executor;
+ASIO_INLINE_CONSTEXPR executor_t executor;
 
 /// Awaitable type that returns the cancellation state of the current coroutine.
 struct cancellation_state_t
@@ -57,7 +57,7 @@ struct cancellation_state_t
  *     // ...
  * } @endcode
  */
-constexpr cancellation_state_t cancellation_state;
+ASIO_INLINE_CONSTEXPR cancellation_state_t cancellation_state;
 
 #if defined(GENERATING_DOCUMENTATION)
 

--- a/asio/include/asio/use_awaitable.hpp
+++ b/asio/include/asio/use_awaitable.hpp
@@ -145,9 +145,9 @@ struct use_awaitable_t
  * See the documentation for asio::use_awaitable_t for a usage example.
  */
 #if defined(GENERATING_DOCUMENTATION)
-constexpr use_awaitable_t<> use_awaitable;
+ASIO_INLINE_CONSTEXPR use_awaitable_t<> use_awaitable;
 #else
-constexpr use_awaitable_t<> use_awaitable(0, 0, 0);
+ASIO_INLINE_CONSTEXPR use_awaitable_t<> use_awaitable(0, 0, 0);
 #endif
 
 } // namespace asio

--- a/asio/include/asio/use_future.hpp
+++ b/asio/include/asio/use_future.hpp
@@ -145,7 +145,7 @@ private:
 /**
  * See the documentation for asio::use_future_t for a usage example.
  */
-constexpr use_future_t<> use_future;
+ASIO_INLINE_CONSTEXPR use_future_t<> use_future;
 
 } // namespace asio
 

--- a/asio/include/asio/uses_executor.hpp
+++ b/asio/include/asio/uses_executor.hpp
@@ -45,7 +45,7 @@ struct executor_arg_t
  * See asio::executor_arg_t and asio::uses_executor
  * for more information.
  */
-constexpr executor_arg_t executor_arg;
+ASIO_INLINE_CONSTEXPR executor_arg_t executor_arg;
 
 /// The uses_executor trait detects whether a type T has an associated executor
 /// that is convertible from type Executor.


### PR DESCRIPTION
Hi Chris,

I am working on experimental module support for boost and it complains about exporting none-inline global variables. 

Declaring them inline seems like the correct thing to do anyhow.