### PR TITLE
Add C++11 override qualifiers to overridden virtual member functions

### DIFF
--- a/asio/include/asio/basic_streambuf.hpp
+++ b/asio/include/asio/basic_streambuf.hpp
@@ -260,7 +260,7 @@ protected:
   /**
    * Behaves according to the specification of @c std::streambuf::underflow().
    */
-  int_type underflow()
+  int_type underflow() override
   {
     if (gptr() < pptr())
     {
@@ -280,7 +280,7 @@ protected:
    * the character to the input sequence would require the condition
    * <tt>size() > max_size()</tt> to be true.
    */
-  int_type overflow(int_type c)
+  int_type overflow(int_type c) override
   {
     if (!traits_type::eq_int_type(c, traits_type::eof()))
     {

--- a/asio/include/asio/cancellation_signal.hpp
+++ b/asio/include/asio/cancellation_signal.hpp
@@ -50,12 +50,12 @@ public:
   {
   }
 
-  void call(cancellation_type_t type)
+  void call(cancellation_type_t type) override
   {
     handler_(type);
   }
 
-  std::pair<void*, std::size_t> destroy() noexcept
+  std::pair<void*, std::size_t> destroy() noexcept override
   {
     std::pair<void*, std::size_t> mem(this, size_);
     this->cancellation_handler::~cancellation_handler();

--- a/asio/include/asio/detail/deadline_timer_service.hpp
+++ b/asio/include/asio/detail/deadline_timer_service.hpp
@@ -81,7 +81,7 @@ public:
   }
 
   // Destroy all user-defined handler objects owned by the service.
-  void shutdown()
+  void shutdown() override
   {
   }
 

--- a/asio/include/asio/detail/epoll_reactor.hpp
+++ b/asio/include/asio/detail/epoll_reactor.hpp
@@ -90,11 +90,11 @@ public:
   ASIO_DECL ~epoll_reactor();
 
   // Destroy all user-defined handler objects owned by the service.
-  ASIO_DECL void shutdown();
+  ASIO_DECL void shutdown() override;
 
   // Recreate internal descriptors following a fork.
   ASIO_DECL void notify_fork(
-      asio::execution_context::fork_event fork_ev);
+      asio::execution_context::fork_event fork_ev) override;
 
   // Initialise the task.
   ASIO_DECL void init_task();
@@ -206,10 +206,10 @@ public:
       typename timer_queue<Time_Traits>::per_timer_data& source);
 
   // Run epoll once until interrupted or events are ready to be dispatched.
-  ASIO_DECL void run(long usec, op_queue<operation>& ops);
+  ASIO_DECL void run(long usec, op_queue<operation>& ops) override;
 
   // Interrupt the select loop.
-  ASIO_DECL void interrupt();
+  ASIO_DECL void interrupt() override;
 
 private:
   // The hint to pass to epoll_create to size its data structures.

--- a/asio/include/asio/detail/null_reactor.hpp
+++ b/asio/include/asio/detail/null_reactor.hpp
@@ -56,17 +56,17 @@ public:
   }
 
   // Destroy all user-defined handler objects owned by the service.
-  void shutdown()
+  void shutdown() override
   {
   }
 
   // No-op because should never be called.
-  void run(long /*usec*/, op_queue<scheduler_operation>& /*ops*/)
+  void run(long /*usec*/, op_queue<scheduler_operation>& /*ops*/) override
   {
   }
 
   // No-op.
-  void interrupt()
+  void interrupt() override
   {
   }
 };

--- a/asio/include/asio/detail/posix_serial_port_service.hpp
+++ b/asio/include/asio/detail/posix_serial_port_service.hpp
@@ -58,7 +58,7 @@ public:
   ASIO_DECL posix_serial_port_service(execution_context& context);
 
   // Destroy all user-defined handler objects owned by the service.
-  ASIO_DECL void shutdown();
+  ASIO_DECL void shutdown() override;
 
   // Construct a new serial port implementation.
   void construct(implementation_type& impl)

--- a/asio/include/asio/detail/posix_thread.hpp
+++ b/asio/include/asio/detail/posix_thread.hpp
@@ -80,7 +80,7 @@ private:
     {
     }
 
-    virtual void run()
+    virtual void run() override
     {
       f_();
     }

--- a/asio/include/asio/detail/reactive_descriptor_service.hpp
+++ b/asio/include/asio/detail/reactive_descriptor_service.hpp
@@ -82,7 +82,7 @@ public:
   ASIO_DECL reactive_descriptor_service(execution_context& context);
 
   // Destroy all user-defined handler objects owned by the service.
-  ASIO_DECL void shutdown();
+  ASIO_DECL void shutdown() override;
 
   // Construct a new descriptor implementation.
   ASIO_DECL void construct(implementation_type& impl);

