### PR TITLE
Fix clang-tidy error: clang-analyzer-cplusplus.NewDelete

### DIFF
--- a/asio/include/asio/detail/impl/win_thread.ipp
+++ b/asio/include/asio/detail/impl/win_thread.ipp
@@ -75,6 +75,7 @@ void win_thread::start_thread(func_base* arg, unsigned int stack_size)
     asio::detail::throw_error(ec, "thread.entry_event");
   }
 
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDelete)
   arg->exit_event_ = exit_event_ = ::CreateEventW(0, true, false, 0);
   if (!exit_event_)
   {
@@ -86,6 +87,7 @@ void win_thread::start_thread(func_base* arg, unsigned int stack_size)
   }
 
   unsigned int thread_id = 0;
+  // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDelete)
   thread_ = reinterpret_cast<HANDLE>(::_beginthreadex(0,
         stack_size, win_thread_function, arg, 0, &thread_id));
   if (!thread_)


### PR DESCRIPTION
It occurs when `arg` is used later after `delete arg;`. clang-tidy doesn't understand that there is an exception thrown after delete.

It leads to the following clang-tidy errors in the main project:
```cpp
...\include\boost/asio/detail/impl/win_thread.ipp:79:20: error: Use of memory after it is freed [clang-analyzer-cplusplus.NewDelete,-warnings-as-errors]
   79 | arg->exit_event_ = exit_event_ = ::CreateEventW(0, true, false, 0);
      |                                ^

...\include\boost/asio/detail/impl/win_thread.ipp:90:38: error: Use of memory after it is freed [clang-analyzer-cplusplus.NewDelete,-warnings-as-errors]
   90 |   thread_ = reinterpret_cast<HANDLE>(::_beginthreadex(0,
      |                                      ^
```