### PR TITLE
Fix channel_service member variable references

### DIFF
--- a/asio/include/asio/experimental/detail/channel_service.hpp
+++ b/asio/include/asio/experimental/detail/channel_service.hpp
@@ -543,10 +543,10 @@ struct channel_service<Mutex>::implementation_type<
   // Move from another buffer.
   void buffer_move_from(implementation_type& other)
   {
-    size_ = other.buffer_;
+    size_ = other.size_;
     other.size_ = 0;
     first_ = other.first_;
-    other.first.count_ = 0;
+    other.first_.count_ = 0;
     rest_ = static_cast<
         typename traits_type::template container<buffered_value>::type&&>(
           other.rest_);


### PR DESCRIPTION
For (concurrent)_channels with the completion signature `void(error_code)`, the employed channel service contained typos preventing compilation when moving channels.

Previously, the following code wouldn't compile:
```c++
io_context ctx;
channel<void(asio::error_code)> ch1(ctx);
auto ch2 = std::move(ch1);
```