### PR TITLE
Update server.cpp

### DIFF
--- a/asio/src/examples/cpp11/tutorial/daytime6/server.cpp
+++ b/asio/src/examples/cpp11/tutorial/daytime6/server.cpp
@@ -40,8 +40,8 @@ private:
     socket_.async_receive_from(
         asio::buffer(recv_buffer_), remote_endpoint_,
         std::bind(&udp_server::handle_receive, this,
-          asio::placeholders::error,
-          asio::placeholders::bytes_transferred));
+          std::placeholders::_1,
+          std::placeholders::_2));
   }
 
   void handle_receive(const std::error_code& error,
@@ -54,8 +54,8 @@ private:
 
       socket_.async_send_to(asio::buffer(*message), remote_endpoint_,
           std::bind(&udp_server::handle_send, this, message,
-            asio::placeholders::error,
-            asio::placeholders::bytes_transferred));
+            std::placeholders::_1,
+            std::placeholders::_2));
 
       start_receive();
     }


### PR DESCRIPTION
`boost::asio::placeholders` used in lines 44-45 and 58-59 only work with `boost::bind`.

`std::bind` should use `std::placeholders::_1` and `std::placeholders::_2` instead.

Refer to [this stackoverflow question](https://stackoverflow.com/questions/52041514/boost-asio-cant-use-stdbind-to-specify-callback?noredirect=1&lq=1)