### PR TITLE
Use MSG_DONTWAIT instead of fcntl with O_NONBLOCK for sockets in sending/receiving

### DIFF
--- a/include/asio/detail/impl/socket_ops.ipp
+++ b/include/asio/detail/impl/socket_ops.ipp
@@ -1007,6 +1007,9 @@ bool non_blocking_recv(socket_type s,
     buf* bufs, size_t count, int flags, bool is_stream,
     asio::error_code& ec, size_t& bytes_transferred)
 {
+#if defined(MSG_DONTWAIT)
+  flags |= MSG_DONTWAIT;
+#endif
   for (;;)
   {
     // Read some data.
@@ -1045,6 +1048,9 @@ bool non_blocking_recv1(socket_type s,
     void* data, size_t size, int flags, bool is_stream,
     asio::error_code& ec, size_t& bytes_transferred)
 {
+#if defined(MSG_DONTWAIT)
+  flags |= MSG_DONTWAIT;
+#endif
   for (;;)
   {
     // Read some data.
@@ -1256,6 +1262,9 @@ bool non_blocking_recvfrom(socket_type s, buf* bufs,
     size_t count, int flags, void* addr, std::size_t* addrlen,
     asio::error_code& ec, size_t& bytes_transferred)
 {
+#if defined(MSG_DONTWAIT)
+  flags |= MSG_DONTWAIT;
+#endif
   for (;;)
   {
     // Read some data.
@@ -1288,6 +1297,9 @@ bool non_blocking_recvfrom1(socket_type s, void* data,
     size_t size, int flags, void* addr, std::size_t* addrlen,
     asio::error_code& ec, size_t& bytes_transferred)
 {
+#if defined(MSG_DONTWAIT)
+  flags |= MSG_DONTWAIT;
+#endif
   for (;;)
   {
     // Read some data.
@@ -1401,6 +1413,9 @@ bool non_blocking_recvmsg(socket_type s,
     buf* bufs, size_t count, int in_flags, int& out_flags,
     asio::error_code& ec, size_t& bytes_transferred)
 {
+#if defined(MSG_DONTWAIT)
+  in_flags |= MSG_DONTWAIT;
+#endif
   for (;;)
   {
     // Read some data.
@@ -1597,6 +1612,9 @@ bool non_blocking_send(socket_type s,
     const buf* bufs, size_t count, int flags,
     asio::error_code& ec, size_t& bytes_transferred)
 {
+#if defined(MSG_DONTWAIT)
+  flags |= MSG_DONTWAIT;
+#endif
   for (;;)
   {
     // Write some data.
@@ -1628,6 +1646,9 @@ bool non_blocking_send1(socket_type s,
     const void* data, size_t size, int flags,
     asio::error_code& ec, size_t& bytes_transferred)
 {
+#if defined(MSG_DONTWAIT)
+  flags |= MSG_DONTWAIT;
+#endif
   for (;;)
   {
     // Write some data.
@@ -1808,6 +1829,9 @@ bool non_blocking_sendto(socket_type s,
     const void* addr, std::size_t addrlen,
     asio::error_code& ec, size_t& bytes_transferred)
 {
+#if defined(MSG_DONTWAIT)
+  flags |= MSG_DONTWAIT;
+#endif
   for (;;)
   {
     // Write some data.
@@ -1841,6 +1865,9 @@ bool non_blocking_sendto1(socket_type s,
     const void* addr, std::size_t addrlen,
     asio::error_code& ec, size_t& bytes_transferred)
 {
+#if defined(MSG_DONTWAIT)
+  flags |= MSG_DONTWAIT;
+#endif
   for (;;)
   {
     // Write some data.

--- a/include/asio/detail/reactive_socket_service.hpp
+++ b/include/asio/detail/reactive_socket_service.hpp
@@ -307,8 +307,14 @@ public:
     ASIO_HANDLER_CREATION((reactor_.context(), *p.p, "socket",
           &impl, impl.socket_, "async_send_to"));
 
+#if defined(MSG_DONTWAIT)
+    constexpr bool has_msg_dontwait = true;
+#else
+    constexpr bool has_msg_dontwait = false;
+#endif
+
     start_op(impl, reactor::write_op, p.p,
-        is_continuation, true, false, true, &io_ex, 0);
+        is_continuation, true, false, !has_msg_dontwait, &io_ex, 0);
     p.v = p.p = 0;
   }
 
@@ -430,10 +436,16 @@ public:
     ASIO_HANDLER_CREATION((reactor_.context(), *p.p, "socket",
           &impl, impl.socket_, "async_receive_from"));
 
+#if defined(MSG_DONTWAIT)
+    constexpr bool has_msg_dontwait = true;
+#else
+    constexpr bool has_msg_dontwait = false;
+#endif
+
     start_op(impl,
         (flags & socket_base::message_out_of_band)
           ? reactor::except_op : reactor::read_op,
-        p.p, is_continuation, true, false, true, &io_ex, 0);
+        p.p, is_continuation, true, false, !has_msg_dontwait, &io_ex, 0);
     p.v = p.p = 0;
   }
 

--- a/include/asio/detail/reactive_socket_service_base.hpp
+++ b/include/asio/detail/reactive_socket_service_base.hpp
@@ -313,10 +313,16 @@ public:
     ASIO_HANDLER_CREATION((reactor_.context(), *p.p, "socket",
           &impl, impl.socket_, "async_send"));
 
+#if defined(MSG_DONTWAIT)
+    constexpr bool has_msg_dontwait = true;
+#else
+    constexpr bool has_msg_dontwait = false;
+#endif
+
     start_op(impl, reactor::write_op, p.p, is_continuation, true,
         ((impl.state_ & socket_ops::stream_oriented)
           && buffer_sequence_adapter<asio::const_buffer,
-            ConstBufferSequence>::all_empty(buffers)), true, &io_ex, 0);
+            ConstBufferSequence>::all_empty(buffers)), !has_msg_dontwait, &io_ex, 0);
     p.v = p.p = 0;
   }
 
@@ -419,6 +425,12 @@ public:
     ASIO_HANDLER_CREATION((reactor_.context(), *p.p, "socket",
           &impl, impl.socket_, "async_receive"));
 
+#if defined(MSG_DONTWAIT)
+    constexpr bool has_msg_dontwait = true;
+#else
+    constexpr bool has_msg_dontwait = false;
+#endif
+
     start_op(impl,
         (flags & socket_base::message_out_of_band)
           ? reactor::except_op : reactor::read_op,
@@ -426,7 +438,7 @@ public:
         (flags & socket_base::message_out_of_band) == 0,
         ((impl.state_ & socket_ops::stream_oriented)
           && buffer_sequence_adapter<asio::mutable_buffer,
-            MutableBufferSequence>::all_empty(buffers)), true, &io_ex, 0);
+            MutableBufferSequence>::all_empty(buffers)), !has_msg_dontwait, &io_ex, 0);
     p.v = p.p = 0;
   }
 
@@ -530,12 +542,18 @@ public:
     ASIO_HANDLER_CREATION((reactor_.context(), *p.p, "socket",
           &impl, impl.socket_, "async_receive_with_flags"));
 
+#if defined(MSG_DONTWAIT)
+    constexpr bool has_msg_dontwait = true;
+#else
+    constexpr bool has_msg_dontwait = false;
+#endif
+
     start_op(impl,
         (in_flags & socket_base::message_out_of_band)
           ? reactor::except_op : reactor::read_op,
         p.p, is_continuation,
         (in_flags & socket_base::message_out_of_band) == 0,
-        false, true, &io_ex, 0);
+        false, !has_msg_dontwait, &io_ex, 0);
     p.v = p.p = 0;
   }
 


### PR DESCRIPTION
On Linux, FreeBSD, OpenBSD and other systems, it's possible to have a non-blocking behavior on sockets using the flag `MSG_DONTWAIT` on sending and receiving functions per syscall, without needing to set the socket in a non-blocking state globally using `ioctl` or `fcntl`. This change will save a few syscalls to achieve the same results.

Another issue with O_NONBLOCK appears when sandboxing. The O_NONBLOCK state is shared among all copies of a file descriptor¹ and therefore if a sandboxed process tries to disable the non-blocking state of a received/inherited socket in a loop, it could potentially freeze the thread of the parent process.

This change was tested and works on Linux and FreeBSD

¹ https://blog.emilua.org/2025/01/12/software-sandboxing-basics/#_non_blocking_io_on_unix_it_sucks


### A minimal echo protocol program

```cpp

#include <asio.hpp>
#include <iostream>
#include <memory>
#include <string_view>
#include <system_error>

using namespace asio::local;

int main()
{
  try
  {
    asio::io_context io_context(1);

    stream_protocol::socket s1(io_context);
    stream_protocol::socket s2(io_context);
    connect_pair(s1, s2);
    
    auto buffer = std::make_shared_for_overwrite<char[]>(128);
    
    s1.async_send(
      asio::buffer("ping"),
      [buffer, &s1](asio::error_code, std::size_t) {
        s1.async_read_some(asio::buffer(buffer.get(), 128),
          [buffer](asio::error_code ec, std::size_t nread) {
            if (ec)
              throw std::system_error(ec);
              
            std::string_view sv(buffer.get(), nread); 
            std::cout << sv << '\n';
          }
        );
      }
    );

    auto buffer2 = std::make_shared_for_overwrite<char[]>(128);
    
    s2.async_read_some(asio::buffer(buffer2.get(), 128),
      [buffer2, &s2](asio::error_code ec, std::size_t nread) {
        if (ec)
          throw std::system_error(ec);
      
        s2.async_write_some(asio::buffer(buffer2.get(), nread),
          asio::detached
        );
      }
    );

    io_context.run();
  }
  catch (std::exception& e)
  {
    std::printf("Exception: %s\n", e.what());
  }
}


```
By running strace on the echo program before and after this patch you can see that the two calls to fcntl (to get flags and to set the O_NONBLOCK) for each socket is not called anymore on the patched version.
```diff
--- before_patch.txt	2026-03-11 12:32:39.522959691 -0300
+++ after_patch.txt 	2026-03-11 12:48:49.532765016 -0300
@@ -69,17 +69,13 @@
 socketpair(AF_UNIX, SOCK_STREAM, 0, [6, 7]) = 0
 epoll_ctl(4, EPOLL_CTL_ADD, 6, {events=EPOLLIN|EPOLLPRI|EPOLLERR|EPOLLHUP|EPOLLET, data=0x55eb3d9b4340}) = 0
 epoll_ctl(4, EPOLL_CTL_ADD, 7, {events=EPOLLIN|EPOLLPRI|EPOLLERR|EPOLLHUP|EPOLLET, data=0x55eb3d9b43e0}) = 0
-fcntl(6, F_GETFL)                       = 0x2 (flags O_RDWR)
-fcntl(6, F_SETFL, O_RDWR|O_NONBLOCK)    = 0
-sendto(6, "ping\0", 5, MSG_NOSIGNAL, NULL, 0) = 5
-fcntl(7, F_GETFL)                       = 0x2 (flags O_RDWR)
-fcntl(7, F_SETFL, O_RDWR|O_NONBLOCK)    = 0
-recvfrom(7, "ping\0", 128, 0, NULL, NULL) = 5
+sendto(6, "ping\0", 5, MSG_DONTWAIT|MSG_NOSIGNAL, NULL, 0) = 5
+recvfrom(7, "ping\0", 128, MSG_DONTWAIT, NULL, NULL) = 5
 epoll_wait(4, [{events=EPOLLIN, data=0x55eb3d9b42dc}], 128, 0) = 1
-recvfrom(6, 0x55eb3d9b4480, 128, 0, NULL, NULL) = -1 EAGAIN (Resource temporarily unavailable)
-sendto(7, "ping\0", 5, MSG_NOSIGNAL, NULL, 0) = 5
+recvfrom(6, 0x55eb3d9b4480, 128, MSG_DONTWAIT, NULL, NULL) = -1 EAGAIN (Resource temporarily unavailable)
+sendto(7, "ping\0", 5, MSG_DONTWAIT|MSG_NOSIGNAL, NULL, 0) = 5
 epoll_wait(4, [{events=EPOLLIN, data=0x55eb3d9b4340}], 128, 0) = 1
-recvfrom(6, "ping\0", 128, 0, NULL, NULL) = 5
+recvfrom(6, "ping\0", 128, MSG_DONTWAIT, NULL, NULL) = 5
 fstat(1, {st_mode=S_IFCHR|0600, st_rdev=makedev(0x88, 0x1), ...}) = 0
 write(1, "ping\0\n", 6)                 = 6
 epoll_ctl(4, EPOLL_CTL_DEL, 7, 0x7ffec38432bc) = 0

