### PR TITLE
Update cirrus CI/CD image to freebsd-14-2.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image_family: freebsd-14-0
+  image_family: freebsd-14-2
   cpu: 1
 
 env:


### PR DESCRIPTION
* Bumped freebsd image to 14-2 (https://cirrus-ci.org/guide/FreeBSD/#list-of-available-image-families)