### PR TITLE
Change posix_thread entry symbol name to avoid clashes #1709

### DIFF
--- a/boostify.pl
+++ b/boostify.pl
@@ -131,9 +131,9 @@ sub copy_source_file
       $line =~ s/[\\@]ref async_read/boost::asio::async_read()/g;
       $line =~ s/[\\@]ref async_write/boost::asio::async_write()/g;
     }
-    if ($line =~ /asio_detail_posix_thread_function/)
+    if ($line =~ /asio_detail_posix_thread_function_for_external_allocator/)
     {
-      $line =~ s/asio_detail_posix_thread_function/boost_asio_detail_posix_thread_function/g;
+      $line =~ s/asio_detail_posix_thread_function_for_external_allocator/boost_asio_detail_posix_thread_function_for_external_allocator/g;
     }
     if ($line =~ /asio_signal_handler/)
     {

--- a/include/asio/detail/impl/posix_thread.ipp
+++ b/include/asio/detail/impl/posix_thread.ipp
@@ -57,7 +57,7 @@ std::size_t posix_thread::hardware_concurrency()
 posix_thread::func_base* posix_thread::start_thread(func_base* arg)
 {
   int error = ::pthread_create(&arg->thread_, 0,
-        asio_detail_posix_thread_function, arg);
+        asio_detail_posix_thread_function_for_external_allocator, arg);
   if (error != 0)
   {
     arg->destroy();
@@ -68,7 +68,7 @@ posix_thread::func_base* posix_thread::start_thread(func_base* arg)
   return arg;
 }
 
-void* asio_detail_posix_thread_function(void* arg)
+void* asio_detail_posix_thread_function_for_external_allocator(void* arg)
 {
   static_cast<posix_thread::func_base*>(arg)->run();
   return 0;

--- a/include/asio/detail/posix_thread.hpp
+++ b/include/asio/detail/posix_thread.hpp
@@ -30,7 +30,7 @@ namespace detail {
 
 extern "C"
 {
-  ASIO_DECL void* asio_detail_posix_thread_function(void* arg);
+  ASIO_DECL void* asio_detail_posix_thread_function_for_external_allocator(void* arg);
 }
 
 class posix_thread
@@ -88,7 +88,7 @@ public:
   ASIO_DECL static std::size_t hardware_concurrency();
 
 private:
-  friend void* asio_detail_posix_thread_function(void* arg);
+  friend void* asio_detail_posix_thread_function_for_external_allocator(void* arg);
 
   class func_base
   {


### PR DESCRIPTION
Add suffix to posix thread entry function to avoid name clashes with older library versions.
Fixes #1709