### PR TITLE
Fix return type in default_immediate_executor

### DIFF
--- a/asio/include/asio/associated_immediate_executor.hpp
+++ b/asio/include/asio/associated_immediate_executor.hpp
@@ -49,7 +49,7 @@ struct has_immediate_executor_type<T,
 template <typename E, typename = void, typename = void>
 struct default_immediate_executor
 {
-  typedef require_result_t<E, execution::blocking_t::never_t> type;
+  typedef require_result_t<const E&, execution::blocking_t::never_t> type;
 
   static type get(const E& e) noexcept
   {


### PR DESCRIPTION
The issue is reproducible with the following code:
https://godbolt.org/z/s6Encj5od
```C++
#include <boost/asio.hpp>

using namespace boost;

struct executor
{
  asio::io_context* context_{ nullptr };

  bool operator==(const executor& other) const noexcept
  {
    return context_ == other.context_;
  }

  bool operator!=(const executor& other) const noexcept
  {
    return !(*this == other);
  }

  asio::execution_context& query(asio::execution::context_t) const noexcept
  {
    return *context_;
  }

  static constexpr asio::execution::blocking_t::never_t query(
    asio::execution::blocking_t) noexcept
  {
    return asio::execution::blocking.never;
  }

  constexpr executor require(asio::execution::blocking_t::never_t) const
  {
    return *this;
  }

  template<class F>
  void execute(F&& f) const
  {
    context_->get_executor().execute(std::forward<F>(f));
  }
};

int main()
{
  asio::io_context ioc;
  auto e = asio::get_associated_immediate_executor([] {}, executor{ &ioc });
}
```

```BASH
In file included from /opt/compiler-explorer/libs/boost_1_84_0/boost/asio/any_completion_handler.hpp:24,
                 from /opt/compiler-explorer/libs/boost_1_84_0/boost/asio.hpp:21,
                 from <source>:1:
/opt/compiler-explorer/libs/boost_1_84_0/boost/asio/associated_immediate_executor.hpp: In instantiation of 'static boost::asio::detail::default_immediate_executor<E, <template-parameter-1-2>, <template-parameter-1-3> >::type boost::asio::detail::default_immediate_executor<E, <template-parameter-1-2>, <template-parameter-1-3> >::get(const E&) [with E = executor; <template-parameter-1-2> = void; <template-parameter-1-3> = void; type = executor&&]':
/opt/compiler-explorer/libs/boost_1_84_0/boost/asio/associated_immediate_executor.hpp:129:46:   required from 'static decltype (boost::asio::detail::default_immediate_executor<E>::get(e)) boost::asio::detail::associated_immediate_executor_impl<T, E, <template-parameter-1-3>, <template-parameter-1-4> >::get(const T&, const E&) [with T = main()::<lambda()>; E = executor; <template-parameter-1-3> = void; <template-parameter-1-4> = void; decltype (boost::asio::detail::default_immediate_executor<E>::get(e)) = executor&&]'
/opt/compiler-explorer/libs/boost_1_84_0/boost/asio/associated_immediate_executor.hpp:210:57:   required from 'decltype (boost::asio::associated_immediate_executor<T, Executor>::get(t, ex)) boost::asio::get_associated_immediate_executor(const T&, const Executor&, constraint_t<(is_executor<Executor>::value || execution::is_executor<Executor>::value)>) [with T = main()::<lambda()>; Executor = executor; decltype (associated_immediate_executor<T, Executor>::get(t, ex)) = executor&&; constraint_t<(is_executor<Executor>::value || execution::is_executor<Executor>::value)> = int]'
<source>:45:51:   required from here
/opt/compiler-explorer/libs/boost_1_84_0/boost/asio/associated_immediate_executor.hpp:57:61: error: cannot bind rvalue reference of type 'boost::asio::detail::default_immediate_executor<executor, void, void>::type' {aka 'executor&&'} to lvalue of type 'const executor'
   57 |     return boost::asio::require(e, execution::blocking.never);
```