### PR TITLE
Clarify IPv4 vs IPv6 semantics of multicast::outbound_interface

### DIFF
--- a/include/asio/ip/multicast.hpp
+++ b/include/asio/ip/multicast.hpp
@@ -85,6 +85,10 @@ typedef asio::ip::detail::socket_option::multicast_request<
 /**
  * Implements the IPPROTO_IP/IP_MULTICAST_IF socket option.
  *
+ * For IPv4, the outbound interface may be specified using an IPv4 address.
+ * For IPv6, an interface index must be used, since an IPv6 address does not
+ * uniquely identify a network interface.
+ * 
  * @par Examples
  * Setting the option:
  * @code


### PR DESCRIPTION
`multicast::outbound_interface` conceptually represents a network interface.

In IPv4, allowing construction from an `address_v4` works because an address often uniquely identifies an interface.
This assumption does not hold for IPv6, where an address does not uniquely identify a specific interface.

This change does not alter behavior, but clarifies the intended semantics by documenting that IPv6 requires specifying the interface index rather than an IPv6 address.

Related #1690.