### PR TITLE
Fix typo in Cancellation documentation

### DIFF
--- a/asio/src/doc/overview/cancellation.qbk
+++ b/asio/src/doc/overview/cancellation.qbk
@@ -201,7 +201,7 @@ occur.
 
 Furthermore, a stronger guarantee always satisfies the requirements of a weaker
 guarantee. The `partial` guarantee still satisfies the `terminal` guarantee.
-The `total` guarantee satisfies both `partial` and `total`. This means that
+The `total` guarantee satisfies both `partial` and `terminal`. This means that
 when an operation supports a given cancellation type as its strongest
 guarantee, it should honour cancellation requests for any of the weaker
 guarantees.


### PR DESCRIPTION
It seems to me that the `total` guarantee should satisfy the `terminal` guarantee, not the `total` guarantee again.