### PR TITLE
Fix MSG_NOSIGNAL handling on NetBSD.

### DIFF
--- a/include/asio/detail/config.hpp
+++ b/include/asio/detail/config.hpp
@@ -1406,7 +1406,7 @@
 
 // Kernel support for MSG_NOSIGNAL.
 #if !defined(ASIO_HAS_MSG_NOSIGNAL)
-# if defined(__linux__)
+# if defined(__linux__) || defined(__NetBSD__)
 #  define ASIO_HAS_MSG_NOSIGNAL 1
 # elif defined(_POSIX_VERSION)
 #  if (_POSIX_VERSION >= 200809L)


### PR DESCRIPTION
In /usr/include/sys/unistd.h:62, `_POSIX_VERSION' is only `200112L', but NetBSD supports MSG_NOSIGNAL anyway.