### PR TITLE
example: operations/composed_6: also free delay_timer_

### DIFF
--- a/asio/src/examples/cpp11/operations/composed_6.cpp
+++ b/asio/src/examples/cpp11/operations/composed_6.cpp
@@ -138,9 +138,10 @@ struct async_write_message_initiation
         // We no longer have any future work coming for the I/O executor.
         io_work_.reset();
 
-        // Deallocate the encoded message before calling the user-supplied
-        // completion handler.
+        // Deallocate the encoded message and delay timer before calling the
+        // user-supplied completion handler.
         encoded_message_.reset();
+        delay_timer_.reset();
 
         // Call the user-supplied handler with the result of the operation.
         handler_(error);

--- a/asio/src/examples/cpp14/operations/composed_6.cpp
+++ b/asio/src/examples/cpp14/operations/composed_6.cpp
@@ -156,9 +156,10 @@ auto async_write_messages(tcp::socket& socket,
         // We no longer have any future work coming for the I/O executor.
         io_work_.reset();
 
-        // Deallocate the encoded message before calling the user-supplied
-        // completion handler.
+        // Deallocate the encoded message and delay timer before calling the
+        // user-supplied completion handler.
         encoded_message_.reset();
+        delay_timer_.reset();
 
         // Call the user-supplied handler with the result of the operation.
         handler_(error);

--- a/asio/src/examples/cpp20/operations/composed_6.cpp
+++ b/asio/src/examples/cpp20/operations/composed_6.cpp
@@ -161,9 +161,10 @@ auto async_write_messages(tcp::socket& socket,
         // We no longer have any future work coming for the I/O executor.
         io_work_.reset();
 
-        // Deallocate the encoded message before calling the user-supplied
-        // completion handler.
+        // Deallocate the encoded message and delay timer before calling the
+        // user-supplied completion handler.
         encoded_message_.reset();
+        delay_timer_.reset();
 
         // Call the user-supplied handler with the result of the operation.
         handler_(error);


### PR DESCRIPTION
Also the delay_timer_ member should be freed before calling the user-supplied completion handler (as in the composed_7 and composed_8 examples).