### PR TITLE
Fix complilation wth clang in C++17 mode with -Werror -Wundef

### DIFF
--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -1314,17 +1314,17 @@
 #     if __has_include(<coroutine>)
 #      define ASIO_HAS_CO_AWAIT 1
 #     endif // __has_include(<coroutine>)
-#    elif (__cplusplus >= 201703) && (__cpp_coroutines >= 201703)
+#    elif (__cplusplus >= 201703) && defined(__cpp_coroutines) && (__cpp_coroutines >= 201703)
 #     if __has_include(<experimental/coroutine>)
 #      define ASIO_HAS_CO_AWAIT 1
 #     endif // __has_include(<experimental/coroutine>)
-#    endif // (__cplusplus >= 201703) && (__cpp_coroutines >= 201703)
+#    endif // (__cplusplus >= 201703) && defined(__cpp_coroutines) && (__cpp_coroutines >= 201703)
 #   else // (__clang_major__ >= 14)
-#    if (__cplusplus >= 201703) && (__cpp_coroutines >= 201703)
+#    if (__cplusplus >= 201703) && defined(__cpp_coroutines) && (__cpp_coroutines >= 201703)
 #     if __has_include(<experimental/coroutine>)
 #      define ASIO_HAS_CO_AWAIT 1
 #     endif // __has_include(<experimental/coroutine>)
-#    endif // (__cplusplus >= 201703) && (__cpp_coroutines >= 201703)
+#    endif // (__cplusplus >= 201703) && defined(__cpp_coroutines) && (__cpp_coroutines >= 201703)
 #   endif // (__clang_major__ >= 14)
 #  elif defined(__GNUC__)
 #   if (__cplusplus >= 201709) && (__cpp_impl_coroutine >= 201902)


### PR DESCRIPTION
clang 14 only defines `__cpp_coroutines` with `-std=c++2a`, it’s undefined with `-std=c++17`.  This results in an undefined macro warning if you don’t check that it’s defined before comparing it to a literal with the `-Wundef` warning option:

```
In file included from asio/include/asio.hpp:18:
In file included from asio/include/asio/any_completion_executor.hpp:18:
asio/include/asio/detail/config.hpp:1317:39: error: '__cpp_coroutines' is not defined, evaluates to 0 [-Werror,-Wundef]
#    elif (__cplusplus >= 201703) && (__cpp_coroutines >= 201703)
                                      ^
```

This pull request adds the check to avoid the warning.