### PR TITLE
Include full snippet for main method for Timer.5 tutorial

### DIFF
--- a/asio/src/doc/tutorial.qbk
+++ b/asio/src/doc/tutorial.qbk
@@ -654,6 +654,11 @@ Just as it would with a call from a single thread, concurrent calls to asio::io\
   ``''''''``  asio::io_context io;
   ``''''''``  printer p(io);
   ``''''''``  std::thread t([&]{ io.run(); });
+  ``''''''``  io.run();
+  ``''''''``  t.join();
+  ``''''''``  
+  ``''''''``  return 0;
+  ``''''''`` }
 
 See the [link asio.tutorial.tuttimer5.src full source listing]
 


### PR DESCRIPTION
Added a full main method example snippet to the Timer.5 tutorial to ensure the source code can be replicated and compiled successfully like the other Boost Asio tutorial examples without having to reference the full source listing page.

```
  ``''''''``int main()
  ``''''''``{
  ``''''''``  asio::io_context io;
  ``''''''``  printer p(io);
  ``''''''``  std::thread t([&]{ io.run(); });
  ``''''''``  io.run();
  ``''''''``  t.join();
  ``''''''``  
  ``''''''``  return 0;
  ``''''''`` }
```