### PR TITLE
Error traits

### DIFF
--- a/asio/include/asio.hpp
+++ b/asio/include/asio.hpp
@@ -81,6 +81,7 @@
 #include "asio/dispatch.hpp"
 #include "asio/error.hpp"
 #include "asio/error_code.hpp"
+#include "asio/error_traits.hpp"
 #include "asio/execution.hpp"
 #include "asio/execution/allocator.hpp"
 #include "asio/execution/any_executor.hpp"

--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -1375,6 +1375,22 @@
 # define ASIO_NODISCARD
 #endif // !defined(ASIO_NODISCARD)
 
+
+// Compiler support for the the [[nodiscard]] attribute.
+#if !defined(ASIO_NORETURN)
+# if defined(__has_cpp_attribute)
+#  if __has_cpp_attribute(noreturn)
+#   if (__cplusplus >= 201103L)
+#    define ASIO_NORETURN [[noreturn]]
+#   endif // (__cplusplus >= 201103L)
+#  endif // __has_cpp_attribute(noreturn)
+# endif // defined(__has_cpp_attribute)
+#endif // !defined(ASIO_NORETURN)
+#if !defined(ASIO_NORETURN)
+# define ASIO_NORETURN
+#endif // !defined(ASIO_NORETURN)
+
+
 // Kernel support for MSG_NOSIGNAL.
 #if !defined(ASIO_HAS_MSG_NOSIGNAL)
 # if defined(__linux__)

--- a/asio/include/asio/detail/throw_error.hpp
+++ b/asio/include/asio/detail/throw_error.hpp
@@ -24,7 +24,7 @@
 namespace asio {
 namespace detail {
 
-ASIO_DECL void do_throw_error(
+ASIO_NORETURN ASIO_DECL void do_throw_error(
     const asio::error_code& err
     ASIO_SOURCE_LOCATION_PARAM);
 

--- a/asio/include/asio/detail/throw_exception.hpp
+++ b/asio/include/asio/detail/throw_exception.hpp
@@ -30,7 +30,7 @@ using boost::throw_exception;
 
 // Declare the throw_exception function for all targets.
 template <typename Exception>
-void throw_exception(
+ASIO_NORETURN void throw_exception(
     const Exception& e
     ASIO_SOURCE_LOCATION_DEFAULTED_PARAM);
 
@@ -39,7 +39,7 @@ void throw_exception(
 // function.
 # if !defined(ASIO_NO_EXCEPTIONS)
 template <typename Exception>
-void throw_exception(
+ASIO_NORETURN void throw_exception(
     const Exception& e
     ASIO_SOURCE_LOCATION_PARAM)
 {

--- a/asio/include/asio/error_traits.hpp
+++ b/asio/include/asio/error_traits.hpp
@@ -1,0 +1,102 @@
+//
+// error_traits.hpp
+// ~~~~~~~~~~~~~~~~
+//
+//
+// Copyright (c) 2024 Klemens Morgenstern (klemens.morgenstern@gmx.net)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef ASIO_ERROR_TRAITS_HPP
+#define ASIO_ERROR_TRAITS_HPP
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#include "asio/error.hpp"
+
+#include "asio/detail/push_options.hpp"
+
+namespace asio {
+
+/// Error traits to automatically convert error values into exceptions.
+template<typename Error>
+struct error_traits;
+
+template<>
+struct error_traits<asio::error_code>
+{
+  typedef asio::error_code type;
+
+  ASIO_NORETURN
+  static void throw_error(
+      const asio::error_code& err
+      ASIO_SOURCE_LOCATION_PARAM)
+  {
+    detail::do_throw_error(err ASIO_SOURCE_LOCATION_ARG);
+  }
+
+  ASIO_NODISCARD
+  static bool is_failure(
+      const asio::error_code  &ec) ASIO_NOEXCEPT
+  {
+     return !!ec;
+  }
+};
+
+
+template<>
+struct error_traits<std::exception_ptr>
+{
+  typedef std::exception_ptr type;
+
+  ASIO_NORETURN
+  static void throw_error(
+      std::exception_ptr e)
+  {
+    std::rethrow_exception(e);
+  }
+
+  ASIO_NODISCARD
+  static bool is_failure(
+      const std::exception_ptr &e) ASIO_NOEXCEPT
+  {
+    return !!e;
+  }
+};
+
+template<typename Error, typename = Error>
+struct is_error : std::false_type {};
+
+template<typename Error>
+struct is_error<Error, typename error_traits<Error>::type> : std::true_type {};
+
+template<>
+struct is_error<std::exception_ptr, std::exception_ptr> : std::true_type {};
+
+template<>
+struct is_error<asio::error_code, asio::error_code> : std::true_type {};
+
+template<typename T>
+struct signature_has_error : std::false_type {};
+
+template<>
+struct signature_has_error<void()> : std::false_type {};
+
+template<typename T>
+struct signature_has_error<void(T)> : is_error<T> {};
+
+
+template<typename T, typename ... Ts>
+struct signature_has_error<void(T, Ts...)> : is_error<T> {};
+
+
+}
+
+#include "asio/detail/pop_options.hpp"
+
+
+#endif //ASIO_ERROR_TRAITS_HPP


### PR DESCRIPTION
Other errors may be used by libraries (e.g. mysql or redis) to add more refined information. Supporting turning those into exceptions by default is however a requirement if library authors want a `void(my_error, ...)` completion signature. 