### PR TITLE
missing `try_lock` in `null_mutex.hpp`

### DIFF
--- a/asio/include/asio/detail/null_mutex.hpp
+++ b/asio/include/asio/detail/null_mutex.hpp
@@ -41,6 +41,12 @@ public:
   {
   }
 
+  // Try to lock the mutex.
+  bool try_lock()
+  {
+    return true;
+  }
+
   // Lock the mutex.
   void lock()
   {


### PR DESCRIPTION
closes #1562 