### PR TITLE
msvc: add libc++ temporariy fix

### DIFF
--- a/include/asio/placeholders.hpp
+++ b/include/asio/placeholders.hpp
@@ -59,6 +59,25 @@ unspecified signal_number;
 
 #else
 
+#if _LIBCPP_STD_VER >= 17
+// C++17 recommends that we implement placeholders as `inline constexpr`, but allows
+// implementing them as `extern <implementation-defined>`. Libc++ implements them as
+// `extern const` in all standard modes to avoid an ABI break in C++03: making them
+// `inline constexpr` requires removing their definition in the shared library to
+// avoid ODR violations, which is an ABI break.
+static ASIO_INLINE_VARIABLE const auto& error
+  = std::placeholders::_1;
+static ASIO_INLINE_VARIABLE const auto& bytes_transferred
+  = std::placeholders::_2;
+static ASIO_INLINE_VARIABLE const auto& iterator
+  = std::placeholders::_2;
+static ASIO_INLINE_VARIABLE const auto& results
+  = std::placeholders::_2;
+static ASIO_INLINE_VARIABLE const auto& endpoint
+  = std::placeholders::_2;
+static ASIO_INLINE_VARIABLE const auto& signal_number
+  = std::placeholders::_2;
+#else
 static ASIO_INLINE_VARIABLE constexpr auto& error
   = std::placeholders::_1;
 static ASIO_INLINE_VARIABLE constexpr auto& bytes_transferred
@@ -71,6 +90,7 @@ static ASIO_INLINE_VARIABLE constexpr auto& endpoint
   = std::placeholders::_2;
 static ASIO_INLINE_VARIABLE constexpr auto& signal_number
   = std::placeholders::_2;
+#endif
 
 #endif
 


### PR DESCRIPTION
from libc++ source code: https://github.com/llvm/llvm-project/blob/458f1aae8d2da5bf786ba53ea200e94a918ff55a/libcxx/include/__functional/bind.h#L48

```
// C++17 recommends that we implement placeholders as `inline constexpr`, but allows
// implementing them as `extern <implementation-defined>`. Libc++ implements them as
// `extern const` in all standard modes to avoid an ABI break in C++03: making them
// `inline constexpr` requires removing their definition in the shared library to
// avoid ODR violations, which is an ABI break.
//
// In practice, since placeholders are empty, `extern const` is almost impossible
// to distinguish from `inline constexpr` from a usage stand point.
_LIBCPP_EXPORTED_FROM_ABI extern const __ph<1> _1;
_LIBCPP_EXPORTED_FROM_ABI extern const __ph<2> _2;
_LIBCPP_EXPORTED_FROM_ABI extern const __ph<3> _3;
_LIBCPP_EXPORTED_FROM_ABI extern const __ph<4> _4;
_LIBCPP_EXPORTED_FROM_ABI extern const __ph<5> _5;
_LIBCPP_EXPORTED_FROM_ABI extern const __ph<6> _6;
_LIBCPP_EXPORTED_FROM_ABI extern const __ph<7> _7;
_LIBCPP_EXPORTED_FROM_ABI extern const __ph<8> _8;
_LIBCPP_EXPORTED_FROM_ABI extern const __ph<9> _9;
_LIBCPP_EXPORTED_FROM_ABI extern const __ph<10> _10;
```

https://github.com/search?q=repo%3Allvm%2Fllvm-project%20_LIBCPP_EXPORTED_FROM_ABI%20extern%20const%20__ph%3C9%3E%20_9%3B%20&type=code

<img width="644" height="556" alt="截屏2026-03-29 09 32 03" src="https://github.com/user-attachments/assets/45db0511-82a8-4b28-8b44-61ca74fa0ea5" />
