### PR TITLE
Use `!defined(_LIBCPP_HAS_NO_ALIGNED_ALLOCATION)` to determine if lib…

### DIFF
--- a/include/asio/detail/config.hpp
+++ b/include/asio/detail/config.hpp
@@ -398,7 +398,7 @@
 #  if (__cplusplus >= 201703)
 #   if defined(__clang__)
 #    if defined(ASIO_HAS_CLANG_LIBCXX)
-#     if (_LIBCPP_STD_VER > 14) && defined(_LIBCPP_HAS_ALIGNED_ALLOC) \
+#     if (_LIBCPP_STD_VER > 14) && !defined(_LIBCPP_HAS_NO_ALIGNED_ALLOCATION) \
         && !defined(_LIBCPP_MSVCRT) && !defined(__MINGW32__)
 #      if defined(__ANDROID__) && (__ANDROID_API__ >= 28)
 #        define ASIO_HAS_STD_ALIGNED_ALLOC 1
@@ -423,7 +423,7 @@
 #      else // defined(__APPLE__)
 #       define ASIO_HAS_STD_ALIGNED_ALLOC 1
 #      endif // defined(__APPLE__)
-#     endif // (_LIBCPP_STD_VER > 14) && defined(_LIBCPP_HAS_ALIGNED_ALLOC)
+#     endif // (_LIBCPP_STD_VER > 14) && !defined(_LIBCPP_HAS_NO_ALIGNED_ALLOCATION)
             //   && !defined(_LIBCPP_MSVCRT) && !defined(__MINGW32__)
 #    elif defined(_GLIBCXX_HAVE_ALIGNED_ALLOC)
 #     define ASIO_HAS_STD_ALIGNED_ALLOC 1


### PR DESCRIPTION
…c++ supports aligned allocations.

The ASIO uses `_LIBCPP_HAS_ALIGNED_ALLOC` to learn if libc++ defines `std::aligned_new`.

I didn't manage to find this define in llvm codebase.

I found these though:

- [_LIBCPP_HAS_NO_ALIGNED_ALLOCATION](https://github.com/llvm/llvm-project/blob/dbd197118db597970a5a9c5688c5e0bb01948ebb/libcxx/include/__config#L642C13-L642C46) is defined when either library or compiler lack support. I didn't trace when it was introduced [but 2018 version defines it](https://github.com/llvm/llvm-project/commit/53ac1776f3be82a97f94591cc08c1864f5e24f4b)
- [_LIBCPP_HAS_ALIGNED_ALLOCATION](https://github.com/llvm/llvm-project/blob/1c094a1ce2ef15b5855b11aa85dbb2f1eea54f13/libcxx/include/__config#L667-L671) is inverse of `_LIBCPP_HAS_NO_ALIGNED_ALLOCATION`` but only available [since Oct 12,2024](https://github.com/llvm/llvm-project/commit/ba87515fea90b5d55836a8e3be63a7e683ce299d#diff-720de38e87ca590a6946574a5c75c382720f1784dd63ba60deb0bb54bd827c43).

I've chosen `_LIBCPP_HAS_NO_ALIGNED_ALLOCATION` to cover more versions.

Closes: #1678 