### PR TITLE
Include `<malloc.h>` for `_alloca`

### DIFF
--- a/asio/include/asio/detail/impl/socket_ops.ipp
+++ b/asio/include/asio/detail/impl/socket_ops.ipp
@@ -41,6 +41,10 @@
 #endif // defined(ASIO_WINDOWS) || defined(__CYGWIN__)
        // || defined(__MACH__) && defined(__APPLE__)
 
+#if defined(_MSC_VER) && (_MSC_VER >= 1800)
+# include <malloc.h>
+#endif
+
 #include "asio/detail/push_options.hpp"
 
 namespace asio {


### PR DESCRIPTION
Recently, I noticed that MSVC's `<exception>` was unnecessarily dragging in `<malloc.h>`, and attempted to remove it in https://github.com/microsoft/STL/pull/4626. This revealed a lot of bugs in open-source projects, so I'll probably revert the change (at least for now). However, I thought I'd report this to you, since it's an easy fix.

asio is using `_alloca` without including `<malloc.h>` (the proper header [as documented on Microsoft Learn](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/alloca?view=msvc-170)), here:

https://github.com/chriskohlhoff/asio/blob/12e0ce9e0500bf0f247dbd1ae894272656456079/asio/include/asio/detail/impl/socket_ops.ipp#L2542-L2543
https://github.com/chriskohlhoff/asio/blob/12e0ce9e0500bf0f247dbd1ae894272656456079/asio/include/asio/detail/impl/socket_ops.ipp#L2756-L2758

This usage is guarded by `#if defined(BOOST_NO_ANSI_APIS) || (defined(_MSC_VER) && (_MSC_VER >= 1800))`, but my proposed inclusion is guarded by only `#if defined(_MSC_VER) && (_MSC_VER >= 1800)` since non-MSVC `defined(BOOST_NO_ANSI_APIS)` configurations are presumably getting `_alloca` from somewhere else.