### PR TITLE
Add asio::basic_errors::not_supported

### DIFF
--- a/include/asio/error.hpp
+++ b/include/asio/error.hpp
@@ -162,6 +162,9 @@ enum basic_errors
   /// Socket operation on non-socket.
   not_socket = ASIO_SOCKET_ERROR(ENOTSOCK),
 
+  // Not supported.
+  not_supported = ASIO_NATIVE_ERROR(ENOTSUP),
+
   /// Operation cancelled.
   operation_aborted = ASIO_WIN_OR_POSIX(
       ASIO_NATIVE_ERROR(ERROR_OPERATION_ABORTED),


### PR DESCRIPTION
As noted by Vinícius dos Santos¹, ENOTSUP and EOPNOTSUPP may alias on some systems. That's the case for Linux and FreeBSD.

On Systems where ENOTSUP and EOPNOTSUPP have the same errno values, one might inadvertently catch EOPNOTSUPP when a composed operation throws ENOTSUP. There's nothing ASIO can do here, so we don't try to.

Reference:
¹https://sourceforge.net/p/asio/mailman/message/58710157/