### PR TITLE
Stored range.size() before forwarding range.

### DIFF
--- a/asio/include/asio/experimental/impl/parallel_group.hpp
+++ b/asio/include/asio/experimental/impl/parallel_group.hpp
@@ -706,6 +706,7 @@ void ranged_parallel_group_launch(Condition cancellation_condition,
       std::move(handler), range.size(), allocator);
 
   std::size_t idx = 0;
+  std::size_t range_size = range.size();
   for (auto&& op : std::forward<Range>(range))
   {
     typedef associated_executor_t<op_type> ex_type;
@@ -718,7 +719,7 @@ void ranged_parallel_group_launch(Condition cancellation_condition,
 
   // Check if any of the operations has already requested cancellation, and if
   // so, emit a signal for each operation in the group.
-  if ((state->cancellations_requested_ -= range.size()) > 0)
+  if ((state->cancellations_requested_ -= range_size) > 0)
     for (auto& signal : state->cancellation_signals_)
       signal.emit(state->cancel_type_);
 


### PR DESCRIPTION
Fixed #1582