### PR TITLE
Add experimental::diagnostic_executor

### DIFF
--- a/include/asio/experimental/diagnostic_executor.hpp
+++ b/include/asio/experimental/diagnostic_executor.hpp
@@ -1,0 +1,357 @@
+//
+// experimental/diagnostic_executor.hpp
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2026 Pinwhell <binarydetective@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+#ifndef ASIO_EXPERIMENTAL_DIAGNOSTIC_EXECUTOR_HPP
+#define ASIO_EXPERIMENTAL_DIAGNOSTIC_EXECUTOR_HPP
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1200)
+# pragma once
+#endif // defined(_MSC_VER) && (_MSC_VER >= 1200)
+
+#include "asio/detail/config.hpp"
+#include "asio/detail/type_traits.hpp"
+#include "asio/execution/blocking.hpp"
+#include "asio/execution/executor.hpp"
+#include "asio/execution_context.hpp"
+#include "asio/query.hpp"
+#include "asio/require.hpp"
+#include "asio/prefer.hpp"
+#include "asio/dispatch.hpp"
+#include "asio/post.hpp"
+#include "asio/defer.hpp"
+#include "asio/bind_executor.hpp"
+
+#include "asio/detail/push_options.hpp"
+
+namespace asio {
+namespace experimental {
+
+/// Default diagnostic policy that performs no action.
+/**
+ * This policy provides a no-op implementation of the diagnostic hooks, ensuring
+ * that the diagnostic executor has zero overhead when no diagnostics are
+ * required.
+ */
+struct null_diagnostic_policy
+{
+  /// Hook called before work is submitted to the underlying executor.
+  template <typename Label>
+  static void on_submit(const Label&) noexcept
+  {
+  }
+};
+
+/// An executor adapter that transparently observes work submission.
+/**
+ * The diagnostic_executor class template is used to wrap another executor and
+ * provide a point of observation for work submission. It forwards all
+ * operations to the underlying executor while invoking a diagnostic policy
+ * hook whenever work is submitted via @c execute, @c dispatch, @c post, or
+ * @c defer.
+ */
+template <typename InnerExecutor, 
+          typename Label = const char*, 
+          typename DiagnosticPolicy = null_diagnostic_policy>
+class diagnostic_executor
+{
+public:
+  /// The type of the underlying executor.
+  typedef InnerExecutor inner_executor_type;
+
+  /// The type of the underlying executor.
+  typedef InnerExecutor nested_executor_type;
+
+  /// The type of the diagnostic label.
+  typedef Label label_type;
+
+  /// The type of the diagnostic policy.
+  typedef DiagnosticPolicy diagnostic_policy_type;
+
+  /// Construct from an inner executor and a label.
+  template <typename InnerEx, typename Lbl>
+  diagnostic_executor(ASIO_MOVE_ARG(InnerEx) inner, ASIO_MOVE_ARG(Lbl) label)
+    : inner_(ASIO_MOVE_CAST(InnerEx)(inner)),
+      label_(ASIO_MOVE_CAST(Lbl)(label))
+  {
+  }
+
+  /// Copy constructor.
+  diagnostic_executor(const diagnostic_executor& other) noexcept
+    : inner_(other.inner_),
+      label_(other.label_)
+  {
+  }
+
+  /// Move constructor.
+  diagnostic_executor(diagnostic_executor&& other) noexcept
+    : inner_(ASIO_MOVE_CAST(InnerExecutor)(other.inner_)),
+      label_(ASIO_MOVE_CAST(Label)(other.label_))
+  {
+  }
+
+  /// Assignment operator.
+  diagnostic_executor& operator=(const diagnostic_executor& other) noexcept
+  {
+    inner_ = other.inner_;
+    label_ = other.label_;
+    return *this;
+  }
+
+  /// Move assignment operator.
+  diagnostic_executor& operator=(diagnostic_executor&& other) noexcept
+  {
+    inner_ = ASIO_MOVE_CAST(InnerExecutor)(other.inner_);
+    label_ = ASIO_MOVE_CAST(Label)(other.label_);
+    return *this;
+  }
+
+  /// Compare two executors for equality.
+  /**
+   * Two diagnostic executors are equal if their underlying executors are equal
+   * and their labels are equal.
+   */
+  friend bool operator==(const diagnostic_executor& a,
+      const diagnostic_executor& b) noexcept
+  {
+    return a.inner_ == b.inner_ && a.label_ == b.label_;
+  }
+
+  /// Compare two executors for inequality.
+  friend bool operator!=(const diagnostic_executor& a,
+      const diagnostic_executor& b) noexcept
+  {
+    return !(a == b);
+  }
+
+  /// Execution function to submit a function object for execution.
+  /**
+   * Invokes the diagnostic policy's @c on_submit hook before forwarding the
+   * function object to the underlying executor's @c execute function.
+   */
+  template <typename Function>
+  void execute(ASIO_MOVE_ARG(Function) f) const
+  {
+    DiagnosticPolicy::on_submit(label_);
+    inner_.execute(ASIO_MOVE_CAST(Function)(f));
+  }
+
+#if !defined(ASIO_NO_TS_EXECUTORS)
+  /// Obtain the underlying execution context.
+  execution_context& context() const noexcept
+  {
+    return inner_.context();
+  }
+
+  /// Inform the executor that it has some outstanding work to do.
+  void on_work_started() const noexcept
+  {
+    inner_.on_work_started();
+  }
+
+  /// Inform the executor that some work is no longer outstanding.
+  void on_work_finished() const noexcept
+  {
+    inner_.on_work_finished();
+  }
+
+  /// Request the underlying executor to invoke the given function object.
+  template <typename Function>
+  void dispatch(ASIO_MOVE_ARG(Function) f) const
+  {
+    DiagnosticPolicy::on_submit(label_);
+    asio::dispatch(inner_, ASIO_MOVE_CAST(Function)(f));
+  }
+
+  /// Request the underlying executor to invoke the given function object.
+  template <typename Function, typename Allocator>
+  void dispatch(ASIO_MOVE_ARG(Function) f, const Allocator& a) const
+  {
+    DiagnosticPolicy::on_submit(label_);
+    inner_.dispatch(asio::bind_executor(*this, ASIO_MOVE_CAST(Function)(f)), a);
+  }
+
+  /// Request the underlying executor to invoke the given function object.
+  template <typename Function>
+  void post(ASIO_MOVE_ARG(Function) f) const
+  {
+    DiagnosticPolicy::on_submit(label_);
+    asio::post(inner_, ASIO_MOVE_CAST(Function)(f));
+  }
+
+  /// Request the underlying executor to invoke the given function object.
+  template <typename Function, typename Allocator>
+  void post(ASIO_MOVE_ARG(Function) f, const Allocator& a) const
+  {
+    DiagnosticPolicy::on_submit(label_);
+    inner_.post(asio::bind_executor(*this, ASIO_MOVE_CAST(Function)(f)), a);
+  }
+
+  /// Request the underlying executor to invoke the given function object.
+  template <typename Function>
+  void defer(ASIO_MOVE_ARG(Function) f) const
+  {
+    DiagnosticPolicy::on_submit(label_);
+    asio::defer(inner_, ASIO_MOVE_CAST(Function)(f));
+  }
+
+  /// Request the underlying executor to invoke the given function object.
+  template <typename Function, typename Allocator>
+  void defer(ASIO_MOVE_ARG(Function) f, const Allocator& a) const
+  {
+    DiagnosticPolicy::on_submit(label_);
+    inner_.defer(asio::bind_executor(*this, ASIO_MOVE_CAST(Function)(f)), a);
+  }
+#endif // !defined(ASIO_NO_TS_EXECUTORS)
+
+  /// Get the underlying executor.
+  ASIO_NODISCARD const InnerExecutor& get_inner_executor() const noexcept
+  {
+    return inner_;
+  }
+
+  /// Forward a query to the underlying executor.
+  template <typename Property>
+  ASIO_NODISCARD auto query(ASIO_MOVE_ARG(Property) p) const 
+    noexcept(asio::can_query<const InnerExecutor&, Property>::value && 
+             asio::is_nothrow_query<const InnerExecutor&, Property>::value)
+    -> asio::query_result_t<const InnerExecutor&, Property>
+  {
+    return asio::query(inner_, ASIO_MOVE_CAST(Property)(p));
+  }
+
+  /// Forward a requirement to the underlying executor.
+  template <typename Property>
+  ASIO_NODISCARD auto require(ASIO_MOVE_ARG(Property) p) const 
+    noexcept(asio::can_require<const InnerExecutor&, Property>::value && 
+             asio::is_nothrow_require<const InnerExecutor&, Property>::value)
+    -> diagnostic_executor<asio::decay_t<asio::require_result_t<const InnerExecutor&, Property>>, Label, DiagnosticPolicy>
+  {
+    return diagnostic_executor<asio::decay_t<asio::require_result_t<const InnerExecutor&, Property>>, Label, DiagnosticPolicy>(
+        asio::require(inner_, ASIO_MOVE_CAST(Property)(p)), label_);
+  }
+
+  /// Forward a preference to the underlying executor.
+  template <typename Property>
+  ASIO_NODISCARD auto prefer(ASIO_MOVE_ARG(Property) p) const 
+    noexcept(asio::can_prefer<const InnerExecutor&, Property>::value && 
+             asio::is_nothrow_prefer<const InnerExecutor&, Property>::value)
+    -> diagnostic_executor<asio::decay_t<asio::prefer_result_t<const InnerExecutor&, Property>>, Label, DiagnosticPolicy>
+  {
+    return diagnostic_executor<asio::decay_t<asio::prefer_result_t<const InnerExecutor&, Property>>, Label, DiagnosticPolicy>(
+        asio::prefer(inner_, ASIO_MOVE_CAST(Property)(p)), label_);
+  }
+
+private:
+  InnerExecutor inner_;
+  Label label_;
+};
+
+/// Create a diagnostic executor for the specified executor and label.
+template <typename Executor, typename Label>
+ASIO_NODISCARD inline diagnostic_executor<asio::decay_t<Executor>, asio::decay_t<Label>>
+make_diagnostic_executor(ASIO_MOVE_ARG(Executor) ex, ASIO_MOVE_ARG(Label) label)
+{
+  return diagnostic_executor<asio::decay_t<Executor>, asio::decay_t<Label>>(
+      ASIO_MOVE_CAST(Executor)(ex), ASIO_MOVE_CAST(Label)(label));
+}
+
+} // namespace experimental
+
+namespace traits {
+
+#if !defined(ASIO_HAS_DEDUCED_EQUALITY_COMPARABLE_TRAIT)
+template <typename InnerExecutor, typename Label, typename DiagnosticPolicy>
+struct equality_comparable<experimental::diagnostic_executor<InnerExecutor, Label, DiagnosticPolicy>>
+{
+  static constexpr bool is_valid = asio::traits::equality_comparable<InnerExecutor>::is_valid;
+  static constexpr bool is_noexcept = asio::traits::equality_comparable<InnerExecutor>::is_noexcept;
+};
+#endif // !defined(ASIO_HAS_DEDUCED_EQUALITY_COMPARABLE_TRAIT)
+
+#if !defined(ASIO_HAS_DEDUCED_EXECUTE_MEMBER_TRAIT)
+template <typename InnerExecutor, typename Label, typename DiagnosticPolicy, typename Function>
+struct execute_member<experimental::diagnostic_executor<InnerExecutor, Label, DiagnosticPolicy>, Function,
+    asio::enable_if_t<
+      asio::traits::execute_member<const InnerExecutor&, Function>::is_valid
+    >>
+{
+  static constexpr bool is_valid = true;
+  static constexpr bool is_noexcept = asio::traits::execute_member<const InnerExecutor&, Function>::is_noexcept;
+  typedef void result_type;
+};
+#endif // !defined(ASIO_HAS_DEDUCED_EXECUTE_MEMBER_TRAIT)
+
+#if !defined(ASIO_HAS_DEDUCED_STATIC_QUERY_TRAIT)
+template <typename InnerExecutor, typename Label, typename DiagnosticPolicy, typename Property>
+struct static_query<experimental::diagnostic_executor<InnerExecutor, Label, DiagnosticPolicy>, Property,
+    asio::enable_if_t<
+      asio::traits::static_query<InnerExecutor, Property>::is_valid
+    >>
+{
+  static constexpr bool is_valid = true;
+  typedef typename asio::traits::static_query<InnerExecutor, Property>::result_type result_type;
+  static constexpr bool is_noexcept = asio::traits::static_query<InnerExecutor, Property>::is_noexcept;
+
+  static constexpr result_type value() noexcept(is_noexcept)
+  {
+    return asio::traits::static_query<InnerExecutor, Property>::value();
+  }
+};
+#endif // !defined(ASIO_HAS_DEDUCED_STATIC_QUERY_TRAIT)
+
+#if !defined(ASIO_HAS_DEDUCED_QUERY_MEMBER_TRAIT)
+template <typename InnerExecutor, typename Label, typename DiagnosticPolicy, typename Property>
+struct query_member<experimental::diagnostic_executor<InnerExecutor, Label, DiagnosticPolicy>, Property,
+    asio::enable_if_t<
+      asio::can_query<const InnerExecutor&, Property>::value
+    >>
+{
+  static constexpr bool is_valid = true;
+  static constexpr bool is_noexcept = asio::is_nothrow_query<const InnerExecutor&, Property>::value;
+  typedef asio::query_result_t<const InnerExecutor&, Property> result_type;
+};
+#endif // !defined(ASIO_HAS_DEDUCED_QUERY_MEMBER_TRAIT)
+
+#if !defined(ASIO_HAS_DEDUCED_REQUIRE_MEMBER_TRAIT)
+template <typename InnerExecutor, typename Label, typename DiagnosticPolicy, typename Property>
+struct require_member<experimental::diagnostic_executor<InnerExecutor, Label, DiagnosticPolicy>, Property,
+    asio::enable_if_t<
+      asio::can_require<const InnerExecutor&, Property>::value
+    >>
+{
+  static constexpr bool is_valid = true;
+  static constexpr bool is_noexcept = asio::is_nothrow_require<const InnerExecutor&, Property>::value;
+  typedef experimental::diagnostic_executor<
+    asio::decay_t<asio::require_result_t<const InnerExecutor&, Property>>,
+    Label, DiagnosticPolicy> result_type;
+};
+#endif // !defined(ASIO_HAS_DEDUCED_REQUIRE_MEMBER_TRAIT)
+
+#if !defined(ASIO_HAS_DEDUCED_PREFER_MEMBER_TRAIT)
+template <typename InnerExecutor, typename Label, typename DiagnosticPolicy, typename Property>
+struct prefer_member<experimental::diagnostic_executor<InnerExecutor, Label, DiagnosticPolicy>, Property,
+    asio::enable_if_t<
+      asio::can_prefer<const InnerExecutor&, Property>::value
+    >>
+{
+  static constexpr bool is_valid = true;
+  static constexpr bool is_noexcept = asio::is_nothrow_prefer<const InnerExecutor&, Property>::value;
+  typedef experimental::diagnostic_executor<
+    asio::decay_t<asio::prefer_result_t<const InnerExecutor&, Property>>,
+    Label, DiagnosticPolicy> result_type;
+};
+#endif // !defined(ASIO_HAS_DEDUCED_PREFER_MEMBER_TRAIT)
+
+} // namespace traits
+} // namespace asio
+
+#include "asio/detail/pop_options.hpp"
+
+#endif // ASIO_EXPERIMENTAL_DIAGNOSTIC_EXECUTOR_HPP

