### PR TITLE
Fix sprintf issue on MacOS for non-XCode compilers

### DIFF
--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -1411,11 +1411,9 @@
 // Standard library support for snprintf.
 #if !defined(ASIO_HAS_SNPRINTF)
 # if !defined(ASIO_DISABLE_SNPRINTF)
-#  if defined(__apple_build_version__)
-#    if (__clang_major__ >= 14)
-#     define ASIO_HAS_SNPRINTF 1
-#    endif // (__clang_major__ >= 14)
-#  endif // defined(__apple_build_version__)
+#  if defined(__APPLE__)
+#   define ASIO_HAS_SNPRINTF 1
+#  endif // defined(__APPLE__)
 # endif // !defined(ASIO_DISABLE_SNPRINTF)
 #endif // !defined(ASIO_HAS_SNPRINTF)
 

--- a/asio/include/asio/detail/impl/socket_ops.ipp
+++ b/asio/include/asio/detail/impl/socket_ops.ipp
@@ -2582,9 +2582,11 @@ const char* inet_ntop(int af, const void* src, char* dest, size_t length,
         || if_indextoname(static_cast<unsigned>(scope_id), if_name + 1) == 0)
 #if defined(ASIO_HAS_SNPRINTF)
       snprintf(if_name + 1, sizeof(if_name) - 1, "%lu", scope_id);
-#else // defined(ASIO_HAS_SNPRINTF)
+#elif defined(ASIO_HAS_SECURE_RTL)
+      sprintf_s(if_name + 1, sizeof(if_name) -1, "%lu", scope_id);
+#else // defined(ASIO_HAS_SECURE_RTL)
       sprintf(if_name + 1, "%lu", scope_id);
-#endif // defined(ASIO_HAS_SNPRINTF)
+#endif // defined(ASIO_HAS_SECURE_RTL)
     strcat(dest, if_name);
   }
   return result;


### PR DESCRIPTION
@chriskohlhoff @klemens-morgenstern

This should fix the sprintf issue on MacOS for good, in particular if XCode is not used but e.g. clang from brew (see https://github.com/chriskohlhoff/asio/issues/1148 for discussion).

The issue is the check of `ASIO_HAS_SNPRINTF` here:
https://github.com/chriskohlhoff/asio/blob/54e3a844eb5f31d25416de9e509d9c24fa203c32/asio/include/asio/detail/config.hpp#L1411-L1420

It only checks if `__apple_build_version__` is defined, however this variable isn't set when using non-XCode compilers on MacOS. [Since `snprintf` is available in MacOS since version 10.0](https://developer.apple.com/documentation/kernel/1441052-snprintf), [which was released in March 2001](https://en.wikipedia.org/wiki/MacOS_version_history#Releases), is think the best option is to always set `ASIO_HAS_SNPRINTF` if `__APPLE__` is detected.

Note that is also fixes a missing instance where `sprintf_s` can be used via Microsoft RTL.

Closes https://github.com/chriskohlhoff/asio/issues/1148 closes https://github.com/chriskohlhoff/asio/issues/1449 closes https://github.com/chriskohlhoff/asio/issues/1183

