### PR TITLE
Annotate deprecated items with `[[deprecated]]`

### DIFF
--- a/asio/include/asio/basic_deadline_timer.hpp
+++ b/asio/include/asio/basic_deadline_timer.hpp
@@ -129,7 +129,7 @@ namespace asio {
 template <typename Time,
     typename TimeTraits = asio::time_traits<Time>,
     typename Executor = any_io_executor>
-class basic_deadline_timer
+class ASIO_DEPRECATED_X("Use basic_waitable_timer") basic_deadline_timer
 {
 private:
   class initiate_async_wait;

--- a/asio/include/asio/basic_io_object.hpp
+++ b/asio/include/asio/basic_io_object.hpp
@@ -30,7 +30,7 @@ namespace detail
 {
   // Type trait used to determine whether a service supports move.
   template <typename IoObjectService>
-  class service_has_move
+  class ASIO_DEPRECATED service_has_move
   {
   private:
     typedef IoObjectService service_type;
@@ -60,7 +60,7 @@ template <typename IoObjectService>
 template <typename IoObjectService,
     bool Movable = detail::service_has_move<IoObjectService>::value>
 #endif
-class basic_io_object
+class ASIO_DEPRECATED basic_io_object
 {
 public:
   /// The type of the service that will be used to provide I/O operations.
@@ -190,7 +190,7 @@ private:
 
 // Specialisation for movable objects.
 template <typename IoObjectService>
-class basic_io_object<IoObjectService, true>
+class ASIO_DEPRECATED basic_io_object<IoObjectService, true>
 {
 public:
   typedef IoObjectService service_type;

--- a/asio/include/asio/buffer.hpp
+++ b/asio/include/asio/buffer.hpp
@@ -328,7 +328,9 @@ private:
 /// (Deprecated: Use the socket/descriptor wait() and async_wait() member
 /// functions.) An implementation of both the ConstBufferSequence and
 /// MutableBufferSequence concepts to represent a null buffer sequence.
-class null_buffers
+class ASIO_DEPRECATED_X(
+  "Use the socket/descriptor wait() and async_wait() member functions")
+null_buffers
 {
 public:
   /// The type for each element in the list of buffers.

--- a/asio/include/asio/deadline_timer.hpp
+++ b/asio/include/asio/deadline_timer.hpp
@@ -31,6 +31,7 @@ namespace asio {
 
 /// (Deprecated: Use system_timer.) Typedef for the typical usage of timer. Uses
 /// a UTC clock.
+ASIO_DEPRECATED_X("Use system_timer")
 typedef basic_deadline_timer<boost::posix_time::ptime> deadline_timer;
 
 } // namespace asio

--- a/asio/include/asio/detail/config.hpp
+++ b/asio/include/asio/detail/config.hpp
@@ -1386,6 +1386,20 @@
 # define ASIO_NODISCARD
 #endif // !defined(ASIO_NODISCARD)
 
+// Compiler support for the the [[deprecated(msg)]] attribute.
+#if !defined(ASIO_DEPRECATED)
+# if defined(__has_cpp_attribute)
+#  if __has_cpp_attribute(deprecated) && !defined(ASIO_IGNORE_DEPRECATED)
+#    define ASIO_DEPRECATED [[deprecated]]
+#    define ASIO_DEPRECATED_X(msg) [[deprecated(msg)]]
+#  endif // __has_cpp_attribute(deprecated)
+# endif // defined(__has_cpp_attribute)
+#endif // !defined(ASIO_DEPRECATED)
+#if !defined(ASIO_DEPRECATED)
+# define ASIO_DEPRECATED
+# define ASIO_DEPRECATED_X(msg)
+#endif // !defined(ASIO_DEPRECATED)
+
 // Kernel support for MSG_NOSIGNAL.
 #if !defined(ASIO_HAS_MSG_NOSIGNAL)
 # if defined(__linux__)

--- a/asio/include/asio/detail/push_options.hpp
+++ b/asio/include/asio/detail/push_options.hpp
@@ -62,6 +62,7 @@
 
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 # if (__clang_major__ >= 6)
 #  pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 # endif // (__clang_major__ >= 6)
@@ -106,6 +107,9 @@
 # if (__GNUC__ == 4 && __GNUC_MINOR__ >= 7) || (__GNUC__ > 4)
 #  pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 # endif // (__GNUC__ == 4 && __GNUC_MINOR__ >= 7) || (__GNUC__ > 4)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+# endif // (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) || (__GNUC__ > 4)
 # if (__GNUC__ >= 7)
 #  pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 # endif // (__GNUC__ >= 7)
@@ -184,6 +188,7 @@
 # pragma warning (disable:4512)
 # pragma warning (disable:4610)
 # pragma warning (disable:4675)
+# pragma warning (disable:4996)
 # if (_MSC_VER < 1600)
 // Visual Studio 2008 generates spurious warnings about unused parameters.
 #  pragma warning (disable:4100)

--- a/asio/include/asio/detail/timer_queue_ptime.hpp
+++ b/asio/include/asio/detail/timer_queue_ptime.hpp
@@ -33,7 +33,7 @@ struct forwarding_posix_time_traits : time_traits<boost::posix_time::ptime> {};
 
 // Template specialisation for the commonly used instantiation.
 template <>
-class timer_queue<time_traits<boost::posix_time::ptime>>
+class ASIO_DEPRECATED timer_queue<time_traits<boost::posix_time::ptime>>
   : public timer_queue_base
 {
 public:

--- a/asio/include/asio/impl/execution_context.hpp
+++ b/asio/include/asio/impl/execution_context.hpp
@@ -46,6 +46,7 @@ Service& make_service(execution_context& e, Args&&... args)
 }
 
 template <typename Service>
+ASIO_DEPRECATED_X("Use make_service()")
 inline void add_service(execution_context& e, Service* svc)
 {
   // Check that Service meets the necessary type requirements.

--- a/asio/include/asio/io_context.hpp
+++ b/asio/include/asio/io_context.hpp
@@ -459,6 +459,7 @@ public:
    *     boost::bind(f, a1, ... an)); @endcode
    */
   template <typename Handler>
+  ASIO_DEPRECATED_X("Use asio::bind_executor()")
 #if defined(GENERATING_DOCUMENTATION)
   unspecified
 #else

--- a/asio/include/asio/io_context_strand.hpp
+++ b/asio/include/asio/io_context_strand.hpp
@@ -236,6 +236,7 @@ public:
    * @code asio::dispatch(strand, boost::bind(f, a1, ... an)); @endcode
    */
   template <typename Handler>
+  ASIO_DEPRECATED_X("Use asio::bind_executor()")
 #if defined(GENERATING_DOCUMENTATION)
   unspecified
 #else

--- a/asio/include/asio/time_traits.hpp
+++ b/asio/include/asio/time_traits.hpp
@@ -30,11 +30,11 @@ namespace asio {
 
 /// (Deprecated) Time traits suitable for use with the deadline timer.
 template <typename Time>
-struct time_traits;
+struct ASIO_DEPRECATED time_traits;
 
 /// (Deprecated) Time traits specialised for posix_time.
 template <>
-struct time_traits<boost::posix_time::ptime>
+struct ASIO_DEPRECATED time_traits<boost::posix_time::ptime>
 {
   /// The time type.
   typedef boost::posix_time::ptime time_type;


### PR DESCRIPTION
Marks items disabled with `ASIO_NO_DEPRECATED` as `[[deprecated]]` (in C++ 14 and later). This helps users migrate earlier. Users can define `ASIO_IGNORE_DEPRECATED` to disable the warnings.

Fixes https://github.com/chriskohlhoff/asio/issues/1571.