### PR TITLE
Fix MSVC-like compile by clang

### DIFF
--- a/asio/include/asio/impl/use_awaitable.hpp
+++ b/asio/include/asio/impl/use_awaitable.hpp
@@ -219,9 +219,9 @@ public:
       };
 
     for (;;) {} // Never reached.
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) and not(__clang__)
     co_return dummy_return<typename return_type::value_type>();
-#endif // defined(_MSC_VER)
+#endif // defined(_MSC_VER) and not(__clang__)
   }
 };
 


### PR DESCRIPTION
When compile in Ubuntu 24.04 LTS in MSVC-like mode by clang-cl 18 this example main.cpp

```cpp
#include <asio/co_spawn.hpp>
#include <asio/thread_pool.hpp>
#include <asio/use_awaitable.hpp>

using namespace asio;

awaitable<int> CoroTask(thread_pool::executor_type executor) {
    co_return 0;
}

int main(int, char**) {
    thread_pool pool;
    auto _[[maybe_unused]] = co_spawn(pool, CoroTask(pool.executor()), use_awaitable);
    pool.wait();
    return 0;
}
```

failed with
```
In file included from /home/dimdim11/arcadia/junk/dimdim11/asio_win/main.cpp:1:
In file included from /home/dimdim11/arcadia/contrib/libs/asio/include/asio/co_spawn.hpp:519:
In file included from /home/dimdim11/arcadia/contrib/libs/asio/include/asio/impl/co_spawn.hpp:27:
In file included from /home/dimdim11/arcadia/contrib/libs/asio/include/asio/use_awaitable.hpp:157:
/home/dimdim11/arcadia/contrib/libs/asio/include/asio/impl/use_awaitable.hpp(180,20): error: binding dereferenced null pointer to reference has undefined behavior [-Werror,-Wnull-dereference]
  180 |   return std::move(*static_cast<T*>(nullptr));
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/dimdim11/arcadia/contrib/libs/asio/include/asio/impl/use_awaitable.hpp(223,15): note: in instantiation of function template specialization 'asio::dummy_return<int>' requested here
  223 |     co_return dummy_return<typename return_type::value_type>();
      |               ^
/home/dimdim11/arcadia/contrib/libs/asio/include/asio/async_result.hpp(628,65): note: in instantiation of function template specialization 'asio::async_result<asio::use_awaitable_t<>, void (std::exception_ptr, int)>::initiate<asio::detail::initiate_co_spawn<asio::any_io_executor>, asio::detail::awaitable_as_function<int, asio::any_io_executor>>' requested here
  628 |   return async_result<decay_t<CompletionToken>, Signatures...>::initiate(
      |                                                                 ^
/home/dimdim11/arcadia/contrib/libs/asio/include/asio/impl/co_spawn.hpp(365,10): note: in instantiation of function template specialization 'asio::async_initiate<const asio::use_awaitable_t<> &, void (std::exception_ptr, int), asio::detail::initiate_co_spawn<asio::any_io_executor>, asio::detail::awaitable_as_function<int, asio::any_io_executor>>' requested here
  365 |   return async_initiate<CompletionToken, void(std::exception_ptr, T)>(
      |          ^
1 error generated.
```
Only if used `awaitable<int>`, with `awaitable<void>` no errors:

```cpp
awaitable<void> CoroTask(thread_pool::executor_type executor) {
    co_return;
}
```

This patch fix this problem by disable dummy_return during compile by clang