--- a/src/tests/unit/experimental/diagnostic_executor.cpp
+++ b/src/tests/unit/experimental/diagnostic_executor.cpp
@@ -1,0 +1,210 @@
+//
+// experimental/diagnostic_executor.cpp
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//
+// Copyright (c) 2026 Pinwhell <binarydetective@gmail.com>
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+
+// Disable autolinking for unit tests.
+#if !defined(BOOST_ALL_NO_LIB)
+#define BOOST_ALL_NO_LIB 1
+#endif // !defined(BOOST_ALL_NO_LIB)
+
+// Test that header file is self-contained and zero-dependency.
+#include "asio/experimental/diagnostic_executor.hpp"
+
+#include "asio/io_context.hpp"
+#include "asio/post.hpp"
+#include "asio/strand.hpp"
+#include "asio/execution/any_executor.hpp"
+#include "../unit_test.hpp"
+#include <vector>
+#include <string>
+#include <mutex>
+
+struct test_policy
+{
+  static std::mutex& mutex()
+  {
+    static std::mutex m;
+    return m;
+  }
+
+  static std::vector<std::string>& labels()
+  {
+    static std::vector<std::string> l;
+    return l;
+  }
+
+  template <typename Label>
+  static void on_submit(const Label& label) noexcept
+  {
+    std::lock_guard<std::mutex> lock(mutex());
+    labels().push_back(std::string(label));
+  }
+};
+
+void test_diagnostic_executor_basic()
+{
+  asio::io_context ioc;
+  
+  typedef asio::experimental::diagnostic_executor<
+    asio::io_context::executor_type, const char*, test_policy> diag_ex_type;
+    
+  diag_ex_type ex(ioc.get_executor(), "test_label");
+
+  ASIO_CHECK(ex.get_inner_executor() == ioc.get_executor());
+
+  bool executed = false;
+  ex.execute([&executed]() { executed = true; });
+
+  ASIO_CHECK(test_policy::labels().size() == 1);
+  ASIO_CHECK(test_policy::labels().back() == "test_label");
+
+  ioc.run();
+  ASIO_CHECK(executed);
+}
+
+void test_diagnostic_executor_traits()
+{
+  asio::io_context ioc;
+  auto ex = asio::experimental::make_diagnostic_executor(ioc.get_executor(), "test");
+
+  // Verify it is recognized as an executor (both old and new models).
+  ASIO_CHECK(asio::is_executor<decltype(ex)>::value);
+  ASIO_CHECK(asio::execution::is_executor<decltype(ex)>::value);
+
+  // Verify property query propagation.
+  ASIO_CHECK(&asio::query(ex, asio::execution::context) == &ioc);
+  ASIO_CHECK(asio::query(ex, asio::execution::blocking) == asio::execution::blocking.possibly);
+
+  // Verify requirement propagation (should return a new diagnostic_executor).
+  auto ex2 = asio::require(ex, asio::execution::blocking.never);
+  ASIO_CHECK(asio::query(ex2, asio::execution::blocking) == asio::execution::blocking.never);
+  
+  typedef asio::experimental::diagnostic_executor<
+    asio::decay_t<asio::require_result_t<asio::io_context::executor_type, decltype(asio::execution::blocking.never)>>,
+    const char*, asio::experimental::null_diagnostic_policy> expected_type;
+
+  (void)ex2; // Silence unused variable warning.
+  (void)sizeof(expected_type);
+}
+
+void test_diagnostic_executor_compatibility()
+{
+  asio::io_context ioc;
+  auto ex = asio::experimental::make_diagnostic_executor(ioc.get_executor(), "compat");
+
+  bool executed = false;
+  asio::post(ex, [&executed]() { executed = true; });
+
+  ioc.run();
+  ASIO_CHECK(executed);
+}
+
+void test_diagnostic_executor_any_executor()
+{
+  asio::io_context ioc;
+  asio::execution::any_executor<
+      asio::execution::blocking_t::possibly_t,
+      asio::execution::outstanding_work_t::tracked_t,
+      asio::execution::relationship_t::fork_t
+    > ex = ioc.get_executor();
+    
+  auto diag_ex = asio::experimental::make_diagnostic_executor(ex, "any_ex");
+
+  ASIO_CHECK(asio::execution::is_executor<decltype(diag_ex)>::value);
+
+  bool executed = false;
+  diag_ex.execute([&executed]() { executed = true; });
+
+  ioc.run();
+  ASIO_CHECK(executed);
+}
+
+void test_diagnostic_executor_strand()
+{
+  asio::io_context ioc;
+  auto s = asio::make_strand(ioc);
+  auto ex = asio::experimental::make_diagnostic_executor(s, "strand");
+
+  bool executed = false;
+  ex.execute([&executed]() { executed = true; });
+
+  ioc.run();
+  ASIO_CHECK(executed);
+}
+
+template <typename T>
+struct test_allocator
+{
+  typedef T value_type;
+  test_allocator() noexcept {}
+  template <typename U> test_allocator(const test_allocator<U>&) noexcept {}
+  bool operator==(const test_allocator&) const { return true; }
+  bool operator!=(const test_allocator&) const { return false; }
+  T* allocate(std::size_t n) { return static_cast<T*>(::operator new(n * sizeof(T))); }
+  void deallocate(T* p, std::size_t) { ::operator delete(p); }
+};
+
+void test_diagnostic_executor_allocator()
+{
+  asio::io_context ioc;
+  auto ex = asio::experimental::make_diagnostic_executor(ioc.get_executor(), "alloc");
+  test_allocator<void> alloc;
+
+  bool executed = false;
+#if !defined(ASIO_NO_TS_EXECUTORS)
+  ex.post([&executed]() { executed = true; }, alloc);
+#else // !defined(ASIO_NO_TS_EXECUTORS)
+  asio::post(ex, [&executed]() { executed = true; });
+#endif // !defined(ASIO_NO_TS_EXECUTORS)
+
+  ioc.run();
+  ASIO_CHECK(executed);
+}
+
+void test_diagnostic_executor_transparency()
+{
+  asio::io_context ioc;
+  typedef asio::experimental::diagnostic_executor<
+    asio::io_context::executor_type> diag_ex_type;
+
+  ASIO_CHECK((asio::is_same<diag_ex_type::nested_executor_type, asio::io_context::executor_type>::value));
+}
+
+void test_diagnostic_executor_legacy_1arg()
+{
+  asio::io_context ioc;
+  auto ex = asio::experimental::make_diagnostic_executor(ioc.get_executor(), "legacy_1arg");
+
+  bool dispatch_executed = false;
+  ex.dispatch([&]() { dispatch_executed = true; });
+
+  bool post_executed = false;
+  ex.post([&]() { post_executed = true; });
+
+  bool defer_executed = false;
+  ex.defer([&]() { defer_executed = true; });
+
+  ioc.run();
+  ASIO_CHECK(dispatch_executed);
+  ASIO_CHECK(post_executed);
+  ASIO_CHECK(defer_executed);
+}
+
+ASIO_TEST_SUITE
+(
+  "experimental/diagnostic_executor",
+  ASIO_TEST_CASE(test_diagnostic_executor_basic)
+  ASIO_TEST_CASE(test_diagnostic_executor_traits)
+  ASIO_TEST_CASE(test_diagnostic_executor_compatibility)
+  ASIO_TEST_CASE(test_diagnostic_executor_any_executor)
+  ASIO_TEST_CASE(test_diagnostic_executor_strand)
+  ASIO_TEST_CASE(test_diagnostic_executor_allocator)
+  ASIO_TEST_CASE(test_diagnostic_executor_transparency)
+  ASIO_TEST_CASE(test_diagnostic_executor_legacy_1arg)
+)


### PR DESCRIPTION
Policy-based adapter for work submission diagnostics.

- Transparently propagates all executor properties and traits.
- Supports both modern and Networking TS executor models.
- Zero-overhead by default via null_diagnostic_policy.