### PR TITLE
Fix undefined behavior in experimental::coro

### DIFF
--- a/asio/include/asio/experimental/impl/coro.hpp
+++ b/asio/include/asio/experimental/impl/coro.hpp
@@ -1000,6 +1000,7 @@ struct coro<Yield, Return, Executor, Allocator>::awaitable_t
         {
           st->second.state = cancellation_state(
               st->second.slot = st->first.slot());
+          coro_->cancel = &st->second;
         }
 
         E e;
@@ -1020,6 +1021,10 @@ struct coro<Yield, Return, Executor, Allocator>::awaitable_t
       {
         hp.cancel->state.slot().template emplace<cancel_handler>(
             coro_.get_executor(), coro_);
+      }
+      else
+      {
+        coro_.coro_->cancel = hp.cancel;
       }
 
       auto hh = detail::coroutine_handle<


### PR DESCRIPTION
Set the cancel member for different coro executors. Fixes chriskohlhoff/asio#1536