### PR TITLE
Help GCC 4.8 distinguish between Functions and Executors

### DIFF
--- a/include/asio/detail/work_dispatcher.hpp
+++ b/include/asio/detail/work_dispatcher.hpp
@@ -40,8 +40,13 @@ struct empty_work_function
   }
 };
 
-template <typename Function>
+template <typename Function, typename = void>
 struct work_result
+{
+};
+
+template <typename Function>
+struct work_result<Function, void_t<result_of_t<decay_t<Function>()>>>
 {
   typedef decay_t<result_of_t<decay_t<Function>()>> type;
 };


### PR DESCRIPTION
GCC 4.8 fails building this code:

```
asio::io_context ctx;
std::function<void()> func = []() {};
asio::post(ctx.get_executor(), func);
```

With the logs reading something like this:
```
In file included from /project/asio/include/asio/detail/initiate_dispatch.hpp:21:0,
                 from /project/asio/include/asio/detail/wrapped_handler.hpp:20,
                 from /project/asio/include/asio/io_context.hpp:26,
                 from /project/main.cpp:6:
/project/asio/include/asio/detail/work_dispatcher.hpp: In instantiation of 'struct asio::detail::work_result<asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >':
/project/asio/include/asio/detail/work_dispatcher.hpp:49:59:   required by substitution of 'template<class Function> using work_result_t = typename asio::detail::work_result::type [with Function = asio::io_context::basic_executor_type<std::allocator<void>, 0ul>]'
/project/asio/include/asio/post.hpp:462:47:   required by substitution of 'template<class Function, class Executor, class CompletionToken> decltype (async_initiate<CompletionToken, void(asio::detail::work_result_t<Function>)>(declval<asio::detail::initiate_post_with_executor<Executor> >(), token, static_cast<Function&&>(function))) asio::post(Function&&, const Executor&, CompletionToken&&, asio::constraint_t<(! std::is_void<typename std::result_of<typename std::decay<_Tp>::type()>::type>::value)>, asio::constraint_t<((asio::execution::is_executor<Executor>::value && asio::can_require<Executor, asio::execution::detail::blocking::never_t<0> >::value) || asio::is_executor<Executor>::value)>) [with Function = asio::io_context::basic_executor_type<std::allocator<void>, 0ul>; Executor = std::function<void()>; CompletionToken = asio::deferred_t]'
/project/main.cpp:46:92:   required from here
/project/asio/include/asio/detail/work_dispatcher.hpp:45:53: error: no type named 'type' in 'class std::result_of<asio::io_context::basic_executor_type<std::allocator<void>, 0ul>()>'
   typedef decay_t<result_of_t<decay_t<Function>()>> type;
```

It appears GCC 4.8 cannot SFINAE its way out of distinguishing an Executor and a Function in the post overloads, and tries to instantiate a `work_result<Executor>`.