### PR TITLE
msvc: fix broken build against sdk7.1a

### DIFF
--- a/include/asio/detail/win_mutex.hpp
+++ b/include/asio/detail/win_mutex.hpp
@@ -22,7 +22,9 @@
 #include "asio/detail/noncopyable.hpp"
 #include "asio/detail/scoped_lock.hpp"
 #include "asio/detail/socket_types.hpp"
+#ifndef _USING_V110_SDK71_
 #include <synchapi.h>
+#endif
 
 #include "asio/detail/push_options.hpp"
 


### PR DESCRIPTION
In SDKs older than 10.0 such as 7.1a, there is no header file named synchapi.h. windows.h should be fine.

```
  In file included from D:\a\yass\yass\third_party\asio\include\asio/detail/mutex.hpp:23:
  D:\a\yass\yass\third_party\asio\include\asio/detail/win_mutex.hpp(25,10): fatal error: 'synchapi.h' file not found
     25 | #include <synchapi.h>
        |          ^~~~~~~~~~~~
  Note: including file:        D:\a\yass\yass\third_party\asio\include\asio/detail/push_options.hpp
```
See https://github.com/hukeyue/yass/actions/runs/23699278385/job/69039985870?pr=89#step:10:739 and https://stackoverflow.com/questions/20927544/using-v110-sdk71-equivalent-for-vs2013 for more.

<img width="1438" height="324" alt="截屏2026-03-29 10 33 01" src="https://github.com/user-attachments/assets/981a4706-5795-416f-8550-4f34a32e2722" />
