### PR TITLE
Fix co_composed crash on MSVC

### DIFF
--- a/include/asio/co_composed.hpp
+++ b/include/asio/co_composed.hpp
@@ -988,7 +988,11 @@ private:
   using allocator_type =
     associated_allocator_t<Handler, recycling_allocator<void>>;
 
+#if defined(ASIO_MSVC) && !defined(__clang__)
+  union alignas(16) block
+#else
   union block
+#endif
   {
     std::max_align_t max_align;
     alignas(allocator_type) char pad[alignof(allocator_type)];


### PR DESCRIPTION
When built with the Visual Studio generator in `Release` (`/O2`), MSVC may emit an aligned SSE store (`movaps`) for `co_composed` block storage that is only 8-byte aligned. At runtime this results with `STATUS_ACCESS_VIOLATION`; in the failing case the fault appears to come from a misaligned `movaps` store triggering a GP fault

I am reproducing this with
- `blazeauth/aero` at `0d125b94dbd3b35d4b8a4b67483e109a77794c3e`
- Visual Studio 17 2022
- Visual Studio 18 2026
- `Release` config
- `examples/chilkat.exe` (the same issue also reproduces with other examples)
- any version of `asio` from 1.32 (not tested below) to 1.38

I don't see a problem with `/O1`, so far, it only appears on `/O2`
when using `clang-cl` with the same configuration as above, there are no errors

This looks like an MSVC backend/codegen bug rather than an `asio` logic bug, because generated code uses `movaps` even though the destination address is only 8-byte aligned in the failing case

The fix is to force the `block` storage used here to be at least 16-byte aligned on MSVC, which avoids the bad codegen assumption and makes the generated aligned SSE access safe:

```cpp
#if defined(ASIO_MSVC) && !defined(__clang__)
  union alignas(16) block
#else
  union block
#endif
```

P.S.
screenshot of the failing `movaps` store:
<img width="1919" height="1079" alt="image_2026-03-08_16-31-47" src="https://github.com/user-attachments/assets/8367b94e-e8de-409b-87bc-bcacd0a98a15" />
