### PR TITLE
Fixes memory issue in thread_info_base

### DIFF
--- a/asio/include/asio/detail/thread_info_base.hpp
+++ b/asio/include/asio/detail/thread_info_base.hpp
@@ -239,11 +239,7 @@ public:
   }
 
 private:
-#if defined(ASIO_HAS_IO_URING)
   enum { chunk_size = 8 };
-#else // defined(ASIO_HAS_IO_URING)
-  enum { chunk_size = 4 };
-#endif // defined(ASIO_HAS_IO_URING)
   void* reusable_memory_[max_mem_index];
 
 #if !defined(ASIO_NO_EXCEPTIONS)


### PR DESCRIPTION
Uses a chunk size of 8 consistently to prevent possible memory allocation issues when ASIO_HAS_IO_URING is inconsistent across compilation units.

Fixes chriskohlhoff/asio#1635