### PR TITLE
Support combine with other event loops

### DIFF
--- a/asio/include/asio/detail/impl/scheduler.ipp
+++ b/asio/include/asio/detail/impl/scheduler.ipp
@@ -230,6 +230,12 @@ std::size_t scheduler::run_one(asio::error_code& ec)
   return do_run_one(lock, this_thread, ec);
 }
 
+std::size_t scheduler::wait_event(long usec, asio::error_code &ec)
+{
+  task_->mask_wait_only();
+  return wait_one(usec, ec);
+}
+
 std::size_t scheduler::wait_one(long usec, asio::error_code& ec)
 {
   ec = asio::error_code();

--- a/asio/include/asio/detail/kqueue_reactor.hpp
+++ b/asio/include/asio/detail/kqueue_reactor.hpp
@@ -208,6 +208,8 @@ public:
   // Run the kqueue loop.
   ASIO_DECL void run(long usec, op_queue<operation>& ops);
 
+  ASIO_DECL void mask_wait_only();
+
   // Interrupt the kqueue loop.
   ASIO_DECL void interrupt();
 
@@ -254,6 +256,14 @@ private:
 
   // Keep track of all registered descriptors.
   object_pool<descriptor_state> registered_descriptors_;
+
+  // Save fired events
+  struct {
+    struct kevent events[128];
+    int num_events;
+    std::atomic_bool has_event;
+    std::atomic_bool is_wait;
+  } event_loop_field_ {};
 };
 
 } // namespace detail

--- a/asio/include/asio/detail/scheduler.hpp
+++ b/asio/include/asio/detail/scheduler.hpp
@@ -77,6 +77,9 @@ public:
   // Poll for one operation without blocking.
   ASIO_DECL std::size_t poll_one(asio::error_code& ec);
 
+  // Wait until timeout, interrupted, or one operation event.
+  ASIO_DECL std::size_t wait_event(long usec, asio::error_code& ec);
+
   // Interrupt the event processing loop.
   ASIO_DECL void stop();
 

--- a/asio/include/asio/detail/scheduler_task.hpp
+++ b/asio/include/asio/detail/scheduler_task.hpp
@@ -31,6 +31,11 @@ public:
   // Run the task once until interrupted or events are ready to be dispatched.
   virtual void run(long usec, op_queue<scheduler_operation>& ops) = 0;
 
+  // Mask just wait event for this time call run
+  virtual void mask_wait_only() {
+    throw_error(std::make_error_code(std::errc::operation_not_supported));
+  };
+
   // Interrupt the task.
   virtual void interrupt() = 0;
 

--- a/asio/src/examples/cpp11/other_eventloop/with_libuv.cpp
+++ b/asio/src/examples/cpp11/other_eventloop/with_libuv.cpp
@@ -1,0 +1,56 @@
+#include <asio.hpp>
+#include <iostream>
+#include <uv.h>
+
+//#define USE_LOG
+#ifdef USE_LOG
+#include "log.h"
+#else
+#define LOG printf
+#endif
+
+int main() {
+  uv_loop_t *loop = uv_default_loop();
+  static asio::io_context io_context;
+  asio::io_context::work work(io_context);
+
+  uv_timer_t timer_req;
+  uv_timer_init(loop, &timer_req);
+  uv_timer_start(
+      &timer_req, [](uv_timer_t *handle) { LOG("libuv Timer fired!\n"); },
+      10000, 10000);
+
+  asio::steady_timer asio_timer(io_context);
+  std::function<void()> start_asio_timer;
+  start_asio_timer = [&] {
+    asio_timer.expires_after(asio::chrono::milliseconds(1000));
+    asio_timer.async_wait([&](const asio::error_code &ec) {
+      LOG("asio Timer fired!\n");
+      start_asio_timer();
+    });
+  };
+  start_asio_timer();
+
+  static std::condition_variable async_done;
+  std::mutex async_done_lock;
+  uv_async_t async;
+  uv_async_init(loop, &async, [](uv_async_t *handle) {
+    io_context.poll_one();
+    async_done.notify_one();
+  });
+
+  std::thread([&] {
+    for (;;) {
+      LOG("wait_event...");
+      asio::error_code ec;
+      auto &service = asio::use_service<asio::detail::scheduler>(io_context);
+      service.wait_event(INTMAX_MAX, ec);
+      uv_async_send(&async);
+      std::unique_lock<std::mutex> lock(async_done_lock);
+      async_done.wait(lock);
+    }
+  }).detach();
+
+  uv_run(loop, UV_RUN_DEFAULT);
+  return 0;
+}


### PR DESCRIPTION
I am very eager for ASIO to be used in combine with other event loops.
For instance, when using Node.js (libuv), I also want to use some ASIO-based libraries. To avoid potential issues, it is best to handle all these asynchronous tasks in a single thread.

It would be really cool and useful if we could run libuv and ASIO simultaneously in the same thread!!!

This submission represents the implementation approach I've come up with so far. It has been successfully tested on macOS, but not yet on other platforms.
Of course, there may be better solutions. Do you have any suggestions or comments? I would be very happy to supplement and improve this, or adopt a different approach.

@chriskohlhoff 