### PR TITLE
co_composed.hpp: Guard use of async_operation

### DIFF
--- a/asio/include/asio/co_composed.hpp
+++ b/asio/include/asio/co_composed.hpp
@@ -845,7 +845,11 @@ public:
     throw;
   }
 
+#ifdef ASIO_DISABLE_CONCEPTS
+  template <typename Op>
+#else
   template <async_operation Op>
+#endif
   auto await_transform(Op&& op
 #if defined(ASIO_ENABLE_HANDLER_TRACKING)
 # if defined(ASIO_HAS_SOURCE_LOCATION)


### PR DESCRIPTION
`async_operation` is defined only when concepts are in use. When ASIO_DISABLE_CONCEPTS is defined, bare `typename` should be used instead.

We can't use ASIO_ASYNC_OPERATION macros here, as it currently does not have a no-argument form.

Fixes: #1547