### PR TITLE
Avoid redundant declaration of error_number_to_condition with GCC -Wredundant-decls

### DIFF
--- a/include/asio/error.hpp
+++ b/include/asio/error.hpp
@@ -357,9 +357,10 @@ inline asio::error_code make_error_code(misc_errors e)
 
 // boostify: non-boost code starts here
 namespace detail {
-
+#if !defined(ASIO_ERROR_NUMBER_TO_CONDITION_DECLARED)
+#define ASIO_ERROR_NUMBER_TO_CONDITION_DECLARED
 ASIO_DECL std::error_condition error_number_to_condition(int ev);
-
+#endif
 } // namespace detail
 // boostify: non-boost code ends here
 } // namespace error

--- a/include/asio/impl/error_code.ipp
+++ b/include/asio/impl/error_code.ipp
@@ -35,7 +35,11 @@ namespace asio {
 namespace error {
 namespace detail {
 
+    // Forward declaration required when error.hpp has not been included.
+#if !defined(ASIO_ERROR_NUMBER_TO_CONDITION_DECLARED)
+#define ASIO_ERROR_NUMBER_TO_CONDITION_DECLARED
 ASIO_DECL std::error_condition error_number_to_condition(int ev);
+#endif
 
 } // namespace detail
 } // namespace error


### PR DESCRIPTION
GCC 14+ diagnoses a redundant redeclaration of
```cpp
asio::error::detail::error_number_to_condition(int)
``` 
when `impl/error_code.ipp` is included via `error_code.hpp` prior to the
public declaration in `error.hpp`.

Guard the forward declaration so it is emitted only once per
translation unit, while preserving existing inclusion order and
behavior.

No functional or ABI changes.

Fixes #1697.
