### PR TITLE
correct nested type in async_result<use_awaitable_t>

### DIFF
--- a/asio/include/asio/impl/use_awaitable.hpp
+++ b/asio/include/asio/impl/use_awaitable.hpp
@@ -191,20 +191,20 @@ class async_result<use_awaitable_t<Executor>, R(Args...)>
 {
 public:
   typedef typename detail::awaitable_handler<
-      Executor, decay_t<Args>...> handler_type;
-  typedef typename handler_type::awaitable_type return_type;
+      Executor, decay_t<Args>...> completion_handler_type;
+  typedef typename completion_handler_type::awaitable_type return_type;
 
   template <typename Initiation, typename... InitArgs>
 #if defined(__APPLE_CC__) && (__clang_major__ == 13)
   __attribute__((noinline))
 #endif // defined(__APPLE_CC__) && (__clang_major__ == 13)
-  static handler_type* do_init(
+  static completion_handler_type* do_init(
       detail::awaitable_frame_base<Executor>* frame, Initiation& initiation,
       use_awaitable_t<Executor> u, InitArgs&... args)
   {
     (void)u;
     ASIO_HANDLER_LOCATION((u.file_name_, u.line_, u.function_name_));
-    handler_type handler(frame->detach_thread());
+    completion_handler_type handler(frame->detach_thread());
     std::move(initiation)(std::move(handler), std::move(args)...);
     return nullptr;
   }


### PR DESCRIPTION
The [async_result](https://www.boost.org/doc/libs/1_87_0/doc/html/boost_asio/reference/async_result.html) type trait mandates the nested type `completion_handler_type`. The specialization `async_result<use_awaitable_t>` instead had the nested type `handler_type`, thereby not conforming to the interface and causing [async_completion](https://www.boost.org/doc/libs/1_87_0/doc/html/boost_asio/reference/async_completion.html) to fail.

This PR changes the nested type name on this specialization from `handler_type`  to `completion_handler_type` to conform to the `async_result` interface.