--- a/asio/include/asio/detail/reactive_socket_service.hpp
+++ b/asio/include/asio/detail/reactive_socket_service.hpp
@@ -82,7 +82,7 @@ public:
   }
 
   // Destroy all user-defined handler objects owned by the service.
-  void shutdown()
+  void shutdown() override
   {
     this->base_shutdown();
   }

--- a/asio/include/asio/detail/resolver_service.hpp
+++ b/asio/include/asio/detail/resolver_service.hpp
@@ -59,13 +59,13 @@ public:
   }
 
   // Destroy all user-defined handler objects owned by the service.
-  void shutdown()
+  void shutdown() override
   {
     this->base_shutdown();
   }
 
   // Perform any fork-related housekeeping.
-  void notify_fork(execution_context::fork_event fork_ev)
+  void notify_fork(execution_context::fork_event fork_ev) override
   {
     this->base_notify_fork(fork_ev);
   }

--- a/asio/include/asio/detail/scheduler.hpp
+++ b/asio/include/asio/detail/scheduler.hpp
@@ -56,7 +56,7 @@ public:
   ASIO_DECL ~scheduler();
 
   // Destroy all user-defined handler objects owned by the service.
-  ASIO_DECL void shutdown();
+  ASIO_DECL void shutdown() override;
 
   // Initialise the task, if required.
   ASIO_DECL void init_task();

--- a/asio/include/asio/detail/select_reactor.hpp
+++ b/asio/include/asio/detail/select_reactor.hpp
@@ -74,11 +74,11 @@ public:
   ASIO_DECL ~select_reactor();
 
   // Destroy all user-defined handler objects owned by the service.
-  ASIO_DECL void shutdown();
+  ASIO_DECL void shutdown() override;
 
   // Recreate internal descriptors following a fork.
   ASIO_DECL void notify_fork(
-      asio::execution_context::fork_event fork_ev);
+      asio::execution_context::fork_event fork_ev) override;
 
   // Initialise the task, but only if the reactor is not in its own thread.
   ASIO_DECL void init_task();

--- a/asio/include/asio/detail/signal_set_service.hpp
+++ b/asio/include/asio/detail/signal_set_service.hpp
@@ -128,11 +128,11 @@ public:
   ASIO_DECL ~signal_set_service();
 
   // Destroy all user-defined handler objects owned by the service.
-  ASIO_DECL void shutdown();
+  ASIO_DECL void shutdown() override;
 
   // Perform fork-related housekeeping.
   ASIO_DECL void notify_fork(
-      asio::execution_context::fork_event fork_ev);
+      asio::execution_context::fork_event fork_ev) override;
 
   // Construct a new signal_set implementation.
   ASIO_DECL void construct(implementation_type& impl);

--- a/asio/include/asio/detail/strand_executor_service.hpp
+++ b/asio/include/asio/detail/strand_executor_service.hpp
@@ -82,7 +82,7 @@ public:
   ASIO_DECL explicit strand_executor_service(execution_context& context);
 
   // Destroy all user-defined handler objects owned by the service.
-  ASIO_DECL void shutdown();
+  ASIO_DECL void shutdown() override;
 
   // Create a new strand_executor implementation.
   ASIO_DECL implementation_type create_implementation();

--- a/asio/include/asio/detail/strand_service.hpp
+++ b/asio/include/asio/detail/strand_service.hpp
@@ -78,7 +78,7 @@ public:
   ASIO_DECL explicit strand_service(asio::io_context& io_context);
 
   // Destroy all user-defined handler objects owned by the service.
-  ASIO_DECL void shutdown();
+  ASIO_DECL void shutdown() override;
 
   // Construct a new strand implementation.
   ASIO_DECL void construct(implementation_type& impl);

--- a/asio/include/asio/detail/timer_queue.hpp
+++ b/asio/include/asio/detail/timer_queue.hpp
@@ -112,13 +112,13 @@ public:
   }
 
   // Whether there are no timers in the queue.
-  virtual bool empty() const
+  virtual bool empty() const override
   {
     return timers_ == 0;
   }
 
   // Get the time for the timer that is earliest in the queue.
-  virtual long wait_duration_msec(long max_duration) const
+  virtual long wait_duration_msec(long max_duration) const override
   {
     if (heap_.empty())
       return max_duration;
@@ -130,7 +130,7 @@ public:
   }
 
   // Get the time for the timer that is earliest in the queue.
-  virtual long wait_duration_usec(long max_duration) const
+  virtual long wait_duration_usec(long max_duration) const override
   {
     if (heap_.empty())
       return max_duration;
@@ -142,7 +142,7 @@ public:
   }
 
   // Dequeue all timers not later than the current time.
-  virtual void get_ready_timers(op_queue<operation>& ops)
+  virtual void get_ready_timers(op_queue<operation>& ops) override
   {
     if (!heap_.empty())
     {
@@ -162,7 +162,7 @@ public:
   }
 
   // Dequeue all timers.
-  virtual void get_all_timers(op_queue<operation>& ops)
+  virtual void get_all_timers(op_queue<operation>& ops) override
   {
     while (timers_)
     {

--- a/asio/include/asio/detail/win_iocp_file_service.hpp
+++ b/asio/include/asio/detail/win_iocp_file_service.hpp
@@ -54,7 +54,7 @@ public:
   ASIO_DECL win_iocp_file_service(execution_context& context);
 
   // Destroy all user-defined handler objects owned by the service.
-  ASIO_DECL void shutdown();
+  ASIO_DECL void shutdown() override;
 
   // Construct a new file implementation.
   void construct(implementation_type& impl)

--- a/asio/include/asio/detail/win_iocp_handle_service.hpp
+++ b/asio/include/asio/detail/win_iocp_handle_service.hpp
@@ -79,7 +79,7 @@ public:
   ASIO_DECL win_iocp_handle_service(execution_context& context);
 
   // Destroy all user-defined handler objects owned by the service.
-  ASIO_DECL void shutdown();
+  ASIO_DECL void shutdown() override;
 
   // Construct a new handle implementation.
   ASIO_DECL void construct(implementation_type& impl);

--- a/asio/include/asio/detail/win_iocp_io_context.hpp
+++ b/asio/include/asio/detail/win_iocp_io_context.hpp
@@ -54,7 +54,7 @@ public:
   ASIO_DECL ~win_iocp_io_context();
 
   // Destroy all user-defined handler objects owned by the service.
-  ASIO_DECL void shutdown();
+  ASIO_DECL void shutdown() override;
 
   // Initialise the task. Nothing to do here.
   void init_task()

--- a/asio/include/asio/detail/win_iocp_serial_port_service.hpp
+++ b/asio/include/asio/detail/win_iocp_serial_port_service.hpp
@@ -45,7 +45,7 @@ public:
   ASIO_DECL win_iocp_serial_port_service(execution_context& context);
 
   // Destroy all user-defined handler objects owned by the service.
-  ASIO_DECL void shutdown();
+  ASIO_DECL void shutdown() override;
 
   // Construct a new serial port implementation.
   void construct(implementation_type& impl)

--- a/asio/include/asio/detail/win_iocp_socket_service.hpp
+++ b/asio/include/asio/detail/win_iocp_socket_service.hpp
@@ -136,7 +136,7 @@ public:
   }
 
   // Destroy all user-defined handler objects owned by the service.
-  void shutdown()
+  void shutdown() override
   {
     this->base_shutdown();
   }

--- a/asio/include/asio/detail/win_object_handle_service.hpp
+++ b/asio/include/asio/detail/win_object_handle_service.hpp
@@ -87,7 +87,7 @@ public:
   ASIO_DECL win_object_handle_service(execution_context& context);
 
   // Destroy all user-defined handler objects owned by the service.
-  ASIO_DECL void shutdown();
+  ASIO_DECL void shutdown() override;
 
   // Construct a new handle implementation.
   ASIO_DECL void construct(implementation_type& impl);

--- a/asio/include/asio/execution/bad_executor.hpp
+++ b/asio/include/asio/execution/bad_executor.hpp
@@ -31,7 +31,7 @@ public:
   ASIO_DECL bad_executor() noexcept;
 
   /// Obtain message associated with exception.
-  ASIO_DECL virtual const char* what() const noexcept;
+  ASIO_DECL virtual const char* what() const noexcept override;
 };
 
 } // namespace execution

--- a/asio/include/asio/executor.hpp
+++ b/asio/include/asio/executor.hpp
@@ -41,7 +41,7 @@ public:
 
   /// Obtain message associated with exception.
   ASIO_DECL virtual const char* what() const
-    noexcept;
+    noexcept override;
 };
 
 /// Polymorphic wrapper for executors.

