### PR TITLE
asio: io_uring: add ASIO_DISABLE_IO_URING_IOWAIT

### DIFF
--- a/include/asio/detail/impl/io_uring_service.ipp
+++ b/include/asio/detail/impl/io_uring_service.ipp
@@ -538,6 +538,14 @@ void io_uring_service::init_ring()
     asio::detail::throw_error(ec, "io_uring_queue_init");
   }
 
+#if defined(ASIO_DISABLE_IO_URING_IOWAIT)
+# if !defined(IORING_FEAT_NO_IOWAIT)
+#  error ASIO_DISABLE_IO_URING_IOWAIT requires liburing 2.12 or later
+# endif // !defined(IORING_FEAT_NO_IOWAIT)
+  // Opt out of io_uring's in_iowait task marking.
+  (void)::io_uring_set_iowait(&ring_, false);
+#endif // defined(ASIO_DISABLE_IO_URING_IOWAIT)
+
 #if !defined(ASIO_HAS_IO_URING_AS_DEFAULT)
   event_fd_ = ::eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
   if (event_fd_ < 0)

--- a/src/doc/platform_macros.qbk
+++ b/src/doc/platform_macros.qbk
@@ -269,6 +269,13 @@ needs.
     []
   ]
   [
+    [`ASIO_DISABLE_IO_URING_IOWAIT`]
+    [
+      Linux: suppress io_uring's `in_iowait` task marking.
+    ]
+    []
+  ]
+  [
     [`ASIO_HAS_KQUEUE`]
     [
       Mac OS X, FreeBSD, NetBSD, OpenBSD: kqueue.

--- a/src/doc/using.qbk
+++ b/src/doc/using.qbk
@@ -261,6 +261,13 @@ functionality, and behaviour of Asio.
     ]
   ]
   [
+    [`ASIO_DISABLE_IO_URING_IOWAIT`]
+    [
+      Suppresses io_uring's `in_iowait` task marking on Linux via
+      `io_uring_set_iowait()`.
+    ]
+  ]
+  [
     [`ASIO_DISABLE_KQUEUE`]
     [
       Explicitly disables `kqueue` support on macOS and BSD variants,


### PR DESCRIPTION
The io_uring backend marks the io_context waiter task as in_iowait whenever any SQE is pending. The kernel doesn't distinguish real I/O SQEs from POLL_ADD/TIMEOUT SQEs submitted for socket and timer waits, and the backend keeps those pending for the full async_wait, so the flag stays set with nothing blocked on I/O. This inflates iowait/load metrics and blocks deeper CPU idle states; on platforms without cpufreq scaling the original hint is moot but the accounting damage remains.
  
Add an opt-in macro ASIO_DISABLE_IO_URING_IOWAIT calling io_uring_set_iowait(ring, false) after queue init; default behaviour is unchanged. The call and the IORING_FEAT_NO_IOWAIT flag both landed in liburing 2.12, so it is guarded on the flag (#error otherwise). Older runtime kernels return -EOPNOTSUPP, which is harmless.