### PR TITLE
Update server.cpp

### DIFF
--- a/asio/src/examples/cpp11/tutorial/daytime6/server.cpp
+++ b/asio/src/examples/cpp11/tutorial/daytime6/server.cpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <string>
 #include <asio.hpp>
+#include <boost/bind/bind.hpp>
 
 using asio::ip::udp;
 
@@ -39,7 +40,7 @@ private:
   {
     socket_.async_receive_from(
         asio::buffer(recv_buffer_), remote_endpoint_,
-        std::bind(&udp_server::handle_receive, this,
+        boost::bind(&udp_server::handle_receive, this,
           asio::placeholders::error,
           asio::placeholders::bytes_transferred));
   }
@@ -53,7 +54,7 @@ private:
           new std::string(make_daytime_string()));
 
       socket_.async_send_to(asio::buffer(*message), remote_endpoint_,
-          std::bind(&udp_server::handle_send, this, message,
+          boost::bind(&udp_server::handle_send, this, message,
             asio::placeholders::error,
             asio::placeholders::bytes_transferred));
 


### PR DESCRIPTION
`boost::asio::placeholders` used in lines 44-45 and 58-59 only work with `boost::bind`. 

`std::bind` should use `std::placeholders::_1` and `std::placeholders::_2` instead. 

Refer to this [stackoverflow question](https://stackoverflow.com/questions/52041514/boost-asio-cant-use-stdbind-to-specify-callback?noredirect=1&lq=1)