### PR TITLE
android: fix 32-bit build under -Wsign-compare

### DIFF
--- a/include/asio/ip/basic_resolver_results.hpp
+++ b/include/asio/ip/basic_resolver_results.hpp
@@ -133,7 +133,7 @@ public:
       if (address_info->ai_family == ASIO_OS_DEF(AF_INET)
           || address_info->ai_family == ASIO_OS_DEF(AF_INET6))
       {
-        const std::size_t expected_size =
+        const decltype(asio::detail::addrinfo_type::ai_addrlen) expected_size =
           address_info->ai_family == ASIO_OS_DEF(AF_INET)
             ? sizeof(asio::detail::sockaddr_in4_type)
             : sizeof(asio::detail::sockaddr_in6_type);


### PR DESCRIPTION
  /home/runner/work/yass/yass/third_party/asio/include/asio/ip/basic_resolver_results.hpp:140:38: error: comparison of integers of different signs: 'socklen_t' (aka 'int') and 'const std::size_t' (aka 'const unsigned int') [-Werror,-Wsign-compare]
    140 |         if (address_info->ai_addrlen >= expected_size)

See https://github.com/hukeyue/yass/actions/runs/23698886199/job/69038926969#step:18:1790 for more.

<img width="1454" height="585" alt="截屏2026-03-29 10 06 43" src="https://github.com/user-attachments/assets/48d5ce3c-fdef-47a4-b530-5554cbba82d5" />