--- a/asio/include/asio/impl/error.ipp
+++ b/asio/include/asio/impl/error.ipp
@@ -31,12 +31,12 @@ namespace detail {
 class netdb_category : public asio::error_category
 {
 public:
-  const char* name() const noexcept
+  const char* name() const noexcept override
   {
     return "asio.netdb";
   }
 
-  std::string message(int value) const
+  std::string message(int value) const override
   {
     if (value == error::host_not_found)
       return "Host not found (authoritative)";
@@ -63,12 +63,12 @@ namespace detail {
 class addrinfo_category : public asio::error_category
 {
 public:
-  const char* name() const noexcept
+  const char* name() const noexcept override
   {
     return "asio.addrinfo";
   }
 
-  std::string message(int value) const
+  std::string message(int value) const override
   {
     if (value == error::service_not_found)
       return "Service not found";
@@ -93,12 +93,12 @@ namespace detail {
 class misc_category : public asio::error_category
 {
 public:
-  const char* name() const noexcept
+  const char* name() const noexcept override
   {
     return "asio.misc";
   }
 
-  std::string message(int value) const
+  std::string message(int value) const override
   {
     if (value == error::already_open)
       return "Already open";

--- a/asio/include/asio/impl/error_code.ipp
+++ b/asio/include/asio/impl/error_code.ipp
@@ -37,12 +37,12 @@ namespace detail {
 class system_category : public error_category
 {
 public:
-  const char* name() const noexcept
+  const char* name() const noexcept override
   {
     return "asio.system";
   }
 
-  std::string message(int value) const
+  std::string message(int value) const override
   {
 #if defined(ASIO_WINDOWS_RUNTIME) || defined(ASIO_WINDOWS_APP)
     std::wstring wmsg(128, wchar_t());

--- a/asio/include/asio/impl/executor.hpp
+++ b/asio/include/asio/impl/executor.hpp
@@ -183,64 +183,64 @@ public:
   {
   }
 
-  impl_base* clone() const noexcept
+  impl_base* clone() const noexcept override
   {
     return const_cast<impl_base*>(static_cast<const impl_base*>(this));
   }
 
-  void destroy() noexcept
+  void destroy() noexcept override
   {
   }
 
-  void on_work_started() noexcept
+  void on_work_started() noexcept override
   {
     executor_.on_work_started();
   }
 
-  void on_work_finished() noexcept
+  void on_work_finished() noexcept override
   {
     executor_.on_work_finished();
   }
 
-  execution_context& context() noexcept
+  execution_context& context() noexcept override
   {
     return executor_.context();
   }
 
-  void dispatch(function&& f)
+  void dispatch(function&& f) override
   {
     executor_.dispatch(static_cast<function&&>(f),
         std::allocator<void>());
   }
 
-  void post(function&& f)
+  void post(function&& f) override
   {
     executor_.post(static_cast<function&&>(f),
         std::allocator<void>());
   }
 
-  void defer(function&& f)
+  void defer(function&& f) override
   {
     executor_.defer(static_cast<function&&>(f),
         std::allocator<void>());
   }
 
-  type_id_result_type target_type() const noexcept
+  type_id_result_type target_type() const noexcept override
   {
     return type_id<system_executor>();
   }
 
-  void* target() noexcept
+  void* target() noexcept override
   {
     return &executor_;
   }
 
-  const void* target() const noexcept
+  const void* target() const noexcept override
   {
     return &executor_;
   }
 
-  bool equals(const impl_base* e) const noexcept
+  bool equals(const impl_base* e) const noexcept override
   {
     return this == e;
   }

--- a/asio/include/asio/io_context.hpp
+++ b/asio/include/asio/io_context.hpp
@@ -1157,7 +1157,7 @@ public:
 
 private:
   /// Destroy all user-defined handler objects owned by the service.
-  ASIO_DECL virtual void shutdown();
+  ASIO_DECL virtual void shutdown() override;
 
 #if !defined(ASIO_NO_DEPRECATED)
   /// (Deprecated: Use shutdown().) Destroy all user-defined handler objects
@@ -1172,7 +1172,7 @@ private:
    * implement it if necessary. The default implementation does nothing.
    */
   ASIO_DECL virtual void notify_fork(
-      execution_context::fork_event event);
+      execution_context::fork_event event) override;
 
 #if !defined(ASIO_NO_DEPRECATED)
   /// (Deprecated: Use notify_fork().) Handle notification of a fork-related

--- a/asio/include/asio/ip/bad_address_cast.hpp
+++ b/asio/include/asio/ip/bad_address_cast.hpp
@@ -49,7 +49,7 @@ public:
   virtual ~bad_address_cast() noexcept {}
 
   /// Get the message associated with the exception.
-  virtual const char* what() const noexcept
+  virtual const char* what() const noexcept override
   {
     return "bad address cast";
   }

--- a/asio/include/asio/multiple_exceptions.hpp
+++ b/asio/include/asio/multiple_exceptions.hpp
@@ -32,7 +32,7 @@ public:
 
   /// Obtain message associated with exception.
   ASIO_DECL virtual const char* what() const
-    noexcept;
+    noexcept override;
 
   /// Obtain a pointer to the first exception.
   ASIO_DECL std::exception_ptr first_exception() const;


### PR DESCRIPTION
This pull request adds `override` qualifiers to overridden virtual member functions in some headers.  It’s by no means exhaustive, but it allows an application using TCP and UDP sockets to build cleanly with clang’s `-Winconsistent-missing-override` warning option and GCC’s `-Wsuggest-override` warning option.