### PR TITLE
Constify X509* certs to match OpenSSL's new interface

### DIFF
--- a/include/asio/ssl/impl/host_name_verification.ipp
+++ b/include/asio/ssl/impl/host_name_verification.ipp
@@ -49,7 +49,7 @@ bool host_name_verification::operator()(
   const bool is_address = !ec;
   (void)address;
 
-  X509* cert = X509_STORE_CTX_get_current_cert(ctx.native_handle());
+  const X509* cert = X509_STORE_CTX_get_current_cert(ctx.native_handle());
 
   if (is_address)
   {

--- a/src/examples/cpp11/ssl/client.cpp
+++ b/src/examples/cpp11/ssl/client.cpp
@@ -49,7 +49,7 @@ private:
 
     // In this example we will simply print the certificate's subject name.
     char subject_name[256];
-    X509* cert = X509_STORE_CTX_get_current_cert(ctx.native_handle());
+    const X509* cert = X509_STORE_CTX_get_current_cert(ctx.native_handle());
     X509_NAME_oneline(X509_get_subject_name(cert), subject_name, 256);
     std::cout << "Verifying " << subject_name << "\n";
 


### PR DESCRIPTION
Fixes: #1718 

Update to match OpenSSL's interface change found here:
https://github.com/openssl/openssl/commit/e5b563366b001be60c64410d063c24c0536373